### PR TITLE
simplyscala.com is offline

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -65,7 +65,6 @@ There are a few interactive resources for trying out Scala, to get a look and fe
  * [Functional Programming Principles in Scala](https://www.coursera.org/course/progfun), free on Coursera. This is a course about functional programming given by Martin Odersky himself. You can access the course material and exercises by
  signing up for the course.
  * [Principles of Reactive Programming](https://www.coursera.org/course/reactive), free on Coursera. This is a course about concurrency and event-based asynchronous programming in Scala. You can access the course material and exercises by signing up for the course.
- * [Try Scala In Your Browser!](http://www.simplyscala.com/): [Simply Scala](http://www.simplyscala.com/) is a web site where you can interactively run the Scala interpreter in your browser! There you will find a tutorial that gives a rapid overview of the basic language features, the syntax, examples you can run and the ability to try your own code with an interactive interpreter.
  * [Independent Courseware](http://scalacourses.com), take a series of online Scala courses ranging from beginner to advanced for a fee.
 
 ## Books


### PR DESCRIPTION
Therefore it should be removed from this section.
Up for discussion.

[This](https://www.reddit.com/r/scala/comments/3didyu/where_is_simplyscala_gone/) reddit thread indicates, that it is at least offline since 3 months.

Also take a look at [archive.org](https://web.archive.org/web/*/http://www.simplyscala.com/).