### PR TITLE
add an "API Docs" page with links to available docs.

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Scala API Docs
+---
+
+## Latest releases
+
+* [Scala 2.10.2](http://www.scala-lang.org/files/archive/api/2.10.2/)
+* [Scala 2.11.0-M5](http://www.scala-lang.org/files/archive/api/2.11.0-M5/)
+
+## Nightly builds
+
+* [Library API](http://www.scala-lang.org/files/archive/nightly/docs-master/library/)
+* [Compiler API](http://www.scala-lang.org/files/archive/nightly/docs-master/compiler/)
+
+## Previous releases
+
+* [Scala 2.11.0-M4](http://www.scala-lang.org/files/archive/api/2.11.0-M4/)
+* [Scala 2.11.0-M3](http://www.scala-lang.org/files/archive/api/2.11.0-M3/)
+* [Scala 2.11.0-M2](http://www.scala-lang.org/files/archive/api/2.11.0-M2/)
+* [Scala 2.10.1](http://www.scala-lang.org/files/archive/api/2.10.1/)
+* [Scala 2.9.3](http://www.scala-lang.org/files/archive/api/2.9.3/)
+* [Scala 2.9.2](http://www.scala-lang.org/files/archive/api/2.9.2/)
+* [Scala 2.9.1-1](http://www.scala-lang.org/files/archive/api/2.9.1-1/)
+* [Scala 2.9.1.final](http://www.scala-lang.org/files/archive/api/2.9.1/)
+* [Scala 2.9.0.1](http://www.scala-lang.org/files/archive/api/2.9.0.1/)
+* [Scala 2.9.0.final](http://www.scala-lang.org/files/archive/api/2.9.0/)
+* [Scala 2.8.2.final](http://www.scala-lang.org/files/archive/api/2.8.2/)
+* [Scala 2.8.1.final](http://www.scala-lang.org/files/archive/api/2.8.1/)
+* [Scala 2.8.0.final](http://www.scala-lang.org/files/archive/api/2.8.0/)
+* [Scala 2.7.7.final](http://www.scala-lang.org/files/archive/api/2.7.7/)
+* [Scala 2.7.6.final](http://www.scala-lang.org/files/archive/api/2.7.6/)
+* [Scala 2.7.5.final](http://www.scala-lang.org/files/archive/api/2.7.5/)
+* [Scala 2.7.4.final](http://www.scala-lang.org/files/archive/api/2.7.4/)
+* [Scala 2.7.3.final](http://www.scala-lang.org/files/archive/api/2.7.3/)
+* [Scala 2.7.2.final](http://www.scala-lang.org/files/archive/api/2.7.2/)
+* [Scala 2.7.1.final](http://www.scala-lang.org/files/archive/api/2.7.1/)
+* [Scala 2.7.0.final](http://www.scala-lang.org/files/archive/api/2.7.0/)
+* [Scala 2.6.1.final](http://www.scala-lang.org/files/archive/api/2.6.1/)
+* [Scala 2.6.0.final](http://www.scala-lang.org/files/archive/api/2.6.0/)
+* [Scala 2.5.1.final](http://www.scala-lang.org/files/archive/api/2.5.1/)
+* [Scala 2.5.0.final](http://www.scala-lang.org/files/archive/api/2.5.0/)

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -21,7 +21,7 @@ title: Learn
 
   <div class="row">
     <div class="span4 doc-block">
-      <h3><a href="http://www.scala-lang.org/api/current/index.html#package">API</a></h3>
+      <h3><a href="{{ site.baseurl }}/documentation/api.html">API</a></h3>
       <p>Dive straight into the API.</p>
     </div>
     <div class="span4 doc-block">


### PR DESCRIPTION
Displays links to scaladoc for:
- current releases
- nightly builds (both library and compiler)
- all previous releases

---

This fixes #89, #99 and #106.
