### PR TITLE
Re-org and simplify contribution section pages.

### DIFF
--- a/contribute/documentation.md
+++ b/contribute/documentation.md
@@ -8,9 +8,8 @@ There are several ways you can help out with the improvement of Scala documentat
 
 * API Documentation in Scaladoc
 * Code examples and tutorials in activator templates.
-* The Scala Wiki
 * Guides, Overviews, Tutorials, Cheat Sheets and more on the docs.scala-lang.org site
-* Updating Documents on the Main Scala Language Site (this one)
+* Updating scala-lang.org
 
 Please read this page, and the pages linked from this one, fully before contributing documentation. Many of the questions you have will be answered in these resources. If you have a question that isn't answered, feel free to ask on the [scala-internals Google group](https://groups.google.com/forum/#!forum/scala-internals) and then, please, submit a pull request with updated documentation reflecting that answer.
 
@@ -36,12 +35,6 @@ is a tool based on SBT, with a UI mode that is ideal for code based tutorials, o
 
 Please see [Contributing an Activator Template](https://typesafe.com/activator/template/contribute) for more details.
 
-### The Scala Wiki
-
-The [Scala wiki](https://wiki.scala-lang.org/) could be a useful resource, but tends to get out of date quickly. It is perhaps best viewed as a place for information to temporarily live while it is constructed and refined, but with an aim to putting the material into the [docs.scala-lang.org](http://docs.scala-lang.org) site eventually (see the next section). Nonetheless, it is a fast way to add some public documentation.
-
-The wiki is self documenting, so make sure to take a look at the [home page](https://wiki.scala-lang.org/) to get started. Please consider contributions to [docs.scala-lang.org](docs.scala-lang.org) for more enduring documentation, even though it is more work to get through the review process for the main doc site.
-
 ### The Main Scala Documentation Site
 
 [docs.scala-lang.org](https://wiki.scala-lang.org/) houses the primary source of written, non-API documentation for Scala. It's a github project that you can fork and submit pull requests from. It includes:
@@ -59,7 +52,7 @@ and more
 Please read [contributing to the docs.scala-lang.org site](http://docs.scala-lang.org/contribute.html) through before embarking on changes. The site uses 
 the [Jekyll](http://jekyllrb.com/) markdown engine so you will need to follow the instructions to get that running as well.
 
-### The Scala Language Site
+### Updating scala-lang.org
 
 Additional high-level documentation (including documentation on contributing
 to Scala and related projects) is provided on the main 

--- a/contribute/documentation.md
+++ b/contribute/documentation.md
@@ -6,9 +6,9 @@ title: Documentation Contributions
 
 There are several ways you can help out with the improvement of Scala documentation. These include:
 
+* API Documentation in Scaladoc
 * Code examples and tutorials in activator templates.
 * The Scala Wiki
-* API Documentation in Scaladoc
 * Guides, Overviews, Tutorials, Cheat Sheets and more on the docs.scala-lang.org site
 * Updating Documents on the Main Scala Language Site (this one)
 
@@ -17,13 +17,6 @@ Please read this page, and the pages linked from this one, fully before contribu
 **General requirements** for documentation submissions include spell-checking all written language, ensuring code samples compile and run correctly, correct grammar, and clean formatting/layout of the documentation. 
 
 Thanks
-
-### Examples/Tutorials in Activator Templates
-
-[Typesafe Activator](https://typesafe.com/community/core-tools/activator-and-sbt) 
-is a tool based on SBT, with a UI mode that is ideal for code based tutorials, overviews and walk-throughs. To contribute an example in activator, you can fork an existing template, edit it, add a tutorial, upload it to github and then submit the github project into the template repository. It's the fastest way to produce a working code example with tutorial.
-
-Please see [Contributing an Activator Template](https://typesafe.com/activator/template/contribute) for more details.
 
 ### API Documentation (Scaladoc)
 
@@ -35,6 +28,13 @@ Please *follow the issue submission process closely* to help prevent duplicate i
 * You can also just 
 [submit new Scaladoc](./scala-standard-library-api-documentation.html) 
 without creating an issue, but please look to see if there is an issue already submitted for your task and claim it if there is. If not, please post your intention to work on a specific scaladoc task on scala-internals so that people know what you are doing. 
+
+### Examples/Tutorials in Activator Templates
+
+[Typesafe Activator](https://typesafe.com/community/core-tools/activator-and-sbt) 
+is a tool based on SBT, with a UI mode that is ideal for code based tutorials, overviews and walk-throughs. To contribute an example in activator, you can fork an existing template, edit it, add a tutorial, upload it to github and then submit the github project into the template repository. It's the fastest way to produce a working code example with tutorial.
+
+Please see [Contributing an Activator Template](https://typesafe.com/activator/template/contribute) for more details.
 
 ### The Scala Wiki
 

--- a/contribute/guide.md
+++ b/contribute/guide.md
@@ -65,7 +65,7 @@ This is the impatient developer's checklist for the steps to submit a bug-fix pu
 https://github.com/scala/scala#git-hygiene). For bug fixes, a single commit is requested, for features several commits may be desirable (but each separate commit must compile and pass all tests)
 9. [Submit a pull request](./hacker-guide.html#submit) following the [Scala project pull-request guidelines](http://docs.scala-lang.org/scala/pull-request-policy.html).
 10. [Work with a reviewer](https://github.com/scala/scala#reviewing) to [get your pull request merged in](./hacker-guide.html#review).
-11. [Bask in the glow of a job well done](./scala-fame.html).
+11. Celebrate!
 
 Need more information or a little more hand-holding for the first one? We got you covered: take a read through the entire [Hacker Guide](./hacker-guide.html) for an example of implementing a new feature (some of the steps can be skipped for bug fixes, this will be obvious from reading it, but many of the steps here will help with bug fixes too).
 

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -13,6 +13,11 @@ everyone make things better?
 
 That depends on what you want to contribute. Below are some getting started resources for different contribution domains. Please read all of the documentation and follow all the links from the topic pages below before attempting to contribute, as many of the questions you have will already be answered.
 
+### Reporting bugs
+
+See our [bug reporting guide](./bug-reporting-guide.html) to learn
+how to efficiently report a bug.
+
 ### Contribute
 
 Coordination of contribution efforts takes place on the 
@@ -22,8 +27,7 @@ Coordination of contribution efforts takes place on the
 <div class="row">
 <div class="span4 doc-block">
 <h4><a href="./documentation.html">Documentation</a></h4>
-<p><a href="https://typesafe.com/activator/template/contribute">Activator templates</a>, 
-<a href="./scala-standard-library-api-documentation.html">Scaladoc (API)</a>, 
+<p><a href="./scala-standard-library-api-documentation.html">Scaladoc (API)</a>, <a href="https://typesafe.com/activator/template/contribute">Activator templates</a>,
 <a href="http://docs.scala-lang.org/contribute.html">docs.scala-lang.org</a> and 
 <a href="https://github.com/scala/scala-lang">scala-lang.org</a>.</p>
 </div>
@@ -35,32 +39,22 @@ Coordination of contribution efforts takes place on the
 
 <div class="row">
 <div class="span4 doc-block">
-<h4><a href="./tools.html">Tools</a></h4>
-<p>Enhance the Scala tooling ecosystem with features for build tools, IDE plug-ins and other related tools.</p>
-</div>
-<div class="span4 doc-block">
 <h4><a href="./corelibs.html">Core Libraries</a></h4>
 <p>Update and expand the capabilities of the core (and associated) Scala libraries.</p>
 </div>
-</div>
-
-<div class="row">
 <div class="span4 doc-block">
-<h4><a href="./guide.html">Compiler/Language</a></h4>
+<h4><a href="./guide.html#larger-changes-new-features">Compiler/Language</a></h4>
 <p>Larger language features and compiler enhancements including language specification and SIPs.</p>
 </div>
+</div>
+
+<!--<div class="row">
 <div class="span4 doc-block">
-<h4><a href="./scala-fame.html">Contributor Hall of Fame</a></h4>
-<p>Get your props, and find your place in the leader-board.</p>
+<h4><a href="./tools.html">Tools</a></h4>
+<p>Enhance the Scala tooling ecosystem with features for build tools, IDE plug-ins and other related tools.</p>
 </div>
+</div> -->
 </div>
-</div>
-
-
-### Reporting bugs
-
-See our [bug reporting guide](./bug-reporting-guide.html) to learn
-how to efficiently report a bug.
 
 ### Community Tickets
 


### PR DESCRIPTION
* Removed hall of fame links (as the feature is being removed)
* Temporarily disabled tools page link until we work out what to do for tools
* Shuffled documentation contrib order to emphasize scaladoc over activator

Review by @heathermiller 