### PR TITLE
be clearer that Scala license is standard 3-clause BSD

### DIFF
--- a/license.md
+++ b/license.md
@@ -3,6 +3,10 @@ layout: page-no-toc
 title: Scala License
 ---
 
+Scala is licensed under the [BSD 3-Clause License](http://opensource.org/licenses/BSD-3-Clause).
+
+## Scala License
+
 Copyright (c) 2002-<span class="current-year">&nbsp;</span> EPFL<br>
 Copyright (c) 2011-<span class="current-year">&nbsp;</span> Lightbend, Inc. (formerly Typesafe, Inc.)
 


### PR DESCRIPTION
the same wording appears in
https://github.com/scala/scala/blob/2.12.x/doc/LICENSE.md