### PR TITLE
SI-9501 add prominent links to relevant docs in main Scala repo

### DIFF
--- a/contribute/hacker-guide.md
+++ b/contribute/hacker-guide.md
@@ -8,6 +8,8 @@ This guide is intended to help you get from an idea of fixing a bug or implement
 
 This guide covers the entire process, from the conception of your idea or bugfix to the point where it is merged into Scala. Throughout, we will use a running example of an idea or bugfix one might wish to contribute.
 
+Other good starting points for first-time contributors include the [Scala README](https://github.com/scala/scala#get-in-touch) and [contributor's guidelines](https://github.com/scala/scala/blob/2.11.x/CONTRIBUTING.md).
+
 ## The Running Example
 
 Let's say that you particularly enjoy the new string interpolation language feature introduced in Scala 2.10.0, and you use it quite heavily.


### PR DESCRIPTION
the text of the guide already links to the same documents at
appropriate places in the narrative, but I also think it's worth
having the same links right up front