### PR TITLE
reactive course does not exist anymore and redirects to the scala specialization

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -64,7 +64,12 @@ There are a few interactive resources for trying out Scala, to get a look and fe
 
  * [Functional Programming Principles in Scala](https://www.coursera.org/course/progfun), free on Coursera. This is a course about functional programming given by Martin Odersky himself. You can access the course material and exercises by
  signing up for the course.
- * [Principles of Reactive Programming](https://www.coursera.org/course/reactive), free on Coursera. This is a course about concurrency and event-based asynchronous programming in Scala. You can access the course material and exercises by signing up for the course.
+ * [Functional Programming in Scala Specialization](https://www.coursera.org/specializations/scala), free on Coursera. The Specialization provides a hands-on introduction to functional programming using Scala. You can access the courses material and exercises by signing up for the specialization. Includes the following courses:
+    * Functional Programming Principles in Scala
+    * Functional Program Design in Scala
+    * Parallel programming
+    * Big Data Analysis with Scala and Spark
+    * Functional Programming in Scala Capstone
  * **Try Scala In Your Browser!**: There are a handful of websites where you can interactively run Scala code in your browser! Have a look at [scala-js-fiddle](http://www.scala-js-fiddle.com/), [Scala Kata](http://www.scalakata.com/), and [Scastie](http://scastie.org/) for more.
  * [Independent Courseware](http://getscala.com), online self-study or instructor-led Scala and Play courses for a fee.
 


### PR DESCRIPTION
This PR is intending to fix a confusion in the documentation regarding the reactive course. Basically we need to remove references to the reactive course and list the new specialization.

Reactive course does not exist anymore (I can only see my certificate in my account).
The [https://www.coursera.org/course/reactive](https://www.coursera.org/course/reactive) link to the reactive course redirects to the new specialization [https://www.coursera.org/specializations/scala](https://www.coursera.org/specializations/scala).
I have contacted coursera and they verified that the old reactive course does not exist any more (maybe someone has more information regarding this)

@heathermiller I am wondering why they removed it, it would be nice to be able to see the course material again even if the course is not offered anymore.

In essence now we have the
1.  Functional Programming Principles in Scala course and 
2.  Functional Programming in Scala Specialization, it is comprised of 5 courses **including the above course**

We have the option to **only** list the specialization which includes anyway the Functional Programming Principles in Scala course as well instead of two references.

Please let me know what you think and I will apply changes accordingly.

Also see:
https://github.com/scala/scala-lang/pull/476