### PR TITLE
relocate Code of Conduct from doc site

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,6 +30,7 @@
       <li><h5>Scala</h5></li>
       <li><a href="{{ site.baseurl }}/blog">Blog</a></li>
       <li><a href="{{ site.baseurl }}/news">Archive</a></li>
+      <li><a href="{{ site.baseurl }}/conduct.html">Code of Conduct</a></li>
       <li><a href="{{ site.baseurl }}/license.html">Scala License</a></li>
     </ul>
     </div>

--- a/community/index.md
+++ b/community/index.md
@@ -11,7 +11,7 @@ The community is also the source of many libraries, tools, and other resources a
 
 ## Mailing Lists
 
-The Scala mailing lists are covered by the [Scala Code of Conduct](http://docs.scala-lang.org/conduct.html).
+The Scala mailing lists are covered by the [Scala Code of Conduct](../conduct.html).
 
 This is our most beginner-friendly list:
 

--- a/conduct.md
+++ b/conduct.md
@@ -1,0 +1,87 @@
+---
+layout: page
+title: The Scala Code of Conduct
+---
+
+This Code of Conduct covers our behaviour as contributors/comitters of
+the Scala Team, as well as those participating in any Scala moderated
+forum, mailing list, wiki, web site, IRC channel, hackathon, public
+meeting or private correspondence.  (See the
+[list of community fora](http://www.scala-lang.org/community/)
+on the main Scala site.)
+
+Scala moderators are appointed by EPFL / Typesafe to maintain the
+health of the community and will arbitrate in any dispute over the
+conduct of a member of the community.
+
+Note: This should not be interpreted like a legal document.  It's a statement
+of intent, and a guideline for collaboration.
+
+The code of conduct consists of a few simple rules:
+
+## (1) Be Respectful
+
+The Scala community is made up of a diverse set of individuals and
+backgrounds. Everyone can make a contribution to Scala. Disagreement is no
+excuse for poor behavior. Also, many users coming to Scala might have
+different background than others. Not knowing a particular domain is not just
+cause for rude behavior. If someone is suggesting concepts
+that go beyond your basic understanding, patiently asking for more information
+is the right way to go. Treat each other with respect in all interactions.
+
+A few examples for clarification.
+
+Abusive language, such as:
+
+> F*** you
+
+is never welcome.  The same goes for personal attacks like the following:
+
+> It's obvious you're a troll.
+
+Snide comments, like the following:
+
+> You really haven't comprehended anything I'm saying.
+
+are generally unhelpful.  What you could have said:
+
+> I think perhaps my point was unclear.  Let's rehash:
+
+## (2) Be Courteous
+
+ Whether posting to a mailing list, or submitting a bug report we value your
+ contribution to Scala. When working with another’s work, be courteous and
+ professional. It’s not courteous to demand responses, insult pull requests
+ or post condescending bug reports. In that same vein, avoid posting messages
+ with little to no content on the mailing list. We have a lot of people in
+ the community, let’s keep our signal to noise ratio high, and set emotions
+ aside before coming to the table.
+
+## (3) Be Excellent
+
+Strive to improve in all things. Strive to better Scala, and improve
+understanding. Improve your own teaching styles. Change the way we think about
+code design. Scala is a gateway into a new world of software design, and we’re
+constantly learning new things and opening new avenues. Keep an open mind
+to try new things, and strive to improve what we already know.
+
+## (4) Be Thorough
+
+No matter what it is, responding to a question, fixing a bug, writing a
+proposal, make sure the contribution is thorough. Don’t leave things half
+written or half done. While the evolution of Scala is a continual process,
+incomplete work is often of negative benefit. At the same time, contributors
+will come and go, as with any open source community. If a contributor needs
+to drop something, take measures to ensure someone else is willing to pick
+it up, or notify the other maintainers.
+
+
+## Violating the Code
+
+If a community member refuses to abide by the Code of Conduct, via
+personal attacks, abusive language or snide comments, then the following
+actions will be taken:
+
+1. **Issued a warning** On the first offense, one of the Scala moderators will issue a warning about the unacceptable behavior.
+2. **Put under moderation** On the second offense, a user may be placed under moderation.  This will continue for a maximum of three months.  If behavior improves, a user can leave moderated status.   If behavior degrades, it can lead to #3.
+3. **Removal from community** If a user has already been placed under moderation and returned, or has not learned to be respectful and courteous to others, it will constitute a removal from the Scala community, including all forums the Scala moderators are responsible for.

--- a/conduct.md
+++ b/conduct.md
@@ -3,12 +3,11 @@ layout: page
 title: The Scala Code of Conduct
 ---
 
-This Code of Conduct covers our behaviour as contributors/comitters of
-the Scala Team, as well as those participating in any Scala moderated
-forum, mailing list, wiki, web site, IRC channel, hackathon, public
-meeting or private correspondence.  (See the
-[list of community fora](http://www.scala-lang.org/community/)
-on the main Scala site.)
+This Code of Conduct covers our behaviour as contributors/committers of
+the Scala team, as well as those participating in any Scala moderated
+forum, mailing list, wiki, web site, Gitter or IRC room, hackathon, public
+meeting or private correspondence.  (See our
+[list of community fora](community/).)
 
 Scala moderators are appointed by EPFL / Typesafe to maintain the
 health of the community and will arbitrate in any dispute over the
@@ -45,17 +44,17 @@ Snide comments, like the following:
 
 are generally unhelpful.  What you could have said:
 
-> I think perhaps my point was unclear.  Let's rehash:
+> I think perhaps my point was unclear.  Let me expand:
 
 ## (2) Be Courteous
 
- Whether posting to a mailing list, or submitting a bug report we value your
- contribution to Scala. When working with another’s work, be courteous and
- professional. It’s not courteous to demand responses, insult pull requests
- or post condescending bug reports. In that same vein, avoid posting messages
- with little to no content on the mailing list. We have a lot of people in
- the community, let’s keep our signal to noise ratio high, and set emotions
- aside before coming to the table.
+Whether posting to a mailing list, or submitting a bug report we value your
+contribution to Scala. When working with another’s work, be courteous and
+professional. It’s not courteous to demand responses, insult pull requests
+or post condescending bug reports. In that same vein, avoid posting messages
+with little to no content on the mailing list. We have a lot of people in
+the community, let’s keep our signal-to-noise ratio high, and set emotions
+aside before coming to the table.
 
 ## (3) Be Excellent
 
@@ -74,7 +73,6 @@ incomplete work is often of negative benefit. At the same time, contributors
 will come and go, as with any open source community. If a contributor needs
 to drop something, take measures to ensure someone else is willing to pick
 it up, or notify the other maintainers.
-
 
 ## Violating the Code
 

--- a/contribute/codereviews.md
+++ b/contribute/codereviews.md
@@ -13,7 +13,7 @@ own pull requests.
  
 ### Review Guidelines
 
-[Code of Conduct Reminder](http://docs.scala-lang.org/conduct.html)
+[Code of Conduct reminder](../conduct.html)
 
 * Keep comments on-topic, concise and precise.
 * Attach comments to particular lines or regions they pertain to whenever possible.


### PR DESCRIPTION
I feel this is important enough to be on the main site.

review by @heathermiller, @dickwall, @propensive...?

if this is approved for merge, then I will prepare a corresponding PR
over in the doc site repo, removing the page there.