### PR TITLE
Reduce duplication of version number in download page sources.

### DIFF
--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -53,8 +53,8 @@ You can find the installer download links for other operating systems, as well a
 {% for resource in page.resources %}
 <tr>
   <td>
-    <a id="#link{{ resource[0] }}" href="{{ resource[2] }}">
-      {{ resource[1] }}
+    <a id="#link{{ resource[0] | liquify }}" href="{{ resource[2] | liquify }}">
+      {{ resource[1] | liquify }}
     </a>
   </td>
   <td>{{ resource[3] }}</td>

--- a/_plugins/liquify_filter.rb
+++ b/_plugins/liquify_filter.rb
@@ -1,0 +1,10 @@
+# Technique from http://stackoverflow.com/questions/14487110/include-jekyll-liquid-template-data-in-a-yaml-variable
+module Jekyll
+  module LiquifyFilter
+    def liquify(input)
+      Liquid::Template.parse(input).render(@context)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::LiquifyFilter)

--- a/download/_posts/2012-04-13-2.9.2.md
+++ b/download/_posts/2012-04-13-2.9.2.md
@@ -8,14 +8,14 @@ show_resources: "true"
 permalink: /download/2.9.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.9.2.tgz",         "/files/archive/scala-2.9.2.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
-  ["-main-windows", "scala-2.9.2.msi",         "/files/archive/scala-2.9.2.msi",         "Windows (msi installer)", "50 MB"],
-  ["-non-main-sys", "scala-2.9.2.zip",         "/files/archive/scala-2.9.2.zip",         "Windows",                 "25 MB"],
-  ["-non-main-sys", "scala-2.9.2.deb",         "/files/archive/scala-2.9.2.deb",         "Debian",                  "20 MB"],
-  ["-non-main-sys", "scala-2.9.2.rpm",         "/files/archive/scala-2.9.2.rpm",         "RPM package",             "20 MB"],
-  ["-non-main-sys", "scala-docs-2.9.2.txz",    "/files/archive/scala-docs-2.9.2.txz",    "API docs",                "3 MB"],
-  ["-non-main-sys", "scala-docs-2.9.2.zip",    "/files/archive/scala-docs-2.9.2.zip",    "API docs",                "27 MB"],
-  ["-non-main-sys", "scala-sources-2.9.2.tgz", "/files/archive/scala-sources-2.9.2.tgz", "sources",                 "37 MB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",         "/files/archive/scala-{{page.release_version}}.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",         "/files/archive/scala-{{page.release_version}}.msi",         "Windows (msi installer)", "50 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",         "/files/archive/scala-{{page.release_version}}.zip",         "Windows",                 "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",         "/files/archive/scala-{{page.release_version}}.deb",         "Debian",                  "20 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",         "/files/archive/scala-{{page.release_version}}.rpm",         "RPM package",             "20 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",    "/files/archive/scala-docs-{{page.release_version}}.txz",    "API docs",                "3 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",    "/files/archive/scala-docs-{{page.release_version}}.zip",    "API docs",                "27 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.tgz", "/files/archive/scala-sources-{{page.release_version}}.tgz", "sources",                 "37 MB"]
 ]
 ---
 

--- a/download/_posts/2013-02-28-2.9.3.md
+++ b/download/_posts/2013-02-28-2.9.3.md
@@ -8,14 +8,14 @@ show_resources: "true"
 permalink: /download/2.9.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.9.3.tgz",         "/files/archive/scala-2.9.3.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
-  ["-main-windows", "scala-2.9.3.msi",         "/files/archive/scala-2.9.3.msi",         "Windows (msi installer)", "50 MB"],
-  ["-non-main-sys", "scala-2.9.3.zip",         "/files/archive/scala-2.9.3.zip",         "Windows",                 "25 MB"],
-  ["-non-main-sys", "scala-2.9.3.deb",         "/files/archive/scala-2.9.3.deb",         "Debian",                  "21 MB"],
-  ["-non-main-sys", "scala-2.9.3.rpm",         "/files/archive/scala-2.9.3.rpm",         "RPM package",             "21 MB"],
-  ["-non-main-sys", "scala-docs-2.9.3.txz",    "/files/archive/scala-docs-2.9.3.txz",    "API docs",                "3 MB"],
-  ["-non-main-sys", "scala-docs-2.9.3.zip",    "/files/archive/scala-docs-2.9.3.zip",    "API docs",                "27 MB"],
-  ["-non-main-sys", "scala-sources-2.9.3.tgz", "/files/archive/scala-sources-2.9.3.tgz", "sources",                 "37 MB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",         "/files/archive/scala-{{page.release_version}}.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",         "/files/archive/scala-{{page.release_version}}.msi",         "Windows (msi installer)", "50 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",         "/files/archive/scala-{{page.release_version}}.zip",         "Windows",                 "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",         "/files/archive/scala-{{page.release_version}}.deb",         "Debian",                  "21 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",         "/files/archive/scala-{{page.release_version}}.rpm",         "RPM package",             "21 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",    "/files/archive/scala-docs-{{page.release_version}}.txz",    "API docs",                "3 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",    "/files/archive/scala-docs-{{page.release_version}}.zip",    "API docs",                "27 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.tgz", "/files/archive/scala-sources-{{page.release_version}}.tgz", "sources",                 "37 MB"]
 ]
 ---
 

--- a/download/_posts/2013-03-13-2.10.1.md
+++ b/download/_posts/2013-03-13-2.10.1.md
@@ -8,14 +8,14 @@ show_resources: "true"
 permalink: /download/2.10.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.1.tgz",         "/files/archive/scala-2.10.1.tgz",         "Max OS X, Unix, Cygwin",  "23.9 MB"],
-  ["-main-windows", "scala-2.10.1.msi",         "/files/archive/scala-2.10.1.msi",         "Windows (msi installer)", "43.3 MB"],
-  ["-non-main-sys", "scala-2.10.1.zip",         "/files/archive/scala-2.10.1.zip",         "Windows",                 "23.9 MB"],
-  ["-non-main-sys", "scala-2.10.1.deb",         "/files/archive/scala-2.10.1.deb",         "Debian",                  "21.0 MB"],
-  ["-non-main-sys", "scala-2.10.1.rpm",         "/files/archive/scala-2.10.1.rpm",         "RPM package",             "21.0 MB"],
-  ["-non-main-sys", "scala-docs-2.10.1.txz",    "/files/archive/scala-docs-2.10.1.txz",    "API docs",                "1.8 MB"],
-  ["-non-main-sys", "scala-docs-2.10.1.zip",    "/files/archive/scala-docs-2.10.1.zip",    "API docs",                "21.3 MB"],
-  ["-non-main-sys", "scala-sources-2.10.1.tgz", "/files/archive/scala-sources-2.10.1.tgz", "sources",                 "43.2 MB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",         "/files/archive/scala-{{page.release_version}}.tgz",         "Max OS X, Unix, Cygwin",  "23.9 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",         "/files/archive/scala-{{page.release_version}}.msi",         "Windows (msi installer)", "43.3 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",         "/files/archive/scala-{{page.release_version}}.zip",         "Windows",                 "23.9 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",         "/files/archive/scala-{{page.release_version}}.deb",         "Debian",                  "21.0 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",         "/files/archive/scala-{{page.release_version}}.rpm",         "RPM package",             "21.0 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",    "/files/archive/scala-docs-{{page.release_version}}.txz",    "API docs",                "1.8 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",    "/files/archive/scala-docs-{{page.release_version}}.zip",    "API docs",                "21.3 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.tgz", "/files/archive/scala-sources-{{page.release_version}}.tgz", "sources",                 "43.2 MB"]
 ]
 ---
 

--- a/download/_posts/2013-03-14-2.11.0-M2.md
+++ b/download/_posts/2013-03-14-2.11.0-M2.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-M2.tgz",         "/files/archive/scala-2.11.0-M2.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
-  ["-main-windows", "scala-2.11.0-M2.msi",         "/files/archive/scala-2.11.0-M2.msi",         "Windows (msi installer)", "50 MB"],
-  ["-non-main-sys", "scala-2.11.0-M2.zip",         "/files/archive/scala-2.11.0-M2.zip",         "Windows",                 "25 MB"],
-  ["-non-main-sys", "scala-2.11.0-M2.deb",         "/files/archive/scala-2.11.0-M2.deb",         "Debian",                  "23 MB"],
-  ["-non-main-sys", "scala-2.11.0-M2.rpm",         "/files/archive/scala-2.11.0-M2.rpm",         "RPM package",             "23 MB"],
-  ["-non-main-sys", "scala-docs-2.11.0-M2.txz",    "/files/archive/scala-docs-2.11.0-M2.txz",    "API docs",                "3 MB"],
-  ["-non-main-sys", "scala-docs-2.11.0-M2.zip",    "/files/archive/scala-docs-2.11.0-M2.zip",    "API docs",                "27 MB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",         "/files/archive/scala-{{page.release_version}}.tgz",         "Max OS X, Unix, Cygwin",  "25 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",         "/files/archive/scala-{{page.release_version}}.msi",         "Windows (msi installer)", "50 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",         "/files/archive/scala-{{page.release_version}}.zip",         "Windows",                 "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",         "/files/archive/scala-{{page.release_version}}.deb",         "Debian",                  "23 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",         "/files/archive/scala-{{page.release_version}}.rpm",         "RPM package",             "23 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",    "/files/archive/scala-docs-{{page.release_version}}.txz",    "API docs",                "3 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",    "/files/archive/scala-docs-{{page.release_version}}.zip",    "API docs",                "27 MB"]
 ]
 ---
 

--- a/download/_posts/2013-05-29-2.11.0-M3.md
+++ b/download/_posts/2013-05-29-2.11.0-M3.md
@@ -8,15 +8,15 @@ show_resources: "true"
 permalink: /download/2.11.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-M3.tgz",                 "/files/archive/scala-2.11.0-M3.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
