### PR TITLE
Scala 2.11.0-M4

### DIFF
--- a/download/_posts/2013-07-11-2.11.0-M4.md
+++ b/download/_posts/2013-07-11-2.11.0-M4.md
@@ -1,0 +1,22 @@
+---
+title: Scala 2.11.0-M4
+start: 11 July 2013
+layout: downloadpage
+release_version: 2.11.0-M4
+release_date: "July 11, 2013"
+show_resources: "true"
+permalink: /download/2.11.0-M4.html
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+resources: [
+  ["-main-unixsys", "scala-2.11.0-M4.tgz",                 "/files/archive/scala-2.11.0-M4.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
+  ["-main-windows", "scala-2.11.0-M4.msi",                 "/files/archive/scala-2.11.0-M4.msi",                 "Windows (msi installer)",    "50 MB"],
+  ["-non-main-sys", "scala-2.11.0-M4.zip",                 "/files/archive/scala-2.11.0-M4.zip",                 "Windows",                    "25 MB"],
+  ["-non-main-sys", "scala-docs-2.11.0-M4.txz",            "/files/archive/scala-docs-2.11.0-M4.txz",            "API docs",                   "3 MB"],
+  ["-non-main-sys", "scala-docs-2.11.0-M4.zip",            "/files/archive/scala-docs-2.11.0-M4.zip",            "API docs",                   "27 MB"],
+  ["-non-main-sys", "scala-tool-support-2.11.0-M4.tgz",    "/files/archive/scala-tool-support-2.11.0-M4.tgz",    "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-2.11.0-M4.zip",    "/files/archive/scala-tool-support-2.11.0-M4.zip",    "Scala Tool Support (zip)",   "46 KB"]
+]
+---
+
+
+

--- a/download/all.md
+++ b/download/all.md
@@ -1,7 +1,7 @@
 ---
 layout: alldownloadspage
 title: Download Previous Versions
-development_version: 2.11.0-M3
+development_version: 2.11.0-M4
 ---
 
 <!-- This page should be auto-generated -->

--- a/download/index.md
+++ b/download/index.md
@@ -5,7 +5,7 @@ release_version: 2.10.2
 release_date: "June 6, 2013"
 other_releases: [
   ["maintenance_version", "Current maintenance release", 2.9.3, "February 28, 2013"],
-  ["development_version", "Current development release", 2.11.0-M3, "May 29, 2013"]
+  ["development_version", "Current development release", 2.11.0-M4, "July 11, 2013"]
 ]
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [

--- a/news/_posts/2013-07-11-release-notes-v2.11.0-M4.md
+++ b/news/_posts/2013-07-11-release-notes-v2.11.0-M4.md
@@ -1,0 +1,43 @@
+---
+layout: news
+post-type: announcement
+title: "Scala 2.11.0-M4 is now available!"
+---
+The [fourth development milestone](https://github.com/scala/scala/releases/v2.11.0-M4) of Scala 2.11 is now available for [download](/download/2.11.0-M4.html)!
+
+It brings the following [goodness](https://github.com/scala/scala/issues?direction=desc&labels=reviewed&milestone=18&page=1&sort=comments&state=closed):
+
+- initial version of a new experimental back-end based on ASM by [@magarciaEPFL](https://github.com/magarciaEPFL) ([[#2620](https://github.com/scala/scala/pull/2620)](https://github.com/scala/scala/pull/2620))
+- [quasiquotes](http://docs.scala-lang.org/overviews/macros/quasiquotes.html) by [@densh](https://github.com/densh) ([#2714](https://github.com/scala/scala/pull/2714))
+- a more modular standard library: scala.xml and scala.util.parsing now come in separate jars ([#2704](https://github.com/scala/scala/pull/2704))
+  - we now also use a bog-standard [jline 2.11](https://github.com/jline/jline2/tree/jline-2.11)
+- [@soc](https://github.com/soc) implemented deprecation of the confusing octal literals ([#2343](https://github.com/scala/scala/pull/2343))
+- [@JamesIry](https://github.com/JamesIry) and [@gkossakowski](https://github.com/gkossakowski) reduced scalac's memory retention ([#2605](https://github.com/scala/scala/pull/2605))
+- a Semmle-driven cleanup of the compiler's code base by [@lexspoon](https://github.com/lexspoon) ([#2693](https://github.com/scala/scala/pull/2693))
+- [@paulp](https://github.com/paulp) thwarted dangerous implicits in [#2625](https://github.com/scala/scala/pull/2625) (SI-6899)
+- other [bug fixes](https://issues.scala-lang.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=project+%3D+SI+AND+resolution+%3D+fixed+AND+fixVersion+%3D+%22Scala+2.11.0-M4%22+ORDER+BY+key+ASC%2C+priority+DESC)
+- a growing number of contributions -- thank you!
+
+We're working on an [overview of the Scala 2.11 release](http://docs.scala-lang.org/scala/2.11/) -- [PRs](https://github.com/scala/scala/blob/gh-pages/2.11/index.markdown) welcome!
+
+### Coming up
+For the [next milestone](https://github.com/scala/scala/issues?milestone=20&state=open), slated for mid August, we're working on:
+
+- optimizations for the experimental back-end ([#2711](https://github.com/scala/scala/pull/2711) and others)
+- a new translation for closures that lifts a closure body to a method
+- [support for SAM target typing](https://github.com/adriaanm/scala/tree/sammy)
+- more modules
+
+### Regressions
+We'd [love to hear](https://issues.scala-lang.org/) about any regressions since 2.10.2 or 2.11.0-M3. Before doing so, please search for existing bugs and/or consult with the [scala-user](https://groups.google.com/forum/#!forum/scala-user) mailing list to be sure it is a genuine problem.
+
+When reporting a bug, please set the 'Affects Version' field to 2.11.0-M4 and add the `regression` label where appropriate.
+
+### Scala IDE Lithium (4.0) for Eclipse
+Please point your Eclipse 4.2/4.3 at http://download.scala-ide.org/sdk/e38/scala211/dev/site/ to update to the latest version that includes this milestone!
+For more info, please see [the getting started guide](http://scala-ide.org/docs/user/gettingstarted.html).
+
+### Binary compatibility
+Note that this release is not binary compatible with the 2.10.x series, so you will need to obtain a fresh build of your dependencies against this version. 
+
+[@cunei](https://github.com/cunei) is working on [a tool](http://typesafehub.github.io/distributed-build/0.6.0/index.html) to solve this problem. The current version already builds [akka, genjavadoc, sbinary, sbt, sbt-full-library, sbt-republish, scala, scala-arm, scala-stm, scalabuff, scalacheck, scalatest, scalaz, shapeless, specs2, sperformance, zeromq-scala-binding, zinc](https://jenkins-dbuild.typesafe.com:8499/job/Community8/1/consoleFull).


### PR DESCRIPTION
Added the news item and download page for 2.11.0-M4. Review by @heathermiller, please.

I verified it looks ok in jekyll (btw, on jekyll 1.1.2, the command to start the server is `jekyll serve`).

I'd also suggest switching to github flavored markdown in _config.yml:

```
--- i/_config.yml
+++ w/_config.yml
@@ -5,3 +5,6 @@ devscalaversion: "2.11.0-M4"
 scala_maindownload_unix: "/files/archive/scala-2.10.2.tgz"
 scala_maindownload_windows: "/files/archive/scala-2.10.2.msi"
 baseurl: ""
+markdown: redcarpet
+redcarpet:
+  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
```
