### PR TITLE
fix link to scala compat for java 8.

### DIFF
--- a/news/_posts/2014-06-30-2.12-roadmap.md
+++ b/news/_posts/2014-06-30-2.12-roadmap.md
@@ -31,7 +31,7 @@ Here’s how we plan to make this transition as smooth as possible.
 * Java 8 interop (bidirectional):
   * Improve support for reading Java 8 bytecode (already in 2.11)
   * Improve and turn on SAM support by default (synthesize anonymous class java 8-style). This allows calling Java 8 higher-order methods seamlessly from Scala (already in 2.11 under -Xexperimental).
-  * [Compatibility module](https://github.com/typesafehub/scala-java8-fun) to let Java 8 call Scala higher-order methods.
+  * [Compatibility module](https://github.com/scala/scala-java8-compat) to let Java 8 call Scala higher-order methods.
 * Fully integrate [Miguel’s new back-end & optimizer](http://magarciaepfl.github.io/scala/) (refactor code, test & document in-depth, remove old back-end).
 * Style checker: an efficient, community-driven, platform for accurate coding style checking (built on top of the compiler).
 * Collections: improve test coverage, performance, documentation (& modularize?)


### PR DESCRIPTION
That links gives me a 404. Either it's a typo, or that repository isn't public...
