### PR TITLE
Remove stray references to 2.10.2

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -9,15 +9,10 @@ other_releases: [
 ]
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.2.tgz",         "/files/archive/scala-2.10.2.tgz",         "Max OS X, Unix, Cygwin",   "20 MB"],
-  ["-main-windows", "scala-2.10.2.msi",         "/files/archive/scala-2.10.2.msi",         "Windows (msi installer)",  "60 MB"]
+  ["-main-unixsys", "scala-2.10.3.tgz",         "/files/archive/scala-2.10.3.tgz",         "Max OS X, Unix, Cygwin",   "20 MB"],
+  ["-main-windows", "scala-2.10.3.msi",         "/files/archive/scala-2.10.3.msi",         "Windows (msi installer)",  "60 MB"]
 ]
 ---
-
-<!-- for safekeeping
-  ["rc_version", "Current release candidate", 2.10.2-RC2, "May 31, 2013"],
-  ["nightly_version", "Nightly build", 2.11.0-latest, ""]
--->
 
 <!-- This page should be auto-generated - it is the main download page of the latest stable release -->
 


### PR DESCRIPTION
After this change:

```
% ack -l --markdown 2.10.2
documentation/api.md
download/_posts/2013-05-31-2.10.2-RC2.md
download/_posts/2013-06-06-2.10.2.md
news/_posts/2013-05-23-release-notes-v2.10.2-RC1.md
news/_posts/2013-05-29-release-notes-v2.11.0-M3.md
news/_posts/2013-05-31-release-notes-v2.10.2-RC2.md
news/_posts/2013-06-06-release-notes-v2.10.2.md
news/_posts/2013-07-11-release-notes-v2.11.0-M4.md
news/_posts/2013-09-18-release-notes-v2.10.3-RC2.md
news/_posts/2013-09-24-release-notes-v2.10.3-RC3.md
news/_posts/2013-10-01-release-notes-v2.10.3.md

% ack -l --markdown 2.10.3
documentation/api.md
download/_posts/2013-09-18-2.10.3-RC2.md
download/_posts/2013-09-24-2.10.3-RC3.md
download/_posts/2013-10-01-2.10.3.md
download/index.md
news/_posts/2013-09-18-release-notes-v2.10.3-RC2.md
news/_posts/2013-09-24-release-notes-v2.10.3-RC3.md
news/_posts/2013-09-28-release-notes-v2.11.0-M5.md
news/_posts/2013-10-01-release-notes-v2.10.3.md
```
