### PR TITLE
Remove extra _ in fix-page link.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,7 +42,7 @@ layout: default
               <div id="toc"></div>
               <br/>
               <div class="alert-info">
-                <a href="/contribute/documentation.html#updating_scala_langorg"><p><strong>Problem with this page?</strong>
+                <a href="/contribute/documentation.html#updating_scalalangorg"><p><strong>Problem with this page?</strong>
                 Please help us fix it!</p></a>
               </div>
             </div>

--- a/contribute/tools.md
+++ b/contribute/tools.md
@@ -17,7 +17,7 @@ if you would like to help revive them.
 
 ### Broken Links?
 
-Stuff changes. Found a broken link or something that needs updating on this page? Please, consider [submitting a documentation pull request](./documentation.html#updating_scala_langorg) to fix it. 
+Stuff changes. Found a broken link or something that needs updating on this page? Please, consider [submitting a documentation pull request](./documentation.html#updating_scalalangorg) to fix it. 
 
 ### Projects
 


### PR DESCRIPTION
Last tweak to get intra-page linking right. Removed extraneous _ in updating_scalalangorg link.