### PR TITLE
Add IDEs and Build Tools page

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -40,6 +40,11 @@ layout: default
             <div class="sidebar-inner">
               <div class="contents">Contents</div>
               <div id="toc"></div>
+              <br/>
+              <div class="alert-info">
+                <a href="/contribute/documentation.html#updating-scala-langorg"><p><strong>Problem with this page?</strong>
+                Please help us fix it!</p></a>
+              </div>
             </div>
           </div>
           <div style="clear:both"></div>

--- a/contribute/corelibs.md
+++ b/contribute/corelibs.md
@@ -2,7 +2,20 @@
 layout: page
 title: Core Library Contributions
 ---
-## Under Construction
+## Core Library Contributions
 
-If you would like to help complete this document, welcome, and please head over and read [Documentation Contributions](./documentation.html#the-scala-language-site), 
-and let us know on the [scala-internals](https://groups.google.com/forum/#!forum/scala-internals) forum (suggested post title: `[docs] Core Library Contributions`) so that we can get you hooked up with the right people.
+There are several options for contributing to Scala's core libraries. You can:
+
+* Help with [Documentation](./scala-standard-library-api-documentation.html).
+* [Report Bugs or Issues](./bug-reporting-guide.html) against the core libraries.
+* [Fix Bugs or Issues](./guide.html) against the 
+  [reported library bugs/issues](https://issues.scala-lang.org/issues/?filter=13001).
+* Contribute significant new functionality or a new API by submitting
+  a Scala Library Improvement Process (SLIP) Document.
+
+### Submitting a SLIP
+
+For significant new functionality or a whole new API to be considered for 
+inclusion in the core Scala distribution, you will be asked to submit a SLIP (Scala Library Improvement Process) document.
+
+Please see [instructions for submitting a new SLIP](http://docs.scala-lang.org/sips/slip-submission.html) and familiarize yourself with the [SIP/SLIP](http://docs.scala-lang.org/sips/) section of the Scala documentation site. Also please pay particular attention to the [pre-requisites](http://docs.scala-lang.org/sips/slip-submission.html) before submitting a SLIP.

--- a/contribute/documentation.md
+++ b/contribute/documentation.md
@@ -60,5 +60,5 @@ to Scala and related projects) is provided on the main
 [scala-lang github project](https://github.com/scala/scala-lang) which may be forked to create pull requests. 
 
 Please read both the
-[docs.scala-lang.org contribution](http://docs.scala-lang.org/contribute.html) document and the scala-lang.org github README file before embarking on any changes to the Scala language site, as it uses the same Jekyll markdown tool and many of the same conventions as the Scala documentation site.
+[docs.scala-lang.org contribution](http://docs.scala-lang.org/contribute.html) document and the [scala-lang.org github README](https://github.com/dickwall/scala-lang#scala-langorg) before embarking on any changes to the Scala language site, as it uses the same Jekyll markdown tool and many of the same conventions as the Scala documentation site.
 

--- a/contribute/documentation.md
+++ b/contribute/documentation.md
@@ -60,5 +60,5 @@ to Scala and related projects) is provided on the main
 [scala-lang github project](https://github.com/scala/scala-lang) which may be forked to create pull requests. 
 
 Please read both the
-[docs.scala-lang.org contribution](http://docs.scala-lang.org/contribute.html) document and the [scala-lang.org github README](https://github.com/dickwall/scala-lang#scala-langorg) before embarking on any changes to the Scala language site, as it uses the same Jekyll markdown tool and many of the same conventions as the Scala documentation site.
+[docs.scala-lang.org contribution](http://docs.scala-lang.org/contribute.html) document and the [scala-lang.org github README](https://github.com/scala/scala-lang#scala-langorg) before embarking on any changes to the Scala language site, as it uses the same Jekyll markdown tool and many of the same conventions as the Scala documentation site.
 

--- a/contribute/guide.md
+++ b/contribute/guide.md
@@ -52,7 +52,7 @@ unencumbered by copyrights or patents.
 
 This is the impatient developer's checklist for the steps to submit a bug-fix pull request to the Scala project. For more information, description and justification for the steps, follow the links in that step. Further specific instructions for the release of Scala you are targeting can be found in the `CONTRIBUTING.md` file for that [github branch](https://github.com/scala/scala)
 
-1. [Select a bug to fix from JIRA](https://issues.scala-lang.org/issues/?filter=12111), or if you found the bug yourself and want to fix it, [create a JIRA issue](./bug-reporting-guide.html) (but please 
+1. [Select a bug to fix from JIRA](/contribute/#community-tickets), or if you found the bug yourself and want to fix it, [create a JIRA issue](./bug-reporting-guide.html) (but please 
 [make sure it's not a duplicate](./bug-reporting-guide.html#reporting-confirmed-bugs-is-a-sin)).
 2. Optional ([but recommended](./scala-internals.html#why-its-a-good-idea)), announce your intention to work on the bug on [scala-internals](./scala-internals.html). After all, don't you want to work on a team with 
 [these friendly people](./hacker-guide.html#connect) - it's one of the perks of contributing.

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -43,17 +43,17 @@ Coordination of contribution efforts takes place on the
 <p>Update and expand the capabilities of the core (and associated) Scala libraries.</p>
 </div>
 <div class="span4 doc-block">
+<h4><a href="./tools.html">IDE and Build Tools</a></h4>
+<p>Enhance the Scala tools with features for build tools, IDE plug-ins and other related projects.</p>
+</div>
+</div>
+
+<div class="row">
+<div class="span4 doc-block">
 <h4><a href="./guide.html#larger-changes-new-features">Compiler/Language</a></h4>
 <p>Larger language features and compiler enhancements including language specification and SIPs.</p>
 </div>
 </div>
-
-<!--<div class="row">
-<div class="span4 doc-block">
-<h4><a href="./tools.html">Tools</a></h4>
-<p>Enhance the Scala tooling ecosystem with features for build tools, IDE plug-ins and other related tools.</p>
-</div>
-</div> -->
 </div>
 
 ### Community Tickets

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -90,7 +90,7 @@ various contributor activities:
 <p>All bugs marked with the label <em>community</em>.</p>
 </div>
 <div class="span4 doc-block">
-<h4><a href="https://issues.scala-lang.org/issues/?filter=12111">All Issues</a></h4>
+<h4><a href="https://issues.scala-lang.org/issues/?filter=13009">All Issues</a></h4>
 <p>Bugs + Enhancements marked with the label <em>community</em>.</p>
 </div>
 </div>

--- a/contribute/tools.md
+++ b/contribute/tools.md
@@ -11,6 +11,10 @@ Since these tools are in separate projects, they may (and likely will) have thei
 Typically, issues for these projects will be reported and kept in the github project issue tracker for that project rather than in the Scala project JIRA.
 Many of these projects have a <a href="https://gitter.im">gitter</a> channel (usually listed in the README or CONTRIBUTING documents) which is a great place to discuss proposed work before commencing.
 
+There are some projects in this section that are in
+[particular need](#projects-in-particular-need) so please check those out
+if you would like to help revive them.
+
 ### Broken Links?
 
 Stuff changes. Found a broken link or something that needs updating on this page? Please, consider [submitting a documentation pull request](./documentation.html#updating-scala-langorg) to fix it. 
@@ -20,14 +24,6 @@ Stuff changes. Found a broken link or something that needs updating on this page
 <div class="container">
 <div class="row">
 <div class="span4 doc-block">
-<a href="https://github.com/scala-ide/scala-ide"><img src="https://avatars2.githubusercontent.com/u/1026788?v=3&s=200" width="50px" height="50px"/><h4>Scala IDE</h4></a>
-<p>The Eclipse Scala IDE project.</p>
-<p><a href="http://scala-ide.org/">Home</a> | 
-<a href="http://scala-ide-portfolio.assembla.com/spaces/scala-ide/support/tickets">Issues</a> | 
-<a href="https://github.com/scala-ide/scala-ide/blob/master/README.md">ReadMe</a> | 
-<a href="https://github.com/scala-ide/scala-ide/blob/master/CONTRIBUTING.md">Contributing</a></p>
-</div>
-<div class="span4 doc-block">
 <a href="https://github.com/sbt/sbt"><img src="http://www.scala-sbt.org/assets/typesafe_sbt_svg.svg" width="100px" height="50px"/>
 <h4>sbt</h4></a>
 <p>Interactive build tool.</p>
@@ -36,9 +32,6 @@ Stuff changes. Found a broken link or something that needs updating on this page
 <a href="https://github.com/sbt/sbt/blob/0.13/README.md">ReadMe</a> | 
 <a href="https://github.com/sbt/sbt/blob/0.13/CONTRIBUTING.md">Contributing</a></p>
 </div>
-</div>
-
-<div class="row">
 <div class="span4 doc-block">
 <a href="https://github.com/scala/scala"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
 <h4>Scaladoc Tool</h4></a>
@@ -47,6 +40,17 @@ Stuff changes. Found a broken link or something that needs updating on this page
 <a href="https://issues.scala-lang.org/issues/?jql=status%20%3D%20Open%20AND%20component%20%3D%20%22Scaladoc%20Tool%22">Issues</a> | 
 <a href="https://github.com/scala/scala#welcome">ReadMe</a> | 
 <a href="./guide.html">Contributing</a></p>
+</div>
+</div>
+
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/scala-ide/scala-ide"><img src="https://avatars2.githubusercontent.com/u/1026788?v=3&s=200" width="50px" height="50px"/><h4>Scala IDE</h4></a>
+<p>The Eclipse Scala IDE project.</p>
+<p><a href="http://scala-ide.org/">Home</a> | 
+<a href="http://scala-ide-portfolio.assembla.com/spaces/scala-ide/support/tickets">Issues</a> | 
+<a href="https://github.com/scala-ide/scala-ide/blob/master/README.md">ReadMe</a> | 
+<a href="https://github.com/scala-ide/scala-ide/blob/master/CONTRIBUTING.md">Contributing</a></p>
 </div>
 <div class="span4 doc-block">
 <a href="https://github.com/typesafehub/dbuild"><img src="https://avatars3.githubusercontent.com/u/784923?v=3&s=200" width="50px" height="50px"/><h4>DBuild</h4></a>
@@ -60,12 +64,31 @@ Stuff changes. Found a broken link or something that needs updating on this page
 
 <div class="row">
 <div class="span4 doc-block">
+<a href="https://github.com/scala/scala-partest"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
+<h4>Partest</h4></a>
+<p>Scala Compiler/Library Testing</p>
+<p><a href="http://docs.scala-lang.org/tutorials/partest-guide.html">Home</a> | 
+<a href="https://github.com/scala/scala-partest/issues">Issues</a> | 
+<a href="https://github.com/scala/scala-partest/blob/master/README.md">ReadMe</a></p>
+</div>
+<div class="span4 doc-block">
 <a href="https://github.com/ensime/ensime-server"><img src="https://avatars0.githubusercontent.com/u/5089042?v=3&s=200" width="50px" height="50px"/><h4>Ensime</h4></a>
 <p>Scala Support for Text Editors</p>
 <p><a href="http://ensime.github.io">Home</a> | 
 <a href="https://github.com/ensime/ensime-server/issues">Issues</a> | 
 <a href="https://github.com/ensime/ensime-server/blob/master/README.md">ReadMe</a> | 
 <a href="https://github.com/ensime/ensime-server/blob/master/README.md#contributions">Contributing</a></p>
+</div>
+</div>
+
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/scoverage/scalac-scoverage-plugin"><img src="https://avatars1.githubusercontent.com/u/5998302?v=3&amp;s=200" width="50px" height="50px"/><h4>Scoverage</h4></a>
+<p>Scala code coverage tool</p>
+<p><a href="http://scoverage.org">Home</a> | 
+<a href="https://github.com/scoverage/scalac-scoverage-plugin/issues">Issues</a> | 
+<a href="https://github.com/scoverage/scalac-scoverage-plugin/blob/master/README.md">ReadMe</a> | 
+<a href="https://groups.google.com/forum/#!forum/scala-code-coverage-tool">Contributing</a></p>
 </div>
 <div class="span4 doc-block">
 <a href="https://github.com/scala/scala-abide"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
@@ -75,25 +98,6 @@ Stuff changes. Found a broken link or something that needs updating on this page
 <a href="https://github.com/scala/scala-abide/issues">Issues</a> | 
 <a href="https://github.com/scala/scala-abide/blob/master/README.md">ReadMe</a> | 
 <a href="https://github.com/scala/scala-abide#extending-abide">Contributing</a></p>
-</div>
-</div>
-
-<div class="row">
-<div class="span4 doc-block">
-<a href="https://github.com/scala/scala-partest"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
-<h4>Partest</h4></a>
-<p>Scala Compiler/Library Testing</p>
-<p><a href="http://docs.scala-lang.org/tutorials/partest-guide.html">Home</a> | 
-<a href="https://github.com/scala/scala-partest/issues">Issues</a> | 
-<a href="https://github.com/scala/scala-partest/blob/master/README.md">ReadMe</a></p>
-</div>
-<div class="span4 doc-block">
-<a href="https://github.com/scoverage/scalac-scoverage-plugin"><img src="https://avatars1.githubusercontent.com/u/5998302?v=3&amp;s=200" width="50px" height="50px"/><h4>Scoverage</h4></a>
-<p>Scala code coverage tool</p>
-<p><a href="http://scoverage.org">Home</a> | 
-<a href="https://github.com/scoverage/scalac-scoverage-plugin/issues">Issues</a> | 
-<a href="https://github.com/scoverage/scalac-scoverage-plugin/blob/master/README.md">ReadMe</a> | 
-<a href="https://groups.google.com/forum/#!forum/scala-code-coverage-tool">Contributing</a></p>
 </div>
 </div>
 </div>

--- a/contribute/tools.md
+++ b/contribute/tools.md
@@ -1,8 +1,123 @@
 ---
 layout: page
-title: Tool Contributions
+title: IDE and Build Tool Contributions
 ---
-## Under Construction
+## Contributing to IDE and Build Tools
 
-If you would like to help complete this document, welcome, and please head over and read [Documentation Contributions](./documentation.html#the-scala-language-site), 
-and let us know on the [scala-internals](https://groups.google.com/forum/#!forum/scala-internals) forum (suggested post title: `[docs] Tool Contributions`) so that we can get you hooked up with the right people.
+The links below are to a number of Scala build and IDE related projects that are important in the larger Scala space, and which welcome contributions.
+
+Since these tools are in separate projects, they may (and likely will) have their own rules and guidelines for contributing. The [Hacker Guide](./hacker-guide.html) and [Bug-fixing](guide.html) pages will likely have much in the way of related information on how to contribute to these projects, and are recommended reading. You should also check the README.md and (if it's present) CONTRIBUTING.md files from the actual projects before contributing to them.
+
+Typically, issues for these projects will be reported and kept in the github project issue tracker for that project rather than in the Scala project JIRA.
+Many of these projects have a <a href="https://gitter.im">gitter</a> channel (usually listed in the README or CONTRIBUTING documents) which is a great place to discuss proposed work before commencing.
+
+### Broken Links?
+
+Stuff changes. Found a broken link or something that needs updating on this page? Please, consider [submitting a documentation pull request](./documentation.html#updating-scala-langorg) to fix it. 
+
+### Projects
+
+<div class="container">
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/scala-ide/scala-ide"><img src="https://avatars2.githubusercontent.com/u/1026788?v=3&s=200" width="50px" height="50px"/><h4>Scala IDE</h4></a>
+<p>The Eclipse Scala IDE project.</p>
+<p><a href="http://scala-ide.org/">Home</a> | 
+<a href="http://scala-ide-portfolio.assembla.com/spaces/scala-ide/support/tickets">Issues</a> | 
+<a href="https://github.com/scala-ide/scala-ide/blob/master/README.md">ReadMe</a> | 
+<a href="https://github.com/scala-ide/scala-ide/blob/master/CONTRIBUTING.md">Contributing</a></p>
+</div>
+<div class="span4 doc-block">
+<a href="https://github.com/sbt/sbt"><img src="http://www.scala-sbt.org/assets/typesafe_sbt_svg.svg" width="100px" height="50px"/>
+<h4>sbt</h4></a>
+<p>Interactive build tool.</p>
+<p><a href="http://www.scala-sbt.org/">Home</a> | 
+<a href="https://github.com/sbt/sbt#issues-and-pull-requests">Issues</a> | 
+<a href="https://github.com/sbt/sbt/blob/0.13/README.md">ReadMe</a> | 
+<a href="https://github.com/sbt/sbt/blob/0.13/CONTRIBUTING.md">Contributing</a></p>
+</div>
+</div>
+
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/scala/scala"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
+<h4>Scaladoc Tool</h4></a>
+<p>(Contribute through scala/scala)</p>
+<p><a href="http://www.scala-lang.org/api">Home</a> | 
+<a href="https://issues.scala-lang.org/issues/?jql=status%20%3D%20Open%20AND%20component%20%3D%20%22Scaladoc%20Tool%22">Issues</a> | 
+<a href="https://github.com/scala/scala#welcome">ReadMe</a> | 
+<a href="./guide.html">Contributing</a></p>
+</div>
+<div class="span4 doc-block">
+<a href="https://github.com/typesafehub/dbuild"><img src="https://avatars3.githubusercontent.com/u/784923?v=3&s=200" width="50px" height="50px"/><h4>DBuild</h4></a>
+<p>Multi-project build tool.</p>
+<p><a href="http://typesafehub.github.io/dbuild">Home</a> | 
+<a href="https://github.com/typesafehub/dbuild/issues">Issues</a> | 
+<a href="https://github.com/typesafehub/dbuild/blob/master/README.md">ReadMe</a> | 
+<a href="https://github.com/typesafehub/dbuild/blob/master/README.md#get-involved">Contributing</a></p>
+</div>
+</div>
+
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/ensime/ensime-server"><img src="https://avatars0.githubusercontent.com/u/5089042?v=3&s=200" width="50px" height="50px"/><h4>Ensime</h4></a>
+<p>Scala Support for Text Editors</p>
+<p><a href="http://ensime.github.io">Home</a> | 
+<a href="https://github.com/ensime/ensime-server/issues">Issues</a> | 
+<a href="https://github.com/ensime/ensime-server/blob/master/README.md">ReadMe</a> | 
+<a href="https://github.com/ensime/ensime-server/blob/master/README.md#contributions">Contributing</a></p>
+</div>
+<div class="span4 doc-block">
+<a href="https://github.com/scala/scala-abide"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
+<h4>Abide</h4></a>
+<p>Lint tooling for Scala</p>
+<p><a href="https://github.com/scala/scala-abide#abide--lint-tooling-for-scala">Home</a> | 
+<a href="https://github.com/scala/scala-abide/issues">Issues</a> | 
+<a href="https://github.com/scala/scala-abide/blob/master/README.md">ReadMe</a> | 
+<a href="https://github.com/scala/scala-abide#extending-abide">Contributing</a></p>
+</div>
+</div>
+
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/scala/scala-partest"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
+<h4>Partest</h4></a>
+<p>Scala Compiler/Library Testing</p>
+<p><a href="http://docs.scala-lang.org/tutorials/partest-guide.html">Home</a> | 
+<a href="https://github.com/scala/scala-partest/issues">Issues</a> | 
+<a href="https://github.com/scala/scala-partest/blob/master/README.md">ReadMe</a></p>
+</div>
+<div class="span4 doc-block">
+<a href="https://github.com/scoverage/scalac-scoverage-plugin"><img src="https://avatars1.githubusercontent.com/u/5998302?v=3&amp;s=200" width="50px" height="50px"/><h4>Scoverage</h4></a>
+<p>Scala code coverage tool</p>
+<p><a href="http://scoverage.org">Home</a> | 
+<a href="https://github.com/scoverage/scalac-scoverage-plugin/issues">Issues</a> | 
+<a href="https://github.com/scoverage/scalac-scoverage-plugin/blob/master/README.md">ReadMe</a> | 
+<a href="https://groups.google.com/forum/#!forum/scala-code-coverage-tool">Contributing</a></p>
+</div>
+</div>
+</div>
+
+### Projects in Particular Need
+
+The following projects are important to the Scala community but are particularly in need of contributors to continue their development.
+
+<div class="container">
+<div class="row">
+<div class="span4 doc-block">
+<a href="https://github.com/scala/scala"><img src="https://avatars1.githubusercontent.com/u/57059?v=3&s=200" width="50px" height="50px"/>
+<h4>Scalap</h4></a>
+<p>Scala Decoder (part of scala/scala)</p>
+<a href="https://issues.scala-lang.org/issues/?jql=status%20%3D%20Open%20AND%20text%20~%20%22scalap%22">Issues</a> | 
+<a href="https://github.com/scala/scala#welcome">ReadMe</a> | 
+<a href="./guide.html">Contributing</a></p>
+</div>
+<div class="span4 doc-block">
+<a href="https://github.com/mdr/scalariform"><img src="/resources/img/white-line.png" width="50px" height="50px"/><h4>Scalariform</h4></a>
+<p>Scala code formatter</p>
+<p><a href="https://github.com/mdr/scalariform/wiki/Command-line-tool">Home</a> | 
+<a href="https://github.com/mdr/scalariform/issues">Issues</a> | 
+<a href="https://github.com/mdr/scalariform/blob/master/README.rst">ReadMe</a> </p>
+</div>
+</div>
+</div>


### PR DESCRIPTION
* IDEs and Build Tools page consists of links out to important scala projects
* Restored link to above page, and renamed to IDEs and Build Tools
* Added a missing link into the documentation.md page

So - this pull request is certain to be wrong! Why did I submit it then? Because it's a lot easier to argue about the way something is when you have a strawman, and this is that strawman.

I have no illusions that before the end, I will drop this PR, squash up a new one with all the incorporated changes, and submit that instead. That said, let's get going.

After talking with Adriaan yesterday, missing out Scalariform (and scalap) because they are not very active is the opposite of the point - we really want to get the battle cry out for these projects, so I put them in a "Needs particular help" section. 

Will the page be a maintenance drag? Almost certainly, but that doesn't mean it shouldn't be there. Following through to the logical conclusion of no maintenance drags would result in an empty site. The real question is, is the potential benefit of the material greater than the cost of updating it? These projects should be reasonably stable (i.e. unlikely to disappear altogether) although I expect the links to change. There is a note at the top reminding people they can scratch their own itch and we just have to decide if it's worth it to keep it up to date. I don't mind if the answer is no, but I would argue against that. Ultimately let's make the decision of whether to include this page, and what should change on it if we do.

Also, formatting - layout and design are not my forte (or even in my skills set) so while I don't think it looks horrible, there are a few bits that don't line up and if we change the look and feel completely I don't mind.

Images are links to external sites rather than pngs uploaded to our site. I suspect I am breaking rules with this, but the idea is to allow the logos (taken from github avatars) to be updated by the project owners without having to make changes to scala-lang. Exception is scalariform which has a picture of Matt (and I didn't know if he would want that) so I made it blank.

Review by @heathermiller @adriaanm 