### PR TITLE
Fixes Lightbend training links

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -393,13 +393,13 @@ $(document).ready(function(){
     {
       title: "{{ training.title }}",
       description: "{{ training.description }}",
-      url: "{{ training.link-out }}",
       sessions: [
         {
           where: "{{ training.where }}",
           when: "{{ training.when }}",
           trainers: "{{ training.trainers }}",
           organizer: "{{ training.organizer }}",
+          url: "{{ training.link-out }}",
           status: "{{ training.status }}"
         }
       ]
@@ -417,7 +417,7 @@ $(document).ready(function(){
         result.push({
           title: training.title,
           description: training.description,
-          url: training.url,
+          url: session.url,
           where: session.where,
           when: session.when,
           trainers: session.trainers,


### PR DESCRIPTION
The previous 'fix' fixed the link for locally stored training events however broke the events coming from Lightbend. 
This now changed the local-events to look like the json ones

I think there are actually 2 problems
1) When 'category: event' was added to 'conference events', the 'training events' were not also updated and so they are appearing in news events. Adding this to local-training-events fixes the problem.  (this is the first non-LB event since the change)
2) this 'bug'
