### PR TITLE
fix session urls for the training feed

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -416,7 +416,7 @@ $(document).ready(function(){
         result.push({
           title: training.title,
           description: training.description,
-          url: training.url,
+          url: session.url,
           where: session.where,
           when: session.when,
           trainers: session.trainers,


### PR DESCRIPTION
In the JSON, the url is in "session", not "training", hence the
"undefined" result.

Fixes #260.