### PR TITLE
Fix Atom feeds

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -27,5 +27,5 @@
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 
     <!-- Atom feeds -->
-    <link rel="alternate" type="application/rss+xml" title="News Feed" href="{{ site.baseurl }}/feed/index.xml" />
-    <link rel="alternate" type="application/rss+xml" title="Blog Feed" href="{{ site.baseurl }}/feed/blog.xml" />
+    <link rel="alternate" type="application/atom+xml" title="News Feed" href="{{ site.baseurl }}/feed/index.xml" />
+    <link rel="alternate" type="application/atom+xml" title="Blog Feed" href="{{ site.baseurl }}/feed/blog.xml" />

--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -25,3 +25,7 @@
     <!-- Typekit (should stay at top of page, do not move to footer)-->
     <script type="text/javascript" src="//use.typekit.net/abh3wgk.js"></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+
+    <!-- Atom feeds -->
+    <link rel="alternate" type="application/rss+xml" title="News Feed" href="{{ site.baseurl }}/feed/index.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Blog Feed" href="{{ site.baseurl }}/feed/blog.xml" />

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -4,7 +4,6 @@ toc: true
 ---
 
 {% include headertop.html %}
-<link href="/feed/blog.xml" rel="alternate" type="application/rss+xml" title="Scala-lang's blog" />
 {% include headerbottom.html %}
 
 <div class="darkstrip"></div>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -3,8 +3,6 @@ layout: default
 ---
 
 {% include headertop.html %}
-    <!-- RSS feed -->
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}/feed/index.xml" />
 {% include headerbottom.html %}
 
 <div class="splash">

--- a/feed/blog.xml
+++ b/feed/blog.xml
@@ -2,11 +2,12 @@
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text" xml:lang="en">{{ site.root_desc }}</title>
+  <id>http://www.scala-lang.org/blog/</id>
+  <title type="text" xml:lang="en">{{ site.title }} :: Blog</title>
   <link type="application/atom+xml" href="http://www.scala-lang.org/feed/blog.xml" rel="self"/>
-  <link type="text" href="http://www.scala-lang.org/" rel="alternate"/>
+  <link type="text/html" href="http://www.scala-lang.org/blog/" rel="alternate"/>
+
   <updated>{{ site.time | date_to_xmlschema }}</updated>
-  <id>http://www.scala-lang.org/</id>
   <author>
     <name>École Polytechnique Fédérale de Lausanne</name>
   </author>

--- a/feed/index.xml
+++ b/feed/index.xml
@@ -2,11 +2,12 @@
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text" xml:lang="en">{{ site.root_desc }}</title>
-  <link type="application/atom+xml" href="http://www.scala-lang.org/feed/index.xml" rel="self"/>
-  <link type="text" href="http://www.scala-lang.org/" rel="alternate"/>
-  <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>http://www.scala-lang.org/</id>
+  <title type="text" xml:lang="en">{{ site.title }} :: News</title>
+  <link type="application/atom+xml" href="http://www.scala-lang.org/feed/index.xml" rel="self"/>
+  <link type="text/html" href="http://www.scala-lang.org/news/" rel="alternate"/>
+
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
   <author>
     <name>École Polytechnique Fédérale de Lausanne</name>
   </author>


### PR DESCRIPTION
Fixes these issues:

- the `<title>` tag was broken, as can be seen by [the W3C validator](https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fwww.scala-lang.org%2Ffeed%2Findex.xml) and this breaks feed readers that are less tolerant, for example Mozilla Thunderbird
- the `<id>` for `blog.xml` is the same as the one in `index.xml` and this is a mistake, because then feed readers may not be able to differentiate between them
- both `<link rel="alternate">` should be present on *all* html pages, as a best practice for discovery by feed readers
- the original `<link rel="alternate">` in the HTML head where indicating `application/rss+xml` as the MIME type, but that's wrong, as it should be `application/atom+xml` (Atom != RSS)