### PR TITLE
Reword "Outstanding features" as "Noteworthy features".

### DIFF
--- a/news/_posts/2013-11-29-announcing-scala-js-v0.1.md
+++ b/news/_posts/2013-11-29-announcing-scala-js-v0.1.md
@@ -19,7 +19,7 @@ All information on how to get started with Scala.js is available
 [on the Website](http://www.scala-js.org/).
 Documentation, a mailing list, third-party libraries and tools, are all available.
 
-## Outstanding features
+## Noteworthy features
 
 *   Support all of Scala (including macros!),
     modulo [a few semantic differences](http://www.scala-js.org/doc/semantics.html)


### PR DESCRIPTION
The sentence "Outstanding features" was reported to be ambiguous, and could be interpreted as "not yet supported".

Since this announcement is referenced in many places, and since it is still the biggest referrer sending people to scala-js.org, I think it's still worth fixing the wording.
