### PR TITLE
Updated the leman lake name

### DIFF
--- a/_layouts/frontpage2.html
+++ b/_layouts/frontpage2.html
@@ -36,7 +36,7 @@ layout: default
           </div>
           <p>&nbsp;</p>
           <div class="tip">
-            Scala began life in 2003, created by Martin Odersky and his research group at EPFL, next to Lake Geneva and the Alps, in Lausanne, Switzerland. Scala has since grown into a mature open source programming language, used by hundreds of thousands of developers, and is developed and maintained by scores of people all over the world.
+            Scala began life in 2003, created by Martin Odersky and his research group at EPFL, next to the Leman lake and the Alps, in Lausanne, Switzerland. Scala has since grown into a mature open source programming language, used by hundreds of thousands of developers, and is developed and maintained by scores of people all over the world.
           </div>
         </div>
       </div>


### PR DESCRIPTION
The lake next to Lausanne is called the Leman lake not Geneva lake.