### PR TITLE
Don't show legacy atypical shebang preamble in intro shell script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SCALA-LANG.ORG
+# scala-lang.org
 
 This repository contains the _static_ source of [scala-lang.org](http://scala-lang.org). It does not contain the source of any content found under the [docs.scala-lang.org](http://docs.scala-lang.org) subdomain (instead, visit the [scala.github.com repo](http://github.com/scala/scala.github.com) for that source).
 
@@ -12,8 +12,8 @@ This site uses a Jekyll, a Ruby framework. The required Jekyll version is 3.1.6.
 
 There are two ways to run Jekyll to build the site:
 
-1. using Bundler, so Jekyll and accompanying gems are installed only inside this directory
-2. using globally installed Jekyll and accompanying gems
+1. Using [Bundler], so Jekyll and accompanying gems are installed only inside this directory.
+2. Using globally-installed Jekyll and accompanying gems.
 
 The latter method is the one currently actually used on scala-lang.org. The
 former method is likely most convenient for users who already have a different
@@ -28,7 +28,7 @@ Start the server in the context of the bundle:
 
     bundle exec jekyll serve
 
-from this point, everything else should be the same, regardless of which method
+From this point, everything else should be the same, regardless of which method
 you used to run Jekyll.
 
 ### Option 2) Building with global Jekyll
@@ -37,7 +37,7 @@ Install Jekyll 3.1.6 on your system using RubyGems:
 
     gem install jekyll -v 3.1.6
 
-After cloning, cd into the directory where you cloned this repository and run:
+After cloning, `cd` into the directory where you cloned this repository and run:
 
     jekyll serve
 
@@ -72,7 +72,7 @@ The "YAML Front Matter" is nothing more than the header on each page that you in
     title: My page title
     ---
 
-You can use these fields in the YAML front matter later in your document. For example, to make a header with the title of the document, in markdown you would write:
+You can use these fields in the YAML front matter later in your document. For example, to make a header with the title of the document, in Markdown you would write:
 
     ---
     layout: page
@@ -87,7 +87,7 @@ You can use these fields in the YAML front matter later in your document. For ex
 
 ## Markdown
 
-There are dozens of guides and cheatsheets that cover markdown syntax out there, though this screenshot from the free OSX markdown editor, [Mou](http://mouapp.com/), is an excellent and concise reference:
+There are dozens of guides and cheatsheets that cover Markdown syntax out there, though this screenshot from the free OS X Markdown editor, [Mou](http://mouapp.com/), is an excellent and concise reference:
 
 ![Mou screen shot](http://25.io/mou/img/1.png)
 
@@ -128,3 +128,4 @@ Example YAML front matter with all possible fields:
     by: Scala Jenkins (Build Kitty)
     ---
 
+[Bundler]: http://bundler.io/

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -3,7 +3,7 @@ layout: page
 title: Getting Started
 ---
 
-The best way to learn Scala depends on what you know already and the way you prefer to learn things. There is a variety of resources available including [books]({{ site.baseurl }}/documentation/books.html), tutorials, training courses, presentations, and of course the Scala compiler for practice. Many people find a good combination is to have one of the Scala books at hand and to start right away trying the examples with the Scala Compiler. On the other hand, you may want to get started with a Scala training course or using the material available online.
+The best way to learn Scala depends on what you know already and the way you prefer to learn things. There is a variety of resources available including [books]({{ site.baseurl }}/documentation/books.html), tutorials, training courses, presentations, and of course the Scala compiler for practice. Many people find a good combination is to have one of the Scala books at hand and to start right away trying the examples with the Scala compiler. On the other hand, you may want to get started with a Scala training course or using the material available online.
 
 As your knowledge of Scala grows, you will find there is more advanced material and a very friendly [Scala community]({{ site.baseurl }}/community/) at hand to help you. They all share a passion for Scala and welcome newcomers warmly. Many have written helpful material for programmers new to Scala, will respond to emails asking for help or are sharing neat new techniques, advanced concepts or tools in one of several Scala forums or personal blogs.
 
@@ -12,7 +12,7 @@ As your knowledge of Scala grows, you will find there is more advanced material 
 
 If you are just starting to learn how to code, you will find that a large portion of the material about Scala assumes that you already have some programming experience. There are two valuable resources which we can recommend to programming beginners that will take you directly into the world of Scala:
 
-* The online class [Functional Programming Principles in Scala](https://www.coursera.org/course/progfun), available on coursera. Taught by the creator of Scala, Martin Odersky, this online class takes a somewhat academic approach to teach the fundamentals of functional programming. You will learn a lot of Scala by solving the programming assignments.
+* The online class [Functional Programming Principles in Scala](https://www.coursera.org/course/progfun), available on Coursera. Taught by the creator of Scala, Martin Odersky, this online class takes a somewhat academic approach to teach the fundamentals of functional programming. You will learn a lot of Scala by solving the programming assignments.
 * [Kojo](http://www.kogics.net/sf:kojo) is an interactive learning environment that uses Scala programming to explore and play with math, art, music, animations and games.
 
 ## Your first lines of code
@@ -29,7 +29,7 @@ As a first example, we use the standard "Hello, world!" program to demonstrate t
 
 The structure of this program should be familiar to Java programmers: it consists of the method `main` which prints out a friendly greeting to the standard output.
 
-We assume that both the [Scala software]({{ site.baseurl  }}/download) and the user environment are set up correctly. For example:
+We assume that both the [Scala software]({{ site.baseurl }}/download) and the user environment are set up correctly. For example:
 
 | Environment | Variable         | Value (example)
 |:------------|:-----------------|:---------------
@@ -96,11 +96,10 @@ Here is how the "Hello, world!" example looks like using the `App` trait:
 
 We may also run our example as a shell script or batch command (see the examples in the man pages of the `scala` command).
 
-The [bash](http://www.gnu.org/software/bash/) shell script `script.sh` containing the following Scala code (and shell preamble)
+The [bash](http://www.gnu.org/software/bash/) shell script `script.sh` containing the following Scala code (and shell preamble):
 
-    #!/bin/sh
-    exec scala "$0" "$@"
-    !#
+    #!/usr/bin/env scala
+
     object HelloWorld extends App {
       println("Hello, world!")
     }
@@ -110,4 +109,4 @@ can be run directly from the command shell:
 
     > ./script.sh
 
-**Note**: We assume here that the file `script.sh` has execute access and the search path for the `scala` command is specified in the `PATH` environment variable.
+**Note**: We assume here that the file `script.sh` has execute permission and the search path for the `scala` command is specified in the `PATH` environment variable.


### PR DESCRIPTION
Using a conventional shell script shebang like `#!/usr/bin/env scala` has been possible for awhile now. When I see this:

```scala
#!/bin/sh
exec scala "$0" "$@"
!#
object HelloWorld extends App {
  println("Hello, world!")
}
HelloWorld.main(args)
```

I pause and think, "Gee, that's kinda weird." Anything that makes me think that way on what is quite possibly the *first* page that a potential new Scala user reads attentively should be improved, IMO.

The `scala` man page (referenced in this same section) still illustrates this legacy script form as well, but then again it also still references `sbaz`… Maybe I'll find time to contribute an update to that as well, after I figure out what works for Windows batch scripts these days.

A few other minor trifles in the diff, I hope you won't mind the noise.

It might be nice to show the shell script example as simply:

```scala
#!/usr/bin/env scala

println("Hello, world!")
```

to make it known that that convenience is possible, but perhaps that introduces too much magic needing a hand-wavy explanation that would detract from this succinct intro doc.