### PR TITLE
Scala 2.11.0-M7

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: The Scala Programming Language
 
 scalaversion: "2.10.3"
-devscalaversion: "2.11.0-M5"
+devscalaversion: "2.11.0-M7"
 scala_maindownload_unix: "/files/archive/scala-2.10.3.tgz"
 scala_maindownload_windows: "/files/archive/scala-2.10.3.msi"
 baseurl: ""

--- a/download/_posts/2013-11-27-2.11.0-M7.md
+++ b/download/_posts/2013-11-27-2.11.0-M7.md
@@ -1,0 +1,24 @@
+---
+title: Scala 2.11.0-M7
+start: 27 November 2013
+layout: downloadpage
+release_version: 2.11.0-M7
+release_date: "November 27, 2013"
+show_resources: "true"
+permalink: /download/2.11.0-M7.html
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the <a href='http://www.java.com/'>Java runtime version 1.6 or later</a>."
+resources: [
+  [-main-unixsys, "scala-2.11.0-M7.tgz", "/files/archive/scala-2.11.0-M7.tgz", "Max OS X, Unix, Cygwin", "28M"],
+  [-main-windows, "scala-2.11.0-M7.msi", "/files/archive/scala-2.11.0-M7.msi", "Windows (msi installer)", "52M"],
+  [-non-main-sys, "scala-2.11.0-M7.zip", "/files/archive/scala-2.11.0-M7.zip", "Windows", "28M"],
+  [-non-main-sys, "scala-2.11.0-M7.deb", "/files/archive/scala-2.11.0-M7.deb", "Debian", "25M"],
+  [-non-main-sys, "scala-2.11.0-M7.rpm", "/files/archive/scala-2.11.0-M7.rpm", "RPM package", "25M"],
+  [-non-main-sys, "scala-docs-2.11.0-M7.txz", "/files/archive/scala-docs-2.11.0-M7.txz", "API docs", "3M"],
+  [-non-main-sys, "scala-docs-2.11.0-M7.zip", "/files/archive/scala-docs-2.11.0-M7.zip", "API docs", "25M"],
+  [-non-main-sys, "scala-sources-2.11.0-M7.zip", "https://github.com/scala/scala/archive/v2.11.0-M7.tar.gz", "sources", "4K"],
+  [-non-main-sys, "scala-tool-support-2.11.0-M7.tgz", "/files/archive/scala-tool-support-2.11.0-M7.tgz", "Scala Tool Support (tgz)", "30K"],
+  [-non-main-sys, "scala-tool-support-2.11.0-M7.zip", "/files/archive/scala-tool-support-2.11.0-M7.zip", "Scala Tool Support (zip)", "50K"]
+]
+---
+
+

--- a/news/_posts/2013-11-27-release-notes-v2.11.0-M7.md
+++ b/news/_posts/2013-11-27-release-notes-v2.11.0-M7.md
@@ -1,0 +1,47 @@
+---
+layout: news
+post-type: announcement
+title: "Scala 2.11.0-M7 is now available!"
+---
+The [seventh development milestone](https://github.com/scala/scala/releases/v2.11.0-M7) of Scala 2.11 is now available for [download](/download/2.11.0-M7.html)!
+
+It brings the following [goodness](https://github.com/scala/scala/issues?milestone=25&page=1&state=closed):
+
+- delambdafication (compiling closures Java 8-style, as close as you can get on Java 6) by @jamesiry
+- blackbox/whitebox macro distinction by @xeno-by,
+- collection deprecation and mutable LongMap/AnyRefMap by @ichoran,
+- several IDE improvements by @dotta (positions for default args, docs on how to hack the compiler in the IDE) and @skyluc (completion for imports)
+- for loop support in quasiquotes by @densh
+- [Experimental Single Abstract Method support](https://github.com/scala/scala/pull/3037)
+
+Full details can be found on [GitHub](https://github.com/scala/scala/releases/v2.11.0-M7).
+
+We're working on an [overview of the Scala 2.11 release](http://docs.scala-lang.org/scala/2.11/) -- [PRs](https://github.com/scala/scala/blob/gh-pages/2.11/index.markdown) welcome!
+
+## Known issues
+Scala compiler artifact (due to scaladoc) depends on the previous version (2.11.0-M6) of `scala-xml` and `scala-parser-combinators` modules.
+If you depend on `scala-compiler` (e.g., because you're developing a macro), you should take care to exclude these `_2.11.0-M6` dependencies,
+and provide the `_2.11.0-M7` ones instead. This will be fixed in M8, which will be released before the end of the year.
+
+
+    def excludeM6Modules(m: ModuleID) = (m
+      exclude("org.scala-lang.modules", "scala-parser-combinators_2.11.0-M6")
+      exclude("org.scala-lang.modules", "scala-xml_2.11.0-M6")
+    )
+
+    // include these settings in your project:
+    libraryDependencies += excludeM6Modules("org.scala-lang" % "scala-compiler" % scalaVersion.value),
+    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.0-RC7",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.0-RC5",
+
+## Regressions
+We'd [love to hear](https://issues.scala-lang.org/) about any regressions since 2.10.3 or 2.11.0-M6. Before doing so, please search for existing bugs and/or consult with the [scala-user](https://groups.google.com/forum/#!forum/scala-user) mailing list to be sure it is a genuine problem.
+
+When reporting a bug, please set the 'Affects Version' field to 2.11.0-M7 and add the `regression` label where appropriate.
+
+## Scala IDE Lithium (4.0) for Eclipse
+Please point your Eclipse 4.2/4.3 at http://download.scala-ide.org/sdk/e38/scala211/dev/site/ to update to the latest version that includes this milestone!
+For more info, please see [the getting started guide](http://scala-ide.org/docs/user/gettingstarted.html).
+
+## Binary compatibility
+Note that this release is not binary compatible with the 2.10.x series, so you will need to obtain a fresh build of your dependencies against this version.


### PR DESCRIPTION
This is scheduled to go live Nov 27. Waiting for SBT and IDE to be published.

I'll comment here when it's ready to go. (Is there a way to automate this going live on a particular date?)

review by @heathermiller
