### PR TITLE
Fix incorrect URL in GSOC pages

### DIFF
--- a/gsoc/2015.md
+++ b/gsoc/2015.md
@@ -32,7 +32,7 @@ We encourage you to have a look at our [Summer of Code
 [2011](http://www.scala-lang.org/gsoc2011#),
 [2012](http://www.scala-lang.org/gsoc2012#),
 [2013](http://www.scala-lang.org/news/2013/03/20/gsoc13.html), and
-[2014](www.scala-lang.org/gsoc/2014.html) pages to
+[2014](http://www.scala-lang.org/gsoc/2014.html) pages to
 get an idea on what we and you can expect while working on Scala.
 
 ## Project Ideas

--- a/gsoc/2016.md
+++ b/gsoc/2016.md
@@ -31,8 +31,8 @@ Scala community.
 ### Previous Summer of Code
 
 We encourage you to have a look at our
-[2015](www.scala-lang.org/gsoc/2015.html),
-[2014](www.scala-lang.org/gsoc/2014.html),
+[2015](http://www.scala-lang.org/gsoc/2015.html),
+[2014](http://www.scala-lang.org/gsoc/2014.html),
 [2013](http://www.scala-lang.org/news/2013/03/20/gsoc13.html),
 [2012](http://www.scala-lang.org/gsoc2012#),
 [2011](http://www.scala-lang.org/gsoc2011#),


### PR DESCRIPTION
Incorrect hyperlink to 2014 and 2015 GSOC pages. Browser tries
to open it relative to current page.