### PR TITLE
Fix Jekyll exit status for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,6 @@ install:
 - bundle install
 
 script:
-- bundle exec jekyll build
+- bundle exec jekyll build 2> error.log
+- cat >&2 error.log
+- ( ! grep -qie Error error.log )


### PR DESCRIPTION
Grep the output of Jekyll for errors since it returns zero exits with
YAML errors.  See jekyll/jekyll#5257.