### PR TITLE
update (and slim down) books page

### DIFF
--- a/documentation/books.md
+++ b/documentation/books.md
@@ -3,20 +3,13 @@ layout: page
 title: Books
 ---
 
-There are more and more books being published about Scala. Here are some
-of the titles with their availability.
+The number of books published about Scala is now large,
+and still growing fast.
 
-We only list books here which give
-an introduction to the Scala language. Books which assume knowledge of
-Scala, in particular books on frameworks like Lift, Play! or Akka, are not
-listed here.
+What follows is only a small selection of recent titles in English that
+address the Scala language in general.  Many more books exist which
+address particular audiences, particular frameworks, etc.
 
-
-- [English Books](#english_scala_books)
-- [Non-English Books](#nonenglish_scala_books)
-
-
-### English Scala Books
 
 [**Programming in
 Scala**, 3rd ed.](http://booksites.artima.com/programming_in_scala_3ed)
@@ -83,39 +76,6 @@ What you don't get:
   </div>
 </div>
 
-<br/>
-
-[**Scala in Depth**](http://www.manning.com/suereth)
-– **Available Now**
-by Joshua D. Suereth
-
-Published by [Manning](http://www.manning.com):
-
-
-<div class="row">
-  <div class="span2">
-    <div align="center">
-    <a href="http://www.manning.com/suereth">
-      <img src="/resources/img/books/icon_Scala_in_Depth_93x116.png" alt="">
-    </a>
-    </div>
-  </div>
-  <div class="span8" style="padding-top: 15px;">
-
-"While information about the Scala language is abundant, skilled
-practitioners, great examples, and insight into the best practices of
-the community are harder to find. Scala in Depth bridges that gap,
-preparing you to adopt Scala successfully for real world projects. Scala
-in Depth is a unique new book designed to help you integrate Scala
-effectively into your development process. By presenting the emerging
-best practices and designs from the Scala community, it guides you
-though dozens of powerful techniques example by example. There's no
-heavy-handed theory here-just lots of crisp, practical guides for coding
-in Scala."
-
-  </div>
-</div>
-
 <br />
 
 [**Scala in Action**](http://www.manning.com/raychaudhuri)
@@ -151,15 +111,16 @@ you'll learn to build DSLs and other productivity tools."
 <br />
 
 [**Programming
-Scala**](http://oreilly.com/catalog/9780596157746/)
-– **Available Now**
+Scala**](http://shop.oreilly.com/product/0636920033073.do)
+– **Updated for Scala 2.11**
 by Alex Payne and Dean Wampler
-- also [available for free online reading](http://ofps.oreilly.com/titles/9780596155957/)
+
+Published by [O'Reilly](http://www.oreilly.com):
 
 <div class="row">
   <div class="span2">
     <div align="center">
-    <a href="http://oreilly.com/catalog/9780596157746/">
+    <a href="http://shop.oreilly.com/product/0636920033073.do">
       <img src="/resources/img/books/ProgrammingScala-final-border.gif" alt="">
     </a>
     </div>
@@ -182,30 +143,58 @@ practical needs of enterprise and Internet projects more easily."
   </div>
 </div>
 
-<br/>
+<br />
 
-[**Programming
-Scala**](http://www.pragprog.com/titles/vsscala/programming-scala)
-– **Available Now**
-Tackle Multi-Core Complexity on the Java Virtual Machine
-by Venkat Subramaniam
+[**Functional Programming in
+Scala**](https://www.manning.com/books/functional-programming-in-scala)
+– **Available now**
+by Paul Chiusano and Rúnar Bjarnason
+
+Published by [Manning](http://www.manning.com):
 
 <div class="row">
   <div class="span2">
     <div align="center">
-    <a href="http://www.pragprog.com/titles/vsscala/programming-scala">
-      <img src="/resources/img/books/ProgrammingScala.gif" alt="">
+    <a href="https://www.manning.com/books/functional-programming-in-scala">
+      <img src="/resources/img/books/FPiS_93x116.png" alt="">
     </a>
     </div>
   </div>
   <div class="span8" style="padding-top: 15px;">
 
-According to the publisher, The Pragmatic Programmers:
+"Functional programming (FP) is a style of software development emphasizing functions that don't depend on program state... <i>Functional Programming in Scala</i> is a serious tutorial for programmers looking to learn FP and apply it to the everyday business of coding. The book guides readers from basic techniques to advanced topics in a logical, concise, and clear progression. In it, you'll find concrete examples and exercises that open up the world of functional programming."
+  </div>
+</div>
 
-“Programming Scala will show you the fundamentals of functional
-programming using Scala. Very quickly, you’ll learn how this statically
-typed language can give you dynamic capabilities to create concise,
-scalable, highly capable concurrent code.”
+<br/>
+
+[**Scala in Depth**](http://www.manning.com/suereth)
+– **Available Now**
+by Joshua D. Suereth
+
+Published by [Manning](http://www.manning.com):
+
+
+<div class="row">
+  <div class="span2">
+    <div align="center">
+    <a href="http://www.manning.com/suereth">
+      <img src="/resources/img/books/icon_Scala_in_Depth_93x116.png" alt="">
+    </a>
+    </div>
+  </div>
+  <div class="span8" style="padding-top: 15px;">
+
+"While information about the Scala language is abundant, skilled
+practitioners, great examples, and insight into the best practices of
+the community are harder to find. Scala in Depth bridges that gap,
+preparing you to adopt Scala successfully for real world projects. Scala
+in Depth is a unique new book designed to help you integrate Scala
+effectively into your development process. By presenting the emerging
+best practices and designs from the Scala community, it guides you
+though dozens of powerful techniques example by example. There's no
+heavy-handed theory here-just lots of crisp, practical guides for coding
+in Scala."
 
   </div>
 </div>
@@ -235,129 +224,3 @@ Scala Puzzlers is a collection of such examples in Scala. It is not only an ente
   </div>
 </div>
 
-<br />
-
-
-[**Learning Concurrent Programming in Scala**](https://www.packtpub.com/application-development/learning-concurrent-programming-scala)
-– **Available Now**
-by Aleksandar Prokopec
-
-Published by [Packt Publishing](https://www.packtpub.com/):
-
-<div class="row">
-  <div class="span2">
-    <div align="center">
-    <a href="https://www.packtpub.com/application-development/learning-concurrent-programming-scala">
-      <img src="/resources/img/books/learningConcurrentProgrammingCover120x149.jpg" alt="">
-    </a>
-    </div>
-  </div>
-  <div class="span8" style="padding-top: 15px;">
-
-"This book is a must-have tutorial for software developers aiming to write concurrent programs in Scala, or broaden their existing knowledge of concurrency. It will give you an insight into the best practices necessary to build concurrent programs in Scala using modern, high-level concurrency libraries. It starts by introducing you to the foundations of concurrent programming on the JVM, outlining the basics of the Java Memory Model, and then shows some of the classic building blocks of concurrency, such as the atomic variables, thread pools, and concurrent data structures, along with the caveats of traditional concurrency. It then walks you through different high-level concurrency abstractions, each tailored toward a specific class of programming tasks. Finally, the book presents an overview of when to use which concurrency library and demonstrates how they all work together."
-  </div>
-</div>
-
-<br />
-
-[**Scala for Data Science**](https://www.packtpub.com/big-data-and-business-intelligence/scala-data-science/?utm_source=&utm_medium=pod&utm_campaign=1785281372)
-– **Available Now**
-by Pascal Bugnion
-
-Published by [Packt Publishing](https://www.packtpub.com/):
-
-<div class="row">
-  <div class="span2">
-    <div align="center">
-    <a href="https://www.packtpub.com/big-data-and-business-intelligence/scala-data-science/?utm_source=&utm_medium=pod&utm_campaign=1785281372">
-      <img src="/resources/img/books/scalaForDataScience.jpg" alt="">
-    </a>
-    </div>
-  </div>
-  <div class="span8" style="padding-top: 15px;">
-
-"This book will introduce you to the libraries for ingesting, storing, manipulating, processing, and visualizing data in Scala. Packed with real-world examples and interesting data sets, this book will teach you to ingest data from flat files and web APIs and store it in a SQL or NoSQL database. It will show you how to design scalable architectures to process and modelling your data, starting from simple concurrency constructs such as parallel collections and futures, through to actor systems and Apache Spark. [...] Finally, you will learn how to build beautiful interactive visualizations using web frameworks."
-
-  </div>
-</div>
-
-<br />
-
-
-[**Building a Recommendation Engine with Scala**](https://www.packtpub.com/application-development/building-recommendation-engine-scala/)
-– **Available Now**
-by Saleem A. Ansari
-
-Published by [Packt Publishing](https://www.packtpub.com/):
-
-<div class="row">
-  <div class="span2">
-    <div align="center">
-    <a href="https://www.packtpub.com/application-development/building-recommendation-engine-scala/">
-      <img src="/resources/img/books/buildingRecommendationEngine.jpg" alt="">
-    </a>
-    </div>
-  </div>
-  <div class="span8" style="padding-top: 15px;">
-
-"This book provides you with the Scala knowledge you need to build a recommendation engine. You'll be introduced to Scala and other related tools to set the stage for the project and familiarise yourself with the different stages in the data processing pipeline \[...\] You'll also discover different machine learning algorithms using MLLib."
-  </div>
-</div>
-
-<br />
-
-
-[**Beginning
-Scala**](http://www.apress.com/book/view/9781430219897)
-– **Available Now**
-by David Pollak.
-
-
-[**Steps in
-Scala**](http://www.cambridge.org/uk/catalogue/catalogue.asp?isbn=9780521747585)
-– **Available Now**
-Introduction to Object-Functional Programming
-by Christos KK Loverdos and Apostolos Syropoulos
-
-
-[**Functional Programming in
-Scala**](http://manning.com/bjarnason)
-– **Early access MEAP available now**
-by Rúnar Bjarnason, Paul Chiusano, and Tony Morris
-
-
-### Non-English Scala Books
-
-[**Durchstarten mit
-Scala**](http://entwickler-press.de/ep/psecom,id,2,buchid,224.html)
-- **Available Now**
-by Heiko Seeberger and Roman Roelofsen
-
-Published by [entwickler.press](http://entwickler-press.de):
-
-<div class="row">
-  <div class="span2">
-    <div align="center">
-    <a href="http://entwickler-press.de/ep/psecom,id,2,buchid,224.html">
-      <img src="/resources/img/books/heiko_117x82.jpg" alt="">
-    </a>
-    </div>
-  </div>
-  <div class="span8" style="padding-top: 15px;">
-
-"Dieses Buch bietet allen Scala-Interessierten und Einsteigern einen
-praxisnahen und zielgerichteten Weg, um Scala zu lernen. Dabei legen die
-Autoren den Fokus bewusst auf die Praxis der Softwareentwicklung, um dem
-Leser die Vorteile von Scala möglichst direkt näher zu bringen. Im
-Rahmen eines durchgängigen Fallbeispiels wird der gesamte Zyklus der
-Softwareentwicklung abgedeckt, vom Einrichten der Entwicklungsumgebung
-über "Debugging" mit dem interaktiven Interpreter (REPL) und
-testgetriebener Entwicklung unter Verwendung von Test-Bibliotheken bis
-hin zur Integration in Java EE Umgebungen. Selbstverständlich wird der
-Leser dabei Schritt für Schritt mit allen Grundlagen von Scala vertraut
-gemacht, sodass er nach der Lektüre dieses Buches das nötige Rüstzeug
-für eigene Scala-Projekte hat."
-
-  </div>
-</div>
-<br />

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -70,7 +70,7 @@ There are a few interactive resources for trying out Scala, to get a look and fe
 
 ## Books
 
-There are more and more books being published about Scala. [Here]({{ site.baseurl  }}/documentation/books.html), you can find some of the titles. We only list books here which give an introduction to the Scala Language. Books which require knowledge of Scala, in particular books on frameworks like Lift, Play! or Akka are not listed here.
+There are more and more books being published about Scala. [Here]({{ site.baseurl  }}/documentation/books.html), you can find just a small selection of the many available titles.
 
 
 ## Bleeding Edge


### PR DESCRIPTION
keeping the page up to date is too much work.
so this commit makes the criteria more stringent: general books
about Scala for a general audience only, in English only, and only if a recent
edition exists.

I removed some outdated and/or not-general-enough books, and I updated
a couple entries (the Payne/Wampler and the Chiusano/Bjarnason).

even so, I can think of at least two important books still missing:
"Atomic Scala" and "Scala Cookbook". sigh