### PR TITLE
Upcoming events from Underscore

### DIFF
--- a/training/_posts/2015-02-24-essential-scala-online.html
+++ b/training/_posts/2015-02-24-essential-scala-online.html
@@ -1,0 +1,9 @@
+---
+title: Essential Scala Online
+description: A studio-style online course for professional developers who want a thorough introduction to Scala.
+link-out: http://underscore.io/events/2015-02-24-essential-scala-online.html
+where: Online
+when: 24 February 2015
+trainers: Noel Welsh and Dave Gurnell
+organizer: Underscore
+---

--- a/training/_posts/2015-03-15-essential-essential-scala.md
+++ b/training/_posts/2015-03-15-essential-essential-scala.md
@@ -1,0 +1,9 @@
+---
+title: Essential Essential Scala
+description: A free and fun taste of Scala. Places available for students and teaching assistants.
+link-out: http://underscore.io/events/2015-03-15-essential-essential-scala.html
+where: San Francisco
+when: 15 March 2015
+trainers: Noel Welsh
+organizer: Underscore
+---

--- a/training/_posts/2015-03-19-essential-scalaz.html
+++ b/training/_posts/2015-03-19-essential-scalaz.html
@@ -1,0 +1,9 @@
+---
+title: Essential Scalaz
+description: Take your Scala skills to the next level. The tools you need for large scale Scala systems.
+link-out: http://underscore.io/events/2015-03-19-essential-scalaz.html
+where: San Francisco 
+when: 19 March 2015
+trainers: Adam Rosien
+organizer: Underscore
+---

--- a/training/_posts/2015-03-20-shapeless.html
+++ b/training/_posts/2015-03-20-shapeless.html
@@ -1,0 +1,9 @@
+---
+title: Shapeless Workshop
+description: Miles Sabin leads a workshop into the design and use of the Shapeless library.
+link-out: http://underscore.io/events/2015-03-20-shapeless.html
+where: San Francisco 
+when: 20 March 2015
+trainers: Miles Sabin
+organizer: Underscore
+---

--- a/training/_posts/2015-03-28-essential-essential-scala.html
+++ b/training/_posts/2015-03-28-essential-essential-scala.html
@@ -1,0 +1,9 @@
+---
+title: Essential Essential Scala
+description: A free and fun taste of Scala.
+link-out: http://underscore.io/events/2015-03-28-essential-essential-scala.html
+where: Edinburgh
+when: 28 March 2015
+trainers: Noel Welsh
+organizer: Underscore
+---

--- a/training/_posts/2015-03-30-advanced-scala.html
+++ b/training/_posts/2015-03-30-advanced-scala.html
@@ -1,0 +1,9 @@
+---
+title: Advanced Scala
+description: Take your Scala skills to the next level. The tools you need to build large scale systems in Scala.
+link-out: http://underscore.io/events/2015-03-30-advanced-scala.html 
+where: Edinburgh
+when: 30 March 2015
+trainers: Noel Welsh
+organizer: Underscore
+---


### PR DESCRIPTION
This adds our upcoming events.

BTW, I noticed that http://scala-lang.org/training/ is not rendering correctly. All the links there are currently broken, pointing to http://scala-lang.org/training/test

Rendering worked fine on my local fork of the repo.