### PR TITLE
Update Ensime's contributing and readme page

### DIFF
--- a/contribute/tools.md
+++ b/contribute/tools.md
@@ -76,8 +76,8 @@ Stuff changes. Found a broken link or something that needs updating on this page
 <p>Scala Support for Text Editors</p>
 <p><a href="http://ensime.github.io">Home</a> | 
 <a href="https://github.com/ensime/ensime-server/issues">Issues</a> | 
-<a href="https://github.com/ensime/ensime-server/blob/master/README.md">ReadMe</a> | 
-<a href="https://github.com/ensime/ensime-server/blob/master/README.md#contributions">Contributing</a></p>
+<a href="https://github.com/ensime/ensime-server/blob/2.0/README.md">ReadMe</a> | 
+<a href="https://ensime.github.io/contributing/">Contributing</a></p>
 </div>
 </div>
 


### PR DESCRIPTION
Hello,

I was browsing on scala's site and found some broken links. Thought I want to contribute.

The current "readme" and "contributing" links on Ensime gives us a standard Github 404 page. This commit updates the links to valid URLs.

If there's something not right with this commit please tell me so I can update it. Thanks before.