### PR TITLE
Fixed external link on training

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -417,7 +417,7 @@ $(document).ready(function(){
         result.push({
           title: training.title,
           description: training.description,
-          url: session.url,
+          url: training.url,
           where: session.where,
           when: session.when,
           trainers: session.trainers,


### PR DESCRIPTION
For training events the external link is being lost as its was looking in 'session' not 'training' where its being stored. 

NOTE: I dont get Lightbend training events when I run everything locally. So cant check this hasn't broken everything coming from this feed.
