### PR TITLE
Fixed SVSS name, date, and description

### DIFF
--- a/events/_posts/2013-08-02-svss.md
+++ b/events/_posts/2013-08-02-svss.md
@@ -1,8 +1,8 @@
 ---
-title: Scala IO
+title: SVSS
 logo: /resources/img/sfscala.png
 location: San Francisco
-description: ""
+description: First annual Silicon Valley Scala Symposium!
 start: 2 August 2013
 end: 2 August 2013
 link-out: http://www.meetup.com/SF-Scala/events/114627952/


### PR DESCRIPTION
Front page showed Scala IO title, but linked to SF Scala's SVSS. Changed file name to match date, changed title and description.