-  ["-main-windows", "scala-2.11.0-M3.msi",                 "/files/archive/scala-2.11.0-M3.msi",                 "Windows (msi installer)",    "50 MB"],
-  ["-non-main-sys", "scala-2.11.0-M3.zip",                 "/files/archive/scala-2.11.0-M3.zip",                 "Windows",                    "25 MB"],
-  ["-non-main-sys", "scala-2.11.0-M3.deb",                 "/files/archive/scala-2.11.0-M3.deb",                 "Debian",                     "24 MB"],
-  ["-non-main-sys", "scala-2.11.0-M3.rpm",                 "/files/archive/scala-2.11.0-M3.rpm",                 "RPM package",                "24 MB"],
-  ["-non-main-sys", "scala-docs-2.11.0-M3.txz",            "/files/archive/scala-docs-2.11.0-M3.txz",            "API docs",                   "3 MB"],
-  ["-non-main-sys", "scala-docs-2.11.0-M3.zip",            "/files/archive/scala-docs-2.11.0-M3.zip",            "API docs",                   "27 MB"],
-  ["-non-main-sys", "scala-tool-support-2.11.0-M3.tgz",    "/files/archive/scala-tool-support-2.11.0-M3.tgz",    "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.11.0-M3.zip",    "/files/archive/scala-tool-support-2.11.0-M3.zip",    "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",                 "/files/archive/scala-{{page.release_version}}.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",                 "/files/archive/scala-{{page.release_version}}.msi",                 "Windows (msi installer)",    "50 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",                 "/files/archive/scala-{{page.release_version}}.zip",                 "Windows",                    "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",                 "/files/archive/scala-{{page.release_version}}.deb",                 "Debian",                     "24 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",                 "/files/archive/scala-{{page.release_version}}.rpm",                 "RPM package",                "24 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",            "/files/archive/scala-docs-{{page.release_version}}.txz",            "API docs",                   "3 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",            "/files/archive/scala-docs-{{page.release_version}}.zip",            "API docs",                   "27 MB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz",    "/files/archive/scala-tool-support-{{page.release_version}}.tgz",    "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip",    "/files/archive/scala-tool-support-{{page.release_version}}.zip",    "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---
 

--- a/download/_posts/2013-05-31-2.10.2-RC2.md
+++ b/download/_posts/2013-05-31-2.10.2-RC2.md
@@ -8,14 +8,14 @@ show_resources: "true"
 permalink: /download/2.10.2-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.2-RC2.tgz",                 "/files/archive/scala-2.10.2-RC2.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
-  ["-main-windows", "scala-2.10.2-RC2.msi",                 "/files/archive/scala-2.10.2-RC2.msi",                           "Windows (msi installer)",    "60 MB"],
-  ["-non-main-sys", "scala-2.10.2-RC2.zip",                 "/files/archive/scala-2.10.2-RC2.zip",                           "Windows",                    "29 MB"],
-  ["-non-main-sys", "scala-docs-2.10.2-RC2.txz",            "/files/archive/scala-docs-2.10.2-RC2.txz",                      "API docs",                   "4 MB"],
-  ["-non-main-sys", "scala-docs-2.10.2-RC2.zip",            "/files/archive/scala-docs-2.10.2-RC2.zip",                      "API docs",                   "33 MB"],
-  ["-non-main-sys", "scala-sources-2.10.2-RC2.zip",         "https://github.com/scala/scala/archive/v2.10.2-RC2.tar.gz",     "sources",                    ""],
-  ["-non-main-sys", "scala-tool-support-2.10.2-RC2.tgz",    "/files/archive/scala-tool-support-2.10.2-RC2.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.10.2-RC2.zip",    "/files/archive/scala-tool-support-2.10.2-RC2.zip",              "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",                 "/files/archive/scala-{{page.release_version}}.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",                 "/files/archive/scala-{{page.release_version}}.msi",                           "Windows (msi installer)",    "60 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",                 "/files/archive/scala-{{page.release_version}}.zip",                           "Windows",                    "29 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",            "/files/archive/scala-docs-{{page.release_version}}.txz",                      "API docs",                   "4 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",            "/files/archive/scala-docs-{{page.release_version}}.zip",                      "API docs",                   "33 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.zip",         "https://github.com/scala/scala/archive/v{{page.release_version}}.tar.gz",     "sources",                    ""],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz",    "/files/archive/scala-tool-support-{{page.release_version}}.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip",    "/files/archive/scala-tool-support-{{page.release_version}}.zip",              "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---
 

--- a/download/_posts/2013-06-06-2.10.2.md
+++ b/download/_posts/2013-06-06-2.10.2.md
@@ -8,15 +8,15 @@ show_resources: "true"
 permalink: /download/2.10.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.2.tgz",              "/files/archive/scala-2.10.2.tgz",                       "Max OS X, Unix, Cygwin",     "20 MB"],
-  ["-main-windows", "scala-2.10.2.msi",              "/files/archive/scala-2.10.2.msi",                       "Windows (msi installer)",    "60 MB"],
-  ["-non-main-sys", "scala-2.10.2.zip",              "/files/archive/scala-2.10.2.zip",                       "Windows",                    "29 MB"],
-  ["-non-main-sys", "scala-2.10.2.deb",              "/files/archive/scala-2.10.2.deb",                       "Debian",                     "25 MB"],
-  ["-non-main-sys", "scala-2.10.2.rpm",              "/files/archive/scala-2.10.2.rpm",                       "RPM package",                "25 MB"],
-  ["-non-main-sys", "scala-docs-2.10.2.txz",         "/files/archive/scala-docs-2.10.2.txz",                  "API docs",                   "4 MB"],
-  ["-non-main-sys", "scala-docs-2.10.2.zip",         "/files/archive/scala-docs-2.10.2.zip",                  "API docs",                   "33 MB"],
-  ["-non-main-sys", "scala-sources-2.10.2.zip",      "https://github.com/scala/scala/archive/v2.10.2.tar.gz", "sources",                    ""],
-  ["-non-main-sys", "scala-tool-support-2.10.2.tgz", "/files/archive/scala-tool-support-2.10.2.tgz",          "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.10.2.zip", "/files/archive/scala-tool-support-2.10.2.zip",          "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",              "/files/archive/scala-{{page.release_version}}.tgz",                       "Max OS X, Unix, Cygwin",     "20 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",              "/files/archive/scala-{{page.release_version}}.msi",                       "Windows (msi installer)",    "60 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",              "/files/archive/scala-{{page.release_version}}.zip",                       "Windows",                    "29 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",              "/files/archive/scala-{{page.release_version}}.deb",                       "Debian",                     "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",              "/files/archive/scala-{{page.release_version}}.rpm",                       "RPM package",                "25 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",         "/files/archive/scala-docs-{{page.release_version}}.txz",                  "API docs",                   "4 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",         "/files/archive/scala-docs-{{page.release_version}}.zip",                  "API docs",                   "33 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.zip",      "https://github.com/scala/scala/archive/v{{page.release_version}}.tar.gz", "sources",                    ""],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz", "/files/archive/scala-tool-support-{{page.release_version}}.tgz",          "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip", "/files/archive/scala-tool-support-{{page.release_version}}.zip",          "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---

--- a/download/_posts/2013-07-11-2.11.0-M4.md
+++ b/download/_posts/2013-07-11-2.11.0-M4.md
@@ -8,15 +8,15 @@ show_resources: "true"
 permalink: /download/2.11.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-M4.tgz",                 "/files/archive/scala-2.11.0-M4.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
-  ["-main-windows", "scala-2.11.0-M4.msi",                 "/files/archive/scala-2.11.0-M4.msi",                 "Windows (msi installer)",    "50 MB"],
-  ["-non-main-sys", "scala-2.11.0-M4.zip",                 "/files/archive/scala-2.11.0-M4.zip",                 "Windows",                    "25 MB"],
-  ["-non-main-sys", "scala-2.11.0-M4.deb",                 "/files/archive/scala-2.11.0-M4.deb",                 "Debian",                     "25 MB"],
-  ["-non-main-sys", "scala-2.11.0-M4.rpm",                 "/files/archive/scala-2.11.0-M4.rpm",                 "RPM package",                "25 MB"],
-  ["-non-main-sys", "scala-docs-2.11.0-M4.txz",            "/files/archive/scala-docs-2.11.0-M4.txz",            "API docs",                   "3 MB"],
-  ["-non-main-sys", "scala-docs-2.11.0-M4.zip",            "/files/archive/scala-docs-2.11.0-M4.zip",            "API docs",                   "27 MB"],
-  ["-non-main-sys", "scala-tool-support-2.11.0-M4.tgz",    "/files/archive/scala-tool-support-2.11.0-M4.tgz",    "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.11.0-M4.zip",    "/files/archive/scala-tool-support-2.11.0-M4.zip",    "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",                 "/files/archive/scala-{{page.release_version}}.tgz",                 "Max OS X, Unix, Cygwin",     "25 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",                 "/files/archive/scala-{{page.release_version}}.msi",                 "Windows (msi installer)",    "50 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",                 "/files/archive/scala-{{page.release_version}}.zip",                 "Windows",                    "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",                 "/files/archive/scala-{{page.release_version}}.deb",                 "Debian",                     "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",                 "/files/archive/scala-{{page.release_version}}.rpm",                 "RPM package",                "25 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",            "/files/archive/scala-docs-{{page.release_version}}.txz",            "API docs",                   "3 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",            "/files/archive/scala-docs-{{page.release_version}}.zip",            "API docs",                   "27 MB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz",    "/files/archive/scala-tool-support-{{page.release_version}}.tgz",    "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip",    "/files/archive/scala-tool-support-{{page.release_version}}.zip",    "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---
 

--- a/download/_posts/2013-09-18-2.10.3-RC2.md
+++ b/download/_posts/2013-09-18-2.10.3-RC2.md
@@ -8,14 +8,14 @@ show_resources: "true"
 permalink: /download/2.10.3-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.3-RC2.tgz",                 "/files/archive/scala-2.10.3-RC2.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
-  ["-main-windows", "scala-2.10.3-RC2.msi",                 "/files/archive/scala-2.10.3-RC2.msi",                           "Windows (msi installer)",    "60 MB"],
-  ["-non-main-sys", "scala-2.10.3-RC2.zip",                 "/files/archive/scala-2.10.3-RC2.zip",                           "Windows",                    "29 MB"],
-  ["-non-main-sys", "scala-docs-2.10.3-RC2.txz",            "/files/archive/scala-docs-2.10.3-RC2.txz",                      "API docs",                   "4 MB"],
-  ["-non-main-sys", "scala-docs-2.10.3-RC2.zip",            "/files/archive/scala-docs-2.10.3-RC2.zip",                      "API docs",                   "33 MB"],
-  ["-non-main-sys", "scala-sources-2.10.3-RC2.zip",         "https://github.com/scala/scala/archive/v2.10.3-RC2.tar.gz",     "sources",                    ""],
-  ["-non-main-sys", "scala-tool-support-2.10.3-RC2.tgz",    "/files/archive/scala-tool-support-2.10.3-RC2.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.10.3-RC2.zip",    "/files/archive/scala-tool-support-2.10.3-RC2.zip",              "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",                 "/files/archive/scala-{{page.release_version}}.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",                 "/files/archive/scala-{{page.release_version}}.msi",                           "Windows (msi installer)",    "60 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",                 "/files/archive/scala-{{page.release_version}}.zip",                           "Windows",                    "29 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",            "/files/archive/scala-docs-{{page.release_version}}.txz",                      "API docs",                   "4 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",            "/files/archive/scala-docs-{{page.release_version}}.zip",                      "API docs",                   "33 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.zip",         "https://github.com/scala/scala/archive/v{{page.release_version}}.tar.gz",     "sources",                    ""],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz",    "/files/archive/scala-tool-support-{{page.release_version}}.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip",    "/files/archive/scala-tool-support-{{page.release_version}}.zip",              "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---
 

--- a/download/_posts/2013-09-24-2.10.3-RC3.md
+++ b/download/_posts/2013-09-24-2.10.3-RC3.md
@@ -8,14 +8,14 @@ show_resources: "true"
 permalink: /download/2.10.3-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.3-RC3.tgz",                 "/files/archive/scala-2.10.3-RC3.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
-  ["-main-windows", "scala-2.10.3-RC3.msi",                 "/files/archive/scala-2.10.3-RC3.msi",                           "Windows (msi installer)",    "60 MB"],
-  ["-non-main-sys", "scala-2.10.3-RC3.zip",                 "/files/archive/scala-2.10.3-RC3.zip",                           "Windows",                    "29 MB"],
-  ["-non-main-sys", "scala-docs-2.10.3-RC3.txz",            "/files/archive/scala-docs-2.10.3-RC3.txz",                      "API docs",                   "4 MB"],
-  ["-non-main-sys", "scala-docs-2.10.3-RC3.zip",            "/files/archive/scala-docs-2.10.3-RC3.zip",                      "API docs",                   "33 MB"],
-  ["-non-main-sys", "scala-sources-2.10.3-RC3.zip",         "https://github.com/scala/scala/archive/v2.10.3-RC3.tar.gz",     "sources",                    ""],
-  ["-non-main-sys", "scala-tool-support-2.10.3-RC3.tgz",    "/files/archive/scala-tool-support-2.10.3-RC3.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.10.3-RC3.zip",    "/files/archive/scala-tool-support-2.10.3-RC3.zip",              "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",                 "/files/archive/scala-{{page.release_version}}.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",                 "/files/archive/scala-{{page.release_version}}.msi",                           "Windows (msi installer)",    "60 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",                 "/files/archive/scala-{{page.release_version}}.zip",                           "Windows",                    "29 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",            "/files/archive/scala-docs-{{page.release_version}}.txz",                      "API docs",                   "4 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",            "/files/archive/scala-docs-{{page.release_version}}.zip",                      "API docs",                   "33 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.zip",         "https://github.com/scala/scala/archive/v{{page.release_version}}.tar.gz",     "sources",                    ""],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz",    "/files/archive/scala-tool-support-{{page.release_version}}.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip",    "/files/archive/scala-tool-support-{{page.release_version}}.zip",              "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---
 

--- a/download/_posts/2013-09-27-2.11.0-M5.md
+++ b/download/_posts/2013-09-27-2.11.0-M5.md
@@ -8,16 +8,16 @@ show_resources: "true"
 permalink: /download/2.11.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  [-main-unixsys, "scala-2.11.0-M5.tgz", "/files/archive/scala-2.11.0-M5.tgz", "Max OS X, Unix, Cygwin", "28M"],
-  [-main-windows, "scala-2.11.0-M5.msi", "/files/archive/scala-2.11.0-M5.msi", "Windows (msi installer)", "52M"],
-  [-non-main-sys, "scala-2.11.0-M5.zip", "/files/archive/scala-2.11.0-M5.zip", "Windows", "28M"],
-  [-non-main-sys, "scala-2.11.0-M5.deb", "/files/archive/scala-2.11.0-M5.deb", "Debian", "25M"],
-  [-non-main-sys, "scala-2.11.0-M5.rpm", "/files/archive/scala-2.11.0-M5.rpm", "RPM package", "25M"],
-  [-non-main-sys, "scala-docs-2.11.0-M5.txz", "/files/archive/scala-docs-2.11.0-M5.txz", "API docs", "3.1M"],
-  [-non-main-sys, "scala-docs-2.11.0-M5.zip", "/files/archive/scala-docs-2.11.0-M5.zip", "API docs", "25M"],
-  [-non-main-sys, "scala-sources-2.11.0-M5.zip", "https://github.com/scala/scala/archive/v2.11.0-M5.tar.gz", "sources", "4.0K"],
-  [-non-main-sys, "scala-tool-support-2.11.0-M5.tgz", "/files/archive/scala-tool-support-2.11.0-M5.tgz", "Scala Tool Support (tgz)", "28K"],
-  [-non-main-sys, "scala-tool-support-2.11.0-M5.zip", "/files/archive/scala-tool-support-2.11.0-M5.zip", "Scala Tool Support (zip)", "48K"]
+  [-main-unixsys, "scala-{{page.release_version}}.tgz", "/files/archive/scala-{{page.release_version}}.tgz", "Max OS X, Unix, Cygwin", "28M"],
+  [-main-windows, "scala-{{page.release_version}}.msi", "/files/archive/scala-{{page.release_version}}.msi", "Windows (msi installer)", "52M"],
+  [-non-main-sys, "scala-{{page.release_version}}.zip", "/files/archive/scala-{{page.release_version}}.zip", "Windows", "28M"],
+  [-non-main-sys, "scala-{{page.release_version}}.deb", "/files/archive/scala-{{page.release_version}}.deb", "Debian", "25M"],
+  [-non-main-sys, "scala-{{page.release_version}}.rpm", "/files/archive/scala-{{page.release_version}}.rpm", "RPM package", "25M"],
+  [-non-main-sys, "scala-docs-{{page.release_version}}.txz", "/files/archive/scala-docs-{{page.release_version}}.txz", "API docs", "3.1M"],
+  [-non-main-sys, "scala-docs-{{page.release_version}}.zip", "/files/archive/scala-docs-{{page.release_version}}.zip", "API docs", "25M"],
+  [-non-main-sys, "scala-sources-{{page.release_version}}.zip", "https://github.com/scala/scala/archive/v{{page.release_version}}.tar.gz", "sources", "4.0K"],
+  [-non-main-sys, "scala-tool-support-{{page.release_version}}.tgz", "/files/archive/scala-tool-support-{{page.release_version}}.tgz", "Scala Tool Support (tgz)", "28K"],
+  [-non-main-sys, "scala-tool-support-{{page.release_version}}.zip", "/files/archive/scala-tool-support-{{page.release_version}}.zip", "Scala Tool Support (zip)", "48K"]
 ]
 ---
 

--- a/download/_posts/2013-10-01-2.10.3.md
+++ b/download/_posts/2013-10-01-2.10.3.md
@@ -8,16 +8,16 @@ show_resources: "true"
 permalink: /download/2.10.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.3.tgz",                 "/files/archive/scala-2.10.3.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
-  ["-main-windows", "scala-2.10.3.msi",                 "/files/archive/scala-2.10.3.msi",                           "Windows (msi installer)",    "60 MB"],
-  ["-non-main-sys", "scala-2.10.3.zip",                 "/files/archive/scala-2.10.3.zip",                           "Windows",                    "29 MB"],
-  ["-non-main-sys", "scala-2.10.3.deb",                 "/files/archive/scala-2.10.3.deb",                           "Debian",                    "25 MB"],
-  ["-non-main-sys", "scala-2.10.3.rpm",                 "/files/archive/scala-2.10.3.rpm",                           "RPM package",               "25 MB"],
-  ["-non-main-sys", "scala-docs-2.10.3.txz",            "/files/archive/scala-docs-2.10.3.txz",                      "API docs",                   "4 MB"],
-  ["-non-main-sys", "scala-docs-2.10.3.zip",            "/files/archive/scala-docs-2.10.3.zip",                      "API docs",                   "33 MB"],
-  ["-non-main-sys", "scala-sources-2.10.3.zip",         "https://github.com/scala/scala/archive/v2.10.3.tar.gz",     "sources",                    ""],
-  ["-non-main-sys", "scala-tool-support-2.10.3.tgz",    "/files/archive/scala-tool-support-2.10.3.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
-  ["-non-main-sys", "scala-tool-support-2.10.3.zip",    "/files/archive/scala-tool-support-2.10.3.zip",              "Scala Tool Support (zip)",   "46 KB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",                 "/files/archive/scala-{{page.release_version}}.tgz",                           "Max OS X, Unix, Cygwin",     "20 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",                 "/files/archive/scala-{{page.release_version}}.msi",                           "Windows (msi installer)",    "60 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.zip",                 "/files/archive/scala-{{page.release_version}}.zip",                           "Windows",                    "29 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.deb",                 "/files/archive/scala-{{page.release_version}}.deb",                           "Debian",                    "25 MB"],
+  ["-non-main-sys", "scala-{{page.release_version}}.rpm",                 "/files/archive/scala-{{page.release_version}}.rpm",                           "RPM package",               "25 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.txz",            "/files/archive/scala-docs-{{page.release_version}}.txz",                      "API docs",                   "4 MB"],
+  ["-non-main-sys", "scala-docs-{{page.release_version}}.zip",            "/files/archive/scala-docs-{{page.release_version}}.zip",                      "API docs",                   "33 MB"],
+  ["-non-main-sys", "scala-sources-{{page.release_version}}.zip",         "https://github.com/scala/scala/archive/v{{page.release_version}}.tar.gz",     "sources",                    ""],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.tgz",    "/files/archive/scala-tool-support-{{page.release_version}}.tgz",              "Scala Tool Support (tgz)",   "25 KB"],
+  ["-non-main-sys", "scala-tool-support-{{page.release_version}}.zip",    "/files/archive/scala-tool-support-{{page.release_version}}.zip",              "Scala Tool Support (zip)",   "46 KB"]
 ]
 ---
 

--- a/download/index.md
+++ b/download/index.md
@@ -9,8 +9,8 @@ other_releases: [
 ]
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.3.tgz",         "/files/archive/scala-2.10.3.tgz",         "Max OS X, Unix, Cygwin",   "20 MB"],
-  ["-main-windows", "scala-2.10.3.msi",         "/files/archive/scala-2.10.3.msi",         "Windows (msi installer)",  "60 MB"]
+  ["-main-unixsys", "scala-{{page.release_version}}.tgz",         "/files/archive/scala-{{page.release_version}}.tgz",         "Max OS X, Unix, Cygwin",   "20 MB"],
+  ["-main-windows", "scala-{{page.release_version}}.msi",         "/files/archive/scala-{{page.release_version}}.msi",         "Windows (msi installer)",  "60 MB"]
 ]
 ---
 


### PR DESCRIPTION
- add a plugin that provided a liquid filter that expands variables
- use this in the download pages

Review by @heathermiller

/cc @gkossakowski @adriaanm
