### PR TITLE
Fail Travis builds if Jekyll outputs empty files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ script:
 - bundle exec jekyll build 2> error.log
 - cat >&2 error.log
 - ( ! grep -qie Error error.log )
+- find ./_site -empty ! -name error.log
+- find ./_site -empty ! -name error.log | ! read

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
 - bundle exec jekyll build 2> error.log
 - cat >&2 error.log
 - ( ! grep -qie Error error.log )
-- find ./_site -empty ! -name error.log
-- find ./_site -empty ! -name error.log | ! read
+- find ./_site \( -type d \( -name events -o -name training \) -prune -false \) -o \( -type f ! -name error.log -empty \)
+- find ./_site \( -type d \( -name events -o -name training \) -prune -false \) -o \( -type f ! -name error.log -empty \) | ( ! read )


### PR DESCRIPTION
While reading #516, it seemed to me that  checking for empty files might be useful.

Turns out it is.