### PR TITLE
Fixes #197, fixes blog index, and various bad formatting

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,7 @@
     <ul>
       <li><h5>Scala</h5></li>
       <li><a href="{{ site.baseurl }}/blog">Blog</a></li>
-      <li><a href="{{ site.baseurl }}/news">News Archive</a></li>
+      <li><a href="{{ site.baseurl }}/news">Archive</a></li>
       <li><a href="{{ site.baseurl }}/license.html">Scala License</a></li>
     </ul>
     </div>

--- a/blog/_posts/2015-07-26-sip-slip-summary-july-2015.md
+++ b/blog/_posts/2015-07-26-sip-slip-summary-july-2015.md
@@ -5,7 +5,7 @@ by: Dick Wall
 title: SIP/SLIP Summary, July 27th 2015
 ---
 
-# SIP/SLIP Summary, July 27th 2015
+## SIP/SLIP Summary, July 27th 2015
 
 ### Next Committee Meeting:
 

--- a/blog/_posts/2015-08-25-minutes-from-aug-2015.md
+++ b/blog/_posts/2015-08-25-minutes-from-aug-2015.md
@@ -5,7 +5,7 @@ by: Dick Wall
 title: Minutes from Aug SIP/SLIP Meeting
 ---
 
-# SIP/SLIP Meeting, Aug 20th 2015
+## SIP/SLIP Meeting, Aug 20th 2015
 
 ### Video of Aug Meeting
 [Video of Aug meeting](https://plus.google.com/u/5/events/cfh933nkhhq0pe7h23c9v4csk6o)
@@ -23,4 +23,3 @@ A number of SIPs and SLIPs were considered, with the following decisions:
 
 * [Either and the larger Validation library questions](https://github.com/scala/slip/issues/5) are large enough to merit the formation of an expert group to discuss the options. Bill Venners has volunteered to coordinate the group.
 * All existing SIPs and SLIPs were captured in [github issues](https://github.com/scala/slip/issues) for tracking.
-

--- a/blog/_posts/2015-10-07-minutes-from-sept-2015.md
+++ b/blog/_posts/2015-10-07-minutes-from-sept-2015.md
@@ -5,13 +5,13 @@ by: Dick Wall
 title: Minutes from Sept SIP/SLIP Meeting
 ---
 
-# SIP/SLIP Meeting, Sept 10th 2015
+## SIP/SLIP Meeting, Sept 10th 2015
 
-### Next Committee Meeting:
+#### Next Committee Meeting:
 
 Monday Oct 12th, 4.30pm GMT. [Google Hangout Event](https://plus.google.com/u/5/events/ci1hc0tn9jf0v45a9qdd7a520j8)
 
-### Video of Sept Meeting
+#### Video of Sept Meeting
 [Video of last meeting](https://plus.google.com/u/5/events/cvv4in7eq5tf4rus2ve0jodvo5c)
 
 ## Opening Matters
@@ -37,4 +37,3 @@ A number of SIPs and SLIPs were considered, with the following decisions:
 * Either/Validation is proceeding but no SLIP proposal or number yet. Progress can be tracked in [Issue 5](https://github.com/scala/slip/issues/5)
 * Scala IO improvements likewise are just getting started, but can be tracked in [Issue 19](https://github.com/scala/slip/issues/19)
 * [SLIP 27](https://github.com/scala/slip/blob/master/text/0027-collection-view-redesign.md) has been assigned to a Views redesign proposed by Josh Suereth. Please note that this SLIP is now open for public review for the period of at least one month. This does not block implementation work in the meantime, but may require changes based on the outcome of the public review. The progress of this SLIP will be tracked under [Issue 23](https://github.com/scala/slip/issues/23).
-

--- a/blog/_posts/2015-11-04-minutes-from-oct-2015.md
+++ b/blog/_posts/2015-11-04-minutes-from-oct-2015.md
@@ -5,13 +5,13 @@ by: Hamish Dickson
 title: Minutes from Oct 2015 SIP/SLIP Meeting
 ---
 
-# SIP/SLIP meeting, October 2015
+## SIP/SLIP meeting, October 2015
 
 Thanks to [@hamishdickson](http://github.com/hamishdickson) for compiling these extensive minutes.
 
 [A video recording of this meeting is available](https://www.youtube.com/watch?v=vonlAh2tmnw).
 
-# Welcomes and apologies
+## Welcomes and apologies
 
 - Welcome to [@sjrd](http://github.com/sjrd) who joins us
 - [@odersky](http://github.com/odersky), [@jsuereth](http://github.com/jsuereth), [@dickwall](http://github.com/dickwall) and [@SethTisue](http://github.com/SethTisue) are all there
@@ -19,7 +19,7 @@ Thanks to [@hamishdickson](http://github.com/hamishdickson) for compiling these 
 - [@non](http://github.com/non) has the flu
 - [@heathermiller](http://github.com/heathermiller) is "otherwise engaged"
 
-# 1. New Google Calendar
+## 1. New Google Calendar
 
 [@dickwall](http://github.com/dickwall) has set up a google calendar for slip:
 
@@ -27,14 +27,14 @@ Thanks to [@hamishdickson](http://github.com/hamishdickson) for compiling these 
 - It's public so people can know when the next slip meeting is
 - The scalaslip@gmail.com calendar which you can add in google calendars under the "add a friends calendar" option
 
-# 2. Expert groups
+## 2. Expert groups
 
-## 2.1 Getting updates from expert groups
+### 2.1 Getting updates from expert groups
 [@dickwall](http://github.com/dickwall) can't email everyone for expert groups, it's simply not a goer. One idea is to create an event
 in the new Google calendar (probably the Friday before the meeting) and ask an expert group representative
 to come to that and provide an update before the next slip meeting.
 
-## 2.2 Role of expert groups
+### 2.2 Role of expert groups
 [@dickwall](http://github.com/dickwall) raises a point that was brought up on the IO overhaul discussion, where people feel they have
 been assigned to an expert group and given work to do without asking. This is entirely not what anyone
 intended and [@dickwall](http://github.com/dickwall) is going to write a blog post about the aim of expert groups, how they are formed
@@ -50,15 +50,15 @@ Actions:
 - someone should check if misconstruisem is a word
 
 
-# 3. SLIPs without recent activity
+## 3. SLIPs without recent activity
 Some SLIPs have had no activity in the last couple of months, it would be good if we can somehow track
 this. [@dickwall](http://github.com/dickwall) suggests are create a github tag to track SLIP issues like this. His initial idea is to
 use "dormant", but thinks this is too passive-aggressive. People agree and [@odersky](http://github.com/odersky) suggests "hibernate"
 (which sticks).
 
-# 4. October milestone issues
+## 4. October milestone issues
 
-## Scala Parser Combinators vs FastParse
+### Scala Parser Combinators vs FastParse
 Link to issue: https://github.com/scala/slip/issues/24
 
 Notes:
@@ -81,7 +81,7 @@ Actions:
 - Invite [@lihaoyi](http://github.com/lihaoyi) to take action if he wants to
 
 
-## SLIP 27
+### SLIP 27
 Link to issue: https://github.com/scala/slip/issues/23
 
 Owner: [@jsuereth](http://github.com/jsuereth)
@@ -109,7 +109,7 @@ Actions:
 - [@jsuereth](http://github.com/jsuereth) and [@sjrd](http://github.com/sjrd) to take scala-js optimization issues offline
 - [@dickwall](http://github.com/dickwall) to create a new issue to track optimization issue
 
-## SLIP 22 - Async
+### SLIP 22 - Async
 Link to issue: https://github.com/scala/slip/issues/22
 
 Owner: [@retronym](http://github.com/retronym)
@@ -126,7 +126,7 @@ few months that will include technical improvements to the lib and improved docu
 Actions:
 None discussed
 
-## Revisit by-name parameters
+### Revisit by-name parameters
 Link to issue: https://github.com/scala/slip/issues/21
 
 Notes:
@@ -137,7 +137,7 @@ as a conflict of interest
 Actions:
 None discussed
 
-## Scala IO fix/overhaul
+### Scala IO fix/overhaul
 Link to issue: https://github.com/scala/slip/issues/19
 
 Notes:
@@ -152,7 +152,7 @@ or someone else in the thread
 - [@dickwall](http://github.com/dickwall) to put all this in a blog post
 
 
-## SIP 24 and 25 - trait parameters and repeating by-names
+### SIP 24 and 25 - trait parameters and repeating by-names
 Link to issue: https://github.com/scala/slip/issues/12
 
 Notes:
@@ -162,7 +162,7 @@ Notes:
 Actions:
 None discussed
 
-## Possible SIP for changes to escapes in string interpolation (double quotes inside of a string interpolation)
+### Possible SIP for changes to escapes in string interpolation (double quotes inside of a string interpolation)
 Link to issue: https://github.com/scala/slip/issues/10
 
 Notes:
@@ -180,7 +180,7 @@ Actions:
 - Allocate hibernate tag
 - [@jsuereth](http://github.com/jsuereth) will reach out to [@som-snytt](http://github.com/som-snytt) to talk about the next steps here
 
-## Binary Literals, Underscores in Literals SIP/SLIP tracking
+### Binary Literals, Underscores in Literals SIP/SLIP tracking
 Link to issue: https://github.com/scala/slip/issues/8
 
 Owner: [@non](http://github.com/non)
@@ -194,7 +194,7 @@ Actions
 - Allocate hibernate tag
 - Probably an update from [@non](http://github.com/non) would be good
 
-## Implicits in for comprehensions/pattern matches SIP tracking
+### Implicits in for comprehensions/pattern matches SIP tracking
 Link to issue: https://github.com/scala/slip/issues/6
 
 Owner: [@haroldl](http://github.com/haroldl)
@@ -208,7 +208,7 @@ Actions:
 
 - [@dickwall](http://github.com/dickwall) to reach out and chat to [@haroldl](http://github.com/haroldl) and see how things are going
 
-## Gather, list, contact interested parties for an Either/Or/Xor/Validation etc SLIP and possible expert group
+### Gather, list, contact interested parties for an Either/Or/Xor/Validation etc SLIP and possible expert group
 Link to issue: https://github.com/scala/slip/issues/5
 
 Notes:
@@ -221,7 +221,7 @@ Actions:
 
 - Expert group to try out each other's libraries
 
-# AOB
+## AOB
 
 - collections doesn't have any tracking - [@dickwall](http://github.com/dickwall) to set something up and ping him with any links/info on
 Gitter and he will collect them and put them into an issue with some links. Expects lots of discussion

--- a/blog/_posts/2015-11-16-minutes-from-nov-2015.md
+++ b/blog/_posts/2015-11-16-minutes-from-nov-2015.md
@@ -5,18 +5,18 @@ by: Hamish Dickson
 title: Minutes from Nov 2015 SIP/SLIP Meeting
 ---
 
-# SIP/SLIP meeting, November 2015
+## SIP/SLIP meeting, November 2015
 
 [A video recording of this meeting](https://www.youtube.com/watch?v=RJAwDhB3Vr8) is available.
 
-# Welcomes and apologies
+## Welcomes and apologies
 Today we have [@dickwall](http://github.com/dickwall), [@sjrd](http://github.com/sjrd), [@SethTisue](http://github.com/SethTisue), [@heathermiller](http://github.com/heathermiller), [@non](http://github.com/non) and [@odersky](http://github.com/odersky).
 
 [@jsuereth](http://github.com/jsuereth) is unable to make it.
 
-# November milestone issues
+## November milestone issues
 
-## Adding scala.io.Target
+### Adding scala.io.Target
 Link to SLIP: [https://github.com/scala/slip/pull/2](https://github.com/scala/slip/pull/2)
 
 Notes:
@@ -24,7 +24,7 @@ Notes:
 - nothing has changed on this one, [@dickwall](http://github.com/dickwall) suggests hibernate tag
 - believe this has been replaced/deprecated by the larger IO library discussion
 
-## Unsigned integer data types
+### Unsigned integer data types
 Link to SLIP: [https://github.com/scala/slip/pull/30](https://github.com/scala/slip/pull/30)
 
 Owner: [@sjrd](http://github.com/sjrd)
@@ -53,7 +53,7 @@ Actions:
 - [@dickwall](http://github.com/dickwall) will create a tag for public review and add it to this SLIP
 
 
-##  Implicits in for comprehensions/pattern matches SIP tracking
+###  Implicits in for comprehensions/pattern matches SIP tracking
 Link to SLIP: [https://github.com/scala/slip/issues/6](https://github.com/scala/slip/issues/6)
 
 Notes:
@@ -80,7 +80,7 @@ Actions:
 - [@SethTisue](http://github.com/SethTisue) to post instructions on the SLIP PR on how to use a specific Scala build so people can try out the current implementation
 
 
-## Implicit enrichment of `scala.util.Either` to support monadic bias
+### Implicit enrichment of `scala.util.Either` to support monadic bias
 Link to SLIP: [https://github.com/scala/slip/pull/20](https://github.com/scala/slip/pull/20)
 
 Notes:
@@ -92,7 +92,7 @@ Actions:
 
 - [@swaldman](https://github.com/swaldman) to co-ordinate this with other SLIPs
 
-## Collections overhaul
+### Collections overhaul
 Link to SLIP: [https://github.com/scala/slip/issues/27](https://github.com/scala/slip/issues/27)
 
 Notes:
@@ -100,7 +100,7 @@ Notes:
 - not much activity this month
 - active, hold fire until next meeting
 
-## scala-parser-combinators vs fastparse
+### scala-parser-combinators vs fastparse
 Link to SLIP: [https://github.com/scala/slip/issues/24](https://github.com/scala/slip/issues/24)
 
 Notes:
@@ -109,7 +109,7 @@ Notes:
 - [@SethTisue](http://github.com/SethTisue) impression from [@lihaoyi](https://github.com/lihaoyi) is that he's ok with FastParse going into the standard module, but he probably doesn't have the time
 - [@odersky](http://github.com/odersky) agrees we're blocked until someone can do this really
 
-## SLIP 27 Tracking
+### SLIP 27 Tracking
 Link to SLIP: [https://github.com/scala/slip/issues/23](https://github.com/scala/slip/issues/23)
 
 Notes:
@@ -118,7 +118,7 @@ Notes:
 - hold this until next month
 - this issue is linked to the collection overhaul and it needs to be decided if this should be done separately or if it should be rolled into a larger change
 
-## Scala IO fix-up/overhaul
+### Scala IO fix-up/overhaul
 Link to SLIP: [https://github.com/scala/slip/issues/19](https://github.com/scala/slip/issues/19)
 
 Notes:
@@ -127,7 +127,7 @@ Notes:
 - [@dickwall](http://github.com/dickwall) is nearly done with his blog post, discussed in the last meeting
 - not ready for hibernate just yet
 
-## Establish a fair survey mechanism for SLIPs?
+### Establish a fair survey mechanism for SLIPs?
 Link to SLIP: [https://github.com/scala/slip/issues/29](https://github.com/scala/slip/issues/29)
 
 Notes:
@@ -145,7 +145,7 @@ Notes:
 
 [@dickwall](http://github.com/dickwall) closes issue, but happy for it to be reopened as and when it's needed
 
-## Gather, list, contact interested parties for an Either/Or/Xor/Validation etc SLIP and possible expert group
+### Gather, list, contact interested parties for an Either/Or/Xor/Validation etc SLIP and possible expert group
 Link to SLIP: [https://github.com/scala/slip/issues/5](https://github.com/scala/slip/issues/5)
 
 Notes:
@@ -153,13 +153,13 @@ Notes:
 - [@non](http://github.com/non) no update on this, know people are to do research on this, but it hasn't happened yet (people get busy)
 - not given hibernated tag
 
-## SIP: Auto-uncurry n-ary functions
+### SIP: Auto-uncurry n-ary functions
 
 There is no SIP tracking issue as yet, but information can be found here: [https://github.com/lampepfl/dotty/issues/897](https://github.com/lampepfl/dotty/issues/897)
 
 No issue created as yet, but [@odersky](http://github.com/odersky) will create one if needed
 
-## SIP for supporting named type arguments and partial type argument lists
+### SIP for supporting named type arguments and partial type argument lists
 Link to SLIP: [https://github.com/scala/scala.github.com/pull/456](https://github.com/scala/scala.github.com/pull/456)
 
 Notes:
@@ -173,7 +173,8 @@ Homework:
 - review in December SLIP meeting
 
 
-# JSON AST, Scala standard library, and the SLIP process
+
+## JSON AST, Scala standard library, and the SLIP process
 Link to issue and document: [https://github.com/scala/slip/issues/31](https://github.com/scala/slip/issues/31)
 
 [A SLIP proposing a standard JSON AST](https://github.com/scala/slip/pull/28) deviated quickly from the purpose of the SLIP and started a long discussion about what should and should not be in a Scala standard library. This and other discussions seem to really stem from the fact that it isn't clear what should go where in the Scala ecosystem.
@@ -242,7 +243,7 @@ Actions:
 - [@dickwall](http://github.com/dickwall) created new issue to track this: https://github.com/scala/slip/issues/31
 - The community should read [@odersky](http://github.com/odersky)'s document and let the SLIP know their thoughts/questions/comments
 
-## ... so what about JSON AST question/discussion
+### ... so what about JSON AST question/discussion
 Link to SLIP: [https://github.com/scala/slip/pull/28](https://github.com/scala/slip/pull/28)
 
 Notes:
@@ -279,7 +280,7 @@ Actions:
 - SLIP give a number (28)
 
 
-# AOB
+## AOB
 - Sadly, [@dickwall](http://github.com/dickwall) is to step aside from the committee meetings but will continue to help with some of the process work. This is [@dickwall](http://github.com/dickwall)'s last committee meeting
 - [@SethTisue](http://github.com/SethTisue) will set up and moderate the December meeting
 - all agree [@dickwall](http://github.com/dickwall) has done a great job and thank him

--- a/blog/index.md
+++ b/blog/index.md
@@ -10,15 +10,15 @@ title: Blog
 
 
 <ul class="post-list">
-  {% for p in site.categories.blog %}
+  {% for p in site.posts %}
     {% if p.post-type == 'blog' %}
       <li>
         {% if p.link-out %}
-          <a href="{{ p.link-out }}">{{ p.title }}</a>
+          <b><a href="{{ p.link-out }}">{{ p.title }}</a></b>
         {% else %}
-          <a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a>
+          <b><a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a></b>
         {% endif %}
-          <span class="date">( {{ p.date | date: "%A, %B %d, %Y" }} )</span>
+          <br><span class="news-archive-date">{{ p.date | date: "%A, %B %d, %Y" }}</span>
       </li>
     {% endif %}
   {% endfor %}

--- a/feed/blog.xml
+++ b/feed/blog.xml
@@ -1,5 +1,4 @@
 ---
-layout: nil
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/feed/index.xml
+++ b/feed/index.xml
@@ -1,5 +1,4 @@
 ---
-layout: nil
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/news/index.md
+++ b/news/index.md
@@ -1,20 +1,43 @@
 ---
 layout: page
-title: News Archive
+title: Archive
 ---
 
+## News & Blog
+
 <ul class="news-archive-list">
-{% for p in site.categories.news limit: 30 %}
-  {% if p.post-type == 'news' %}
+{% for p in site.posts %}
+  {% if p.post-type == 'news' or p.post-type == 'blog' %}
     <li class="news-archive-entry">
+      {% if p.post-type == 'blog' %}
+        <span class="label label-primary">Blog</span>
+      {% elsif p.post-type == 'news' %}  
+        <span class="label label-success">News</span>
+      {% endif %}  
       {% if p.link-out %}
-        <a href="{{ p.link-out }}">{{ p.title }}</a>
+        <b><a href="{{ p.link-out }}">{{ p.title }}</a></b>
       {% else %}
-        <a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a>
+        <b><a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a></b>
       {% endif %}
-        <span class="date">( {{ p.date | date: "%A, %B %d, %Y" }} )</span>
+        <br><span class="news-archive-date">{{ p.date | date: "%A, %B %d, %Y" }}</span>
     </li>
   {% endif %}
 {% endfor %}
 </ul>
 
+## Announcements & Changelog
+
+<ul class="news-archive-list">
+{% for p in site.categories.news %}
+  {% if p.post-type == 'announcement' %}
+    <li class="news-archive-entry">
+      {% if p.link-out %}
+        <b><a href="{{ p.link-out }}">{{ p.title }}</a></b>
+      {% else %}
+        <b><a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a></b>
+      {% endif %}
+        <br><span class="news-archive-date">{{ p.date | date: "%A, %B %d, %Y" }}</span>
+    </li>
+  {% endif %}
+{% endfor %}
+</ul>

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -2695,3 +2695,11 @@ div#toc ul > li + ul > li { margin-top: 12px; }
   text-shadow:none;
   color:#FFF;
 }
+
+
+.news-archive-date {
+  font-family: 'proxima-nova', sans-serif;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #93a1a1;
+}


### PR DESCRIPTION
Fixed #197 so now the "News Archive" is called "Archive" and it contains both news/blog articles, as well as announcements/releases.

**On news/index.md:**
![screen shot 2015-12-11 at 9 51 04 pm](https://cloud.githubusercontent.com/assets/687163/11755423/b3071dda-a052-11e5-98f4-fc28fabbd92d.png)
![screen shot 2015-12-11 at 9 51 15 pm](https://cloud.githubusercontent.com/assets/687163/11755424/b3277cba-a052-11e5-8fc2-06a96bed86c2.png)

I also fixed the index in the blog (it was missing entries), and I improved the formatting of all indices.

I also fixed a bunch of formatting problems in SIP/SLIP meeting notes.