### PR TITLE
Download analytics, also for same-page links

### DIFF
--- a/_includes/headerbottom.html
+++ b/_includes/headerbottom.html
@@ -32,7 +32,13 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
       var f = function(event){
-        _gaq.push(['_trackEvent','Downloads','Download',$(this).attr('href')]);
+        var href = $(this).attr('href');
+        var target = $(this).attr('target');
+        _gaq.push(['_trackEvent','Downloads','Download',href]);
+        if (target === undefined || target.toLowerCase() != '_blank') {
+          setTimeout(function() { location.href = href; }, 200);
+          return false;
+        }
       };
       function endsWith(str, suffix) {
           return str.indexOf(suffix, str.length - suffix.length) !== -1;


### PR DESCRIPTION
Improves on #5 by adding a timeout of 200ms when the link does not have target="_blank". This lets some time for GA to do its magic before all scripts on the page are canceled due to the page being left.
