### PR TITLE
add download links for rpm and deb; fix some others

### DIFF
--- a/download/_posts/2012-04-13-2.9.2.md
+++ b/download/_posts/2012-04-13-2.9.2.md
@@ -11,8 +11,11 @@ resources: [
   ["-main-unixsys", "scala-2.9.2.tgz",         "/files/archive/scala-2.9.2.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.2.msi",         "/files/archive/scala-2.9.2.msi",         "Windows (msi installer)", "50 MB"],
   ["-non-main-sys", "scala-2.9.2.zip",         "/files/archive/scala-2.9.2.zip",         "Windows",                 "25 MB"],
+  ["-non-main-sys", "scala-2.9.2.deb",         "/files/archive/scala-2.9.2.deb",         "Debian",                  "20 MB"],
+  ["-non-main-sys", "scala-2.9.2.rpm",         "/files/archive/scala-2.9.2.rpm",         "RPM package",             "20 MB"],
   ["-non-main-sys", "scala-docs-2.9.2.txz",    "/files/archive/scala-docs-2.9.2.txz",    "API docs",                "3 MB"],
-  ["-non-main-sys", "scala-docs-2.9.2.zip",    "/files/archive/scala-docs-2.9.2.zip",    "API docs",                "27 MB"]
+  ["-non-main-sys", "scala-docs-2.9.2.zip",    "/files/archive/scala-docs-2.9.2.zip",    "API docs",                "27 MB"],
+  ["-non-main-sys", "scala-sources-2.9.2.tgz", "/files/archive/scala-sources-2.9.2.tgz", "sources",                 "37 MB"]
 ]
 ---
 

--- a/download/_posts/2013-02-28-2.9.3.md
+++ b/download/_posts/2013-02-28-2.9.3.md
@@ -11,8 +11,11 @@ resources: [
   ["-main-unixsys", "scala-2.9.3.tgz",         "/files/archive/scala-2.9.3.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.3.msi",         "/files/archive/scala-2.9.3.msi",         "Windows (msi installer)", "50 MB"],
   ["-non-main-sys", "scala-2.9.3.zip",         "/files/archive/scala-2.9.3.zip",         "Windows",                 "25 MB"],
+  ["-non-main-sys", "scala-2.9.3.deb",         "/files/archive/scala-2.9.3.deb",         "Debian",                  "21 MB"],
+  ["-non-main-sys", "scala-2.9.3.rpm",         "/files/archive/scala-2.9.3.rpm",         "RPM package",             "21 MB"],
   ["-non-main-sys", "scala-docs-2.9.3.txz",    "/files/archive/scala-docs-2.9.3.txz",    "API docs",                "3 MB"],
-  ["-non-main-sys", "scala-docs-2.9.3.zip",    "/files/archive/scala-docs-2.9.3.zip",    "API docs",                "27 MB"]
+  ["-non-main-sys", "scala-docs-2.9.3.zip",    "/files/archive/scala-docs-2.9.3.zip",    "API docs",                "27 MB"],
+  ["-non-main-sys", "scala-sources-2.9.3.tgz", "/files/archive/scala-sources-2.9.3.tgz", "sources",                 "37 MB"]
 ]
 ---
 

--- a/download/_posts/2013-03-13-2.10.1.md
+++ b/download/_posts/2013-03-13-2.10.1.md
@@ -15,7 +15,7 @@ resources: [
   ["-non-main-sys", "scala-2.10.1.rpm",         "/files/archive/scala-2.10.1.rpm",         "RPM package",             "21.0 MB"],
   ["-non-main-sys", "scala-docs-2.10.1.txz",    "/files/archive/scala-docs-2.10.1.txz",    "API docs",                "1.8 MB"],
   ["-non-main-sys", "scala-docs-2.10.1.zip",    "/files/archive/scala-docs-2.10.1.zip",    "API docs",                "21.3 MB"],
-  ["-non-main-sys", "scala-sources-2.10.1.zip", "/files/archive/scala-sources-2.10.1.zip", "sources",                 "37.6 MB"]
+  ["-non-main-sys", "scala-sources-2.10.1.tgz", "/files/archive/scala-sources-2.10.1.tgz", "sources",                 "43.2 MB"]
 ]
 ---
 

--- a/download/_posts/2013-03-14-2.11.0-M2.md
+++ b/download/_posts/2013-03-14-2.11.0-M2.md
@@ -11,6 +11,8 @@ resources: [
   ["-main-unixsys", "scala-2.11.0-M2.tgz",         "/files/archive/scala-2.11.0-M2.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.11.0-M2.msi",         "/files/archive/scala-2.11.0-M2.msi",         "Windows (msi installer)", "50 MB"],
   ["-non-main-sys", "scala-2.11.0-M2.zip",         "/files/archive/scala-2.11.0-M2.zip",         "Windows",                 "25 MB"],
+  ["-non-main-sys", "scala-2.11.0-M2.deb",         "/files/archive/scala-2.11.0-M2.deb",         "Debian",                  "23 MB"],
+  ["-non-main-sys", "scala-2.11.0-M2.rpm",         "/files/archive/scala-2.11.0-M2.rpm",         "RPM package",             "23 MB"],
   ["-non-main-sys", "scala-docs-2.11.0-M2.txz",    "/files/archive/scala-docs-2.11.0-M2.txz",    "API docs",                "3 MB"],
   ["-non-main-sys", "scala-docs-2.11.0-M2.zip",    "/files/archive/scala-docs-2.11.0-M2.zip",    "API docs",                "27 MB"]
 ]

--- a/download/_posts/2013-05-29-2.11.0-M3.md
+++ b/download/_posts/2013-05-29-2.11.0-M3.md
@@ -11,6 +11,8 @@ resources: [
   ["-main-unixsys", "scala-2.11.0-M3.tgz",                 "/files/archive/scala-2.11.0-M3.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
   ["-main-windows", "scala-2.11.0-M3.msi",                 "/files/archive/scala-2.11.0-M3.msi",                 "Windows (msi installer)",    "50 MB"],
   ["-non-main-sys", "scala-2.11.0-M3.zip",                 "/files/archive/scala-2.11.0-M3.zip",                 "Windows",                    "25 MB"],
+  ["-non-main-sys", "scala-2.11.0-M3.deb",                 "/files/archive/scala-2.11.0-M3.deb",                 "Debian",                     "24 MB"],
+  ["-non-main-sys", "scala-2.11.0-M3.rpm",                 "/files/archive/scala-2.11.0-M3.rpm",                 "RPM package",                "24 MB"],
   ["-non-main-sys", "scala-docs-2.11.0-M3.txz",            "/files/archive/scala-docs-2.11.0-M3.txz",            "API docs",                   "3 MB"],
   ["-non-main-sys", "scala-docs-2.11.0-M3.zip",            "/files/archive/scala-docs-2.11.0-M3.zip",            "API docs",                   "27 MB"],
   ["-non-main-sys", "scala-tool-support-2.11.0-M3.tgz",    "/files/archive/scala-tool-support-2.11.0-M3.tgz",    "Scala Tool Support (tgz)",   "25 KB"],

--- a/download/_posts/2013-06-06-2.10.2.md
+++ b/download/_posts/2013-06-06-2.10.2.md
@@ -11,6 +11,8 @@ resources: [
   ["-main-unixsys", "scala-2.10.2.tgz",              "/files/archive/scala-2.10.2.tgz",                       "Max OS X, Unix, Cygwin",     "20 MB"],
   ["-main-windows", "scala-2.10.2.msi",              "/files/archive/scala-2.10.2.msi",                       "Windows (msi installer)",    "60 MB"],
   ["-non-main-sys", "scala-2.10.2.zip",              "/files/archive/scala-2.10.2.zip",                       "Windows",                    "29 MB"],
+  ["-non-main-sys", "scala-2.10.2.deb",              "/files/archive/scala-2.10.2.deb",                       "Debian",                     "25 MB"],
+  ["-non-main-sys", "scala-2.10.2.rpm",              "/files/archive/scala-2.10.2.rpm",                       "RPM package",                "25 MB"],
   ["-non-main-sys", "scala-docs-2.10.2.txz",         "/files/archive/scala-docs-2.10.2.txz",                  "API docs",                   "4 MB"],
   ["-non-main-sys", "scala-docs-2.10.2.zip",         "/files/archive/scala-docs-2.10.2.zip",                  "API docs",                   "33 MB"],
   ["-non-main-sys", "scala-sources-2.10.2.zip",      "https://github.com/scala/scala/archive/v2.10.2.tar.gz", "sources",                    ""],

--- a/download/_posts/2013-07-11-2.11.0-M4.md
+++ b/download/_posts/2013-07-11-2.11.0-M4.md
@@ -11,6 +11,8 @@ resources: [
   ["-main-unixsys", "scala-2.11.0-M4.tgz",                 "/files/archive/scala-2.11.0-M4.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
   ["-main-windows", "scala-2.11.0-M4.msi",                 "/files/archive/scala-2.11.0-M4.msi",                 "Windows (msi installer)",    "50 MB"],
   ["-non-main-sys", "scala-2.11.0-M4.zip",                 "/files/archive/scala-2.11.0-M4.zip",                 "Windows",                    "25 MB"],
+  ["-non-main-sys", "scala-2.11.0-M4.deb",                 "/files/archive/scala-2.11.0-M4.deb",                 "Debian",                     "25 MB"],
+  ["-non-main-sys", "scala-2.11.0-M4.rpm",                 "/files/archive/scala-2.11.0-M4.rpm",                 "RPM package",                "25 MB"],
   ["-non-main-sys", "scala-docs-2.11.0-M4.txz",            "/files/archive/scala-docs-2.11.0-M4.txz",            "API docs",                   "3 MB"],
   ["-non-main-sys", "scala-docs-2.11.0-M4.zip",            "/files/archive/scala-docs-2.11.0-M4.zip",            "API docs",                   "27 MB"],
   ["-non-main-sys", "scala-tool-support-2.11.0-M4.tgz",    "/files/archive/scala-tool-support-2.11.0-M4.tgz",    "Scala Tool Support (tgz)",   "25 KB"],


### PR DESCRIPTION
- add download links for the .rpm and .deb for 2.9.2, 2.9.3, 2.10.2,
  2.11.0-(M2, M3, M4),
- add missing source links for 2.9.2 and 2.9.3,
- fix brocken source link for 2.10.1.

This fixes #113.
