### PR TITLE
Update development release link to 2.11.0-M7.

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -5,7 +5,7 @@ release_version: 2.10.3
 release_date: "June 6, 2013"
 other_releases: [
   ["maintenance_version", "Current maintenance release", 2.9.3, "February 28, 2013"],
-  ["development_version", "Current development release", 2.11.0-M5, "September 06, 2013"]
+  ["development_version", "Current development release", 2.11.0-M7, "November 27, 2013"]
 ]
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [


### PR DESCRIPTION
The main download page still linked to 2.11.0-M5.
