### PR TITLE
Adding Scala workshops 

### DIFF
--- a/events/_posts/2017-05-22-advanced-functional-programming
+++ b/events/_posts/2017-05-22-advanced-functional-programming
@@ -1,0 +1,9 @@
+---
+category: event
+title: Advanced Functional Programming With Scala
+location: Boulder, CO
+description: Intensive, two-day workshop that teaches attendees to effectively use advanced features of Scala to develop large-scale, purely-functional programs.
+start: 22 May 2017
+end: 23 May 2017
+link-out: http://lambdaconf.us/training/lcusc/advanced-functional-programming-with-scala.html
+---

--- a/events/_posts/2017-05-22-mastering-apache-spark
+++ b/events/_posts/2017-05-22-mastering-apache-spark
@@ -1,3 +1,4 @@
+---
 category: event
 title: Mastering Apache Spark
 location: Boulder, CO
@@ -5,3 +6,4 @@ description: Extended workshop designed to familiarize attendees with Apache Spa
 start: 22 May 2017
 end: 23 May 2017
 link-out: http://lambdaconf.us/training/lcusc/mastering-apache-spark.html
+---

--- a/events/_posts/2017-05-22-mastering-apache-spark
+++ b/events/_posts/2017-05-22-mastering-apache-spark
@@ -1,0 +1,7 @@
+category: event
+title: Mastering Apache Spark
+location: Boulder, CO
+description: Extended workshop designed to familiarize attendees with Apache Spark.
+start: 22 May 2017
+end: 23 May 2017
+link-out: http://lambdaconf.us/training/lcusc/mastering-apache-spark.html


### PR DESCRIPTION
These files add two workshops happening right before LamdbaConf 2017.
http://lambdaconf.us/training/lcusc/mastering-apache-spark.html
http://lambdaconf.us/training/lcusc/advanced-functional-programming-with-scala.html