### PR TITLE
Correct link to scala.exchange-15

### DIFF
--- a/events/_posts/2015-12-10-scalax15.md
+++ b/events/_posts/2015-12-10-scalax15.md
@@ -5,5 +5,5 @@ location: London
 description: ""
 start: 10 December 2015
 end: 11 December 2015
-link-out: http://skillsmatter.com/event/scala/scala-exchange-2014
+link-out: https://skillsmatter.com/conferences/6862-scala-exchange-2015
 ---


### PR DESCRIPTION
How much of a idiot am I, this was pointing to last years conf. this is now correct. (Hopefully) 
Sorry :-(