### PR TITLE
link to both 2.11 & 2.12 nightly API doc, not just 2.11

### DIFF
--- a/_layouts/frontpage2.html
+++ b/_layouts/frontpage2.html
@@ -61,8 +61,8 @@ layout: default
       <p class="all-releases"><img src="{{ site.baseurl }}/resources/img/list.png" alt="list icon" /><a href="{{ site.baseurl }}/download/all.html">&nbsp;All Previous Releases</a></p>
     </div>
     <div class="right-side">
-      <p class="getting-started"><b>API: </b><a href="http://www.scala-lang.org/api/current/"><b>Current</b></a> | <a href="http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/"><b>Nightly</b></a></p>
-      <p class="dev-releases"><img src="{{ site.baseurl }}/resources/img/list.png" alt="list icon" /><a href="{{ site.baseurl }}/documentation/api.html">&nbsp;All Previous API Docs</a></p>
+      <p class="getting-started"><a href="http://www.scala-lang.org/api/current/"><b>Current API Docs</b></a></p>
+      <p class="dev-releases"><img src="{{ site.baseurl }}/resources/img/list.png" alt="list icon" /><a href="{{ site.baseurl }}/documentation/api.html">&nbsp;API Docs (other versions)</a></p>
       <p class="dev-releases"><img src="{{ site.baseurl }}/resources/img/books.png" alt="books icon" /><a href="{{ site.baseurl }}/documentation/">&nbsp;Scala Documentation</a></p>
       <p class="all-releases"><img src="{{ site.baseurl }}/resources/img/books.png" alt="books icon" /><a href="{{ site.baseurl }}/files/archive/spec/2.11/">&nbsp;Language Specification</a></p>
     </div>

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -27,8 +27,12 @@ title: Scala API Docs
 
 ## Nightly builds
 
-* [Library API](http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/)
-* [Compiler API](http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/scala-compiler/)
+* Scala 2.11.x
+  * [Library API](http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/)
+  * [Compiler API](http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/scala-compiler/)
+* Scala 2.12.x
+  * [Library API](http://www.scala-lang.org/files/archive/nightly/2.12.x/api/2.12.x/)
+  * [Compiler API](http://www.scala-lang.org/files/archive/nightly/2.12.x/api/2.12.x/scala-compiler/)
 
 ## Previous releases
 * Scala 2.11.6


### PR DESCRIPTION
as suggested by (iirc) @som-snytt

review @heathermiller