### PR TITLE
Added Scala Exercises link to Community resources

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -55,6 +55,7 @@ Scala is an active [topic on Stack Overflow](http://stackoverflow.com/questions/
 
 ## Other Community-Powered Resources
 
+* [Scala Exercises](http://scala-exercises.47deg.com/)
 * [Scala School](http://twitter.github.com/scala_school/)
 * [Effective Scala](http://twitter.github.com/effectivescala/)
 * [Scala Puzzlers](http://scalapuzzlers.com/)


### PR DESCRIPTION
Added link to Scala Exercises (http://scala-exercises.47deg.com/) to the 'Community-Powered Resources' list.

Would love to have this included in the list, thanks!