### PR TITLE
Fix intra-page links for main markdown engine.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,7 +42,7 @@ layout: default
               <div id="toc"></div>
               <br/>
               <div class="alert-info">
-                <a href="/contribute/documentation.html#updating-scala-langorg"><p><strong>Problem with this page?</strong>
+                <a href="/contribute/documentation.html#updating_scala_langorg"><p><strong>Problem with this page?</strong>
                 Please help us fix it!</p></a>
               </div>
             </div>

--- a/contribute/guide.md
+++ b/contribute/guide.md
@@ -17,7 +17,7 @@ title: Contributing guide
 
   <div class="row">
     <div class="span4 doc-block">
-      <h3><a href="{{ site.baseurl }}/contribute/#community-tickets">Community issues</a></h3>
+      <h3><a href="{{ site.baseurl }}/contribute/#community_tickets">Community issues</a></h3>
       <p>Get cracking on some easy to approach issues.</p>
     </div>
     <div class="span4 doc-block">
@@ -52,9 +52,9 @@ unencumbered by copyrights or patents.
 
 This is the impatient developer's checklist for the steps to submit a bug-fix pull request to the Scala project. For more information, description and justification for the steps, follow the links in that step. Further specific instructions for the release of Scala you are targeting can be found in the `CONTRIBUTING.md` file for that [github branch](https://github.com/scala/scala)
 
-1. [Select a bug to fix from JIRA](/contribute/#community-tickets), or if you found the bug yourself and want to fix it, [create a JIRA issue](./bug-reporting-guide.html) (but please 
-[make sure it's not a duplicate](./bug-reporting-guide.html#reporting-confirmed-bugs-is-a-sin)).
-2. Optional ([but recommended](./scala-internals.html#why-its-a-good-idea)), announce your intention to work on the bug on [scala-internals](./scala-internals.html). After all, don't you want to work on a team with 
+1. [Select a bug to fix from JIRA](/contribute/index.html#community_tickets), or if you found the bug yourself and want to fix it, [create a JIRA issue](./bug-reporting-guide.html) (but please 
+[make sure it's not a duplicate](./bug-reporting-guide.html#reporting_confirmed_bugs_is_a_sin)).
+2. Optional ([but recommended](./scala-internals.html#why_its_a_good_idea)), announce your intention to work on the bug on [scala-internals](./scala-internals.html). After all, don't you want to work on a team with 
 [these friendly people](./hacker-guide.html#connect) - it's one of the perks of contributing.
 3. [Fork the Scala repository](./hacker-guide.html#fork) and clone your fork (if you haven't already).
 4. [Create a feature branch](./hacker-guide.html#branch) to work on: use the branch name `issue/NNNN` where NNNN is the JIRA issue number.

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -50,7 +50,7 @@ Coordination of contribution efforts takes place on the
 
 <div class="row">
 <div class="span4 doc-block">
-<h4><a href="./guide.html#larger-changes-new-features">Compiler/Language</a></h4>
+<h4><a href="./guide.html#larger_changes_new_features">Compiler/Language</a></h4>
 <p>Larger language features and compiler enhancements including language specification and SIPs.</p>
 </div>
 </div>

--- a/contribute/tools.md
+++ b/contribute/tools.md
@@ -12,12 +12,12 @@ Typically, issues for these projects will be reported and kept in the github pro
 Many of these projects have a <a href="https://gitter.im">gitter</a> channel (usually listed in the README or CONTRIBUTING documents) which is a great place to discuss proposed work before commencing.
 
 There are some projects in this section that are in
-[particular need](#projects-in-particular-need) so please check those out
+[particular need](#projects_in_particular_need) so please check those out
 if you would like to help revive them.
 
 ### Broken Links?
 
-Stuff changes. Found a broken link or something that needs updating on this page? Please, consider [submitting a documentation pull request](./documentation.html#updating-scala-langorg) to fix it. 
+Stuff changes. Found a broken link or something that needs updating on this page? Please, consider [submitting a documentation pull request](./documentation.html#updating_scala_langorg) to fix it. 
 
 ### Projects
 


### PR DESCRIPTION
* Local jekyll uses - but main site uses _ for intra-page anchors