### PR TITLE
Remove Typesafe copyright line pending clarification.

### DIFF
--- a/license.md
+++ b/license.md
@@ -4,7 +4,6 @@ title: Scala License
 ---
 
 Copyright (c) 2002-<span class="current-year">&nbsp;</span> EPFL<br>
-Copyright (c) 2011-<span class="current-year">&nbsp;</span> Typesafe, Inc.
 
 All rights reserved.
 


### PR DESCRIPTION
This line was added under the belief that this was simply a clarification of existing agreements.

I still think it's the right thing to do for the Scala project
(my understanding is that it doesn't give Typesafe any rights not already provided by the license itself;
it's purely an attribution and a legal defense mechanism in case someone challenges the copyright).

Nonetheless, I agree we should not add it until everyone is convinced it's the right thing to do.
