### PR TITLE
Change all HTTP links to HTTPS

### DIFF
--- a/download/_posts/2014-01-28-2.11.0-M8.md
+++ b/download/_posts/2014-01-28-2.11.0-M8.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.0-M8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-M8.tgz", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.tgz", "Mac OS X, Unix, Cygwin", "28.32M"],
-  ["-main-windows", "scala-2.11.0-M8.msi", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.msi", "Windows (msi installer)", "91.31M"],
-  ["-non-main-sys", "scala-2.11.0-M8.zip", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.zip", "Windows", "28.33M"],
-  ["-non-main-sys", "scala-2.11.0-M8.deb", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.deb", "Debian", "90.37M"],
-  ["-non-main-sys", "scala-2.11.0-M8.rpm", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.rpm", "RPM package", "90.36M"],
-  ["-non-main-sys", "scala-docs-2.11.0-M8.txz", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-docs-2.11.0-M8.txz", "API docs", "35.22M"],
-  ["-non-main-sys", "scala-docs-2.11.0-M8.zip", "http://downloads.lightbend.com/scala/2.11.0-M8/scala-docs-2.11.0-M8.zip", "API docs", "65.30M"],
+  ["-main-unixsys", "scala-2.11.0-M8.tgz", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.tgz", "Mac OS X, Unix, Cygwin", "28.32M"],
+  ["-main-windows", "scala-2.11.0-M8.msi", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.msi", "Windows (msi installer)", "91.31M"],
+  ["-non-main-sys", "scala-2.11.0-M8.zip", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.zip", "Windows", "28.33M"],
+  ["-non-main-sys", "scala-2.11.0-M8.deb", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.deb", "Debian", "90.37M"],
+  ["-non-main-sys", "scala-2.11.0-M8.rpm", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.rpm", "RPM package", "90.36M"],
+  ["-non-main-sys", "scala-docs-2.11.0-M8.txz", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-docs-2.11.0-M8.txz", "API docs", "35.22M"],
+  ["-non-main-sys", "scala-docs-2.11.0-M8.zip", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-docs-2.11.0-M8.zip", "API docs", "65.30M"],
   ["-non-main-sys", "scala-sources-2.11.0-M8.zip", "https://github.com/scala/scala/archive/v2.11.0-M8.tar.gz", "sources", ""]
 ]
 

--- a/download/_posts/2014-03-06-2.11.0-RC1.md
+++ b/download/_posts/2014-03-06-2.11.0-RC1.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-RC1.tgz", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "24.73M"],
-  ["-main-windows", "scala-2.11.0-RC1.msi", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.msi", "Windows (msi installer)", "88.88M"],
-  ["-non-main-sys", "scala-2.11.0-RC1.zip", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.zip", "Windows", "24.74M"],
-  ["-non-main-sys", "scala-2.11.0-RC1.deb", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.deb", "Debian", "87.87M"],
-  ["-non-main-sys", "scala-2.11.0-RC1.rpm", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.rpm", "RPM package", "87.86M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC1.txz", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-docs-2.11.0-RC1.txz", "API docs", "36.02M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC1.zip", "http://downloads.lightbend.com/scala/2.11.0-RC1/scala-docs-2.11.0-RC1.zip", "API docs", "66.52M"],
+  ["-main-unixsys", "scala-2.11.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "24.73M"],
+  ["-main-windows", "scala-2.11.0-RC1.msi", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.msi", "Windows (msi installer)", "88.88M"],
+  ["-non-main-sys", "scala-2.11.0-RC1.zip", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.zip", "Windows", "24.74M"],
+  ["-non-main-sys", "scala-2.11.0-RC1.deb", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.deb", "Debian", "87.87M"],
+  ["-non-main-sys", "scala-2.11.0-RC1.rpm", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.rpm", "RPM package", "87.86M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC1.txz", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-docs-2.11.0-RC1.txz", "API docs", "36.02M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC1.zip", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-docs-2.11.0-RC1.zip", "API docs", "66.52M"],
   ["-non-main-sys", "scala-sources-2.11.0-RC1.zip", "https://github.com/scala/scala/archive/v2.11.0-RC1.tar.gz", "sources", ""]
 ]
 ---

--- a/download/_posts/2014-03-20-2.11.0-RC3.md
+++ b/download/_posts/2014-03-20-2.11.0-RC3.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.0-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-RC3.tgz", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "24.77M"],
-  ["-main-windows", "scala-2.11.0-RC3.msi", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.msi", "Windows (msi installer)", "88.95M"],
-  ["-non-main-sys", "scala-2.11.0-RC3.zip", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.zip", "Windows", "24.79M"],
-  ["-non-main-sys", "scala-2.11.0-RC3.deb", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.deb", "Debian", "87.98M"],
-  ["-non-main-sys", "scala-2.11.0-RC3.rpm", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.rpm", "RPM package", "87.96M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC3.txz", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-docs-2.11.0-RC3.txz", "API docs", "36.10M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC3.zip", "http://downloads.lightbend.com/scala/2.11.0-RC3/scala-docs-2.11.0-RC3.zip", "API docs", "66.59M"],
+  ["-main-unixsys", "scala-2.11.0-RC3.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "24.77M"],
+  ["-main-windows", "scala-2.11.0-RC3.msi", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.msi", "Windows (msi installer)", "88.95M"],
+  ["-non-main-sys", "scala-2.11.0-RC3.zip", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.zip", "Windows", "24.79M"],
+  ["-non-main-sys", "scala-2.11.0-RC3.deb", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.deb", "Debian", "87.98M"],
+  ["-non-main-sys", "scala-2.11.0-RC3.rpm", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.rpm", "RPM package", "87.96M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC3.txz", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-docs-2.11.0-RC3.txz", "API docs", "36.10M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC3.zip", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-docs-2.11.0-RC3.zip", "API docs", "66.59M"],
   ["-non-main-sys", "scala-sources-2.11.0-RC3.zip", "https://github.com/scala/scala/archive/v2.11.0-RC3.tar.gz", "sources", ""]
 ]
 ---

--- a/download/_posts/2014-04-08-2.11.0-RC4.md
+++ b/download/_posts/2014-04-08-2.11.0-RC4.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.0-RC4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0-RC4.tgz", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.tgz", "Mac OS X, Unix, Cygwin", "24.79M"],
-  ["-main-windows", "scala-2.11.0-RC4.msi", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.msi", "Windows (msi installer)", "89.02M"],
-  ["-non-main-sys", "scala-2.11.0-RC4.zip", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.zip", "Windows", "24.81M"],
-  ["-non-main-sys", "scala-2.11.0-RC4.deb", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.deb", "Debian", "88.05M"],
-  ["-non-main-sys", "scala-2.11.0-RC4.rpm", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.rpm", "RPM package", "88.03M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC4.txz", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-docs-2.11.0-RC4.txz", "API docs", "36.12M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC4.zip", "http://downloads.lightbend.com/scala/2.11.0-RC4/scala-docs-2.11.0-RC4.zip", "API docs", "66.63M"],
+  ["-main-unixsys", "scala-2.11.0-RC4.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.tgz", "Mac OS X, Unix, Cygwin", "24.79M"],
+  ["-main-windows", "scala-2.11.0-RC4.msi", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.msi", "Windows (msi installer)", "89.02M"],
+  ["-non-main-sys", "scala-2.11.0-RC4.zip", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.zip", "Windows", "24.81M"],
+  ["-non-main-sys", "scala-2.11.0-RC4.deb", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.deb", "Debian", "88.05M"],
+  ["-non-main-sys", "scala-2.11.0-RC4.rpm", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.rpm", "RPM package", "88.03M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC4.txz", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-docs-2.11.0-RC4.txz", "API docs", "36.12M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC4.zip", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-docs-2.11.0-RC4.zip", "API docs", "66.63M"],
   ["-non-main-sys", "scala-sources-2.11.0-RC4.zip", "https://github.com/scala/scala/archive/v2.11.0-RC4.tar.gz", "sources", ""]
 ]
 ---

--- a/download/_posts/2014-04-21-2.11.0.md
+++ b/download/_posts/2014-04-21-2.11.0.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.0.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.0.tgz", "http://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.tgz", "Mac OS X, Unix, Cygwin", "24.80M"],
-  ["-main-windows", "scala-2.11.0.msi", "http://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.msi", "Windows (msi installer)", "89.00M"],
-  ["-non-main-sys", "scala-2.11.0.zip", "http://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.zip", "Windows", "24.81M"],
-  ["-non-main-sys", "scala-2.11.0.deb", "http://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.deb", "Debian", "88.03M"],
-  ["-non-main-sys", "scala-2.11.0.rpm", "http://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.rpm", "RPM package", "88.03M"],
-  ["-non-main-sys", "scala-docs-2.11.0.txz", "http://downloads.lightbend.com/scala/2.11.0/scala-docs-2.11.0.txz", "API docs", "35.95M"],
-  ["-non-main-sys", "scala-docs-2.11.0.zip", "http://downloads.lightbend.com/scala/2.11.0/scala-docs-2.11.0.zip", "API docs", "66.59M"],
+  ["-main-unixsys", "scala-2.11.0.tgz", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.tgz", "Mac OS X, Unix, Cygwin", "24.80M"],
+  ["-main-windows", "scala-2.11.0.msi", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.msi", "Windows (msi installer)", "89.00M"],
+  ["-non-main-sys", "scala-2.11.0.zip", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.zip", "Windows", "24.81M"],
+  ["-non-main-sys", "scala-2.11.0.deb", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.deb", "Debian", "88.03M"],
+  ["-non-main-sys", "scala-2.11.0.rpm", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.rpm", "RPM package", "88.03M"],
+  ["-non-main-sys", "scala-docs-2.11.0.txz", "https://downloads.lightbend.com/scala/2.11.0/scala-docs-2.11.0.txz", "API docs", "35.95M"],
+  ["-non-main-sys", "scala-docs-2.11.0.zip", "https://downloads.lightbend.com/scala/2.11.0/scala-docs-2.11.0.zip", "API docs", "66.59M"],
   ["-non-main-sys", "scala-sources-2.11.0.zip", "https://github.com/scala/scala/archive/v2.11.0.tar.gz", "sources", ""]
 ]
 ---

--- a/download/_posts/2014-05-21-2.11.1.md
+++ b/download/_posts/2014-05-21-2.11.1.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.1.tgz", "http://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.tgz", "Mac OS X, Unix, Cygwin", "24.50M"],
-  ["-main-windows", "scala-2.11.1.msi", "http://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.msi", "Windows (msi installer)", "93.05M"],
-  ["-non-main-sys", "scala-2.11.1.zip", "http://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.zip", "Windows", "24.51M"],
-  ["-non-main-sys", "scala-2.11.1.deb", "http://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.deb", "Debian", "92.01M"],
-  ["-non-main-sys", "scala-2.11.1.rpm", "http://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.rpm", "RPM package", "91.98M"],
-  ["-non-main-sys", "scala-docs-2.11.1.txz", "http://downloads.lightbend.com/scala/2.11.1/scala-docs-2.11.1.txz", "API docs", "39.51M"],
-  ["-non-main-sys", "scala-docs-2.11.1.zip", "http://downloads.lightbend.com/scala/2.11.1/scala-docs-2.11.1.zip", "API docs", "70.83M"],
+  ["-main-unixsys", "scala-2.11.1.tgz", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.tgz", "Mac OS X, Unix, Cygwin", "24.50M"],
+  ["-main-windows", "scala-2.11.1.msi", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.msi", "Windows (msi installer)", "93.05M"],
+  ["-non-main-sys", "scala-2.11.1.zip", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.zip", "Windows", "24.51M"],
+  ["-non-main-sys", "scala-2.11.1.deb", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.deb", "Debian", "92.01M"],
+  ["-non-main-sys", "scala-2.11.1.rpm", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.rpm", "RPM package", "91.98M"],
+  ["-non-main-sys", "scala-docs-2.11.1.txz", "https://downloads.lightbend.com/scala/2.11.1/scala-docs-2.11.1.txz", "API docs", "39.51M"],
+  ["-non-main-sys", "scala-docs-2.11.1.zip", "https://downloads.lightbend.com/scala/2.11.1/scala-docs-2.11.1.zip", "API docs", "70.83M"],
   ["-non-main-sys", "scala-sources-2.11.1.tar.gz", "https://github.com/scala/scala/archive/v2.11.1.tar.gz", "sources", ""]
 ]
 ---

--- a/download/_posts/2014-07-24-2.11.2.md
+++ b/download/_posts/2014-07-24-2.11.2.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.2.tgz", "http://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.tgz", "Mac OS X, Unix, Cygwin", "25.26M"],
-  ["-main-windows", "scala-2.11.2.msi", "http://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.msi", "Windows (msi installer)", "95.03M"],
-  ["-non-main-sys", "scala-2.11.2.zip", "http://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.zip", "Windows", "25.27M"],
-  ["-non-main-sys", "scala-2.11.2.deb", "http://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.deb", "Debian", "94.00M"],
-  ["-non-main-sys", "scala-2.11.2.rpm", "http://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.rpm", "RPM package", "93.96M"],
-  ["-non-main-sys", "scala-docs-2.11.2.txz", "http://downloads.lightbend.com/scala/2.11.2/scala-docs-2.11.2.txz", "API docs", "40.48M"],
-  ["-non-main-sys", "scala-docs-2.11.2.zip", "http://downloads.lightbend.com/scala/2.11.2/scala-docs-2.11.2.zip", "API docs", "72.06M"],
+  ["-main-unixsys", "scala-2.11.2.tgz", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.tgz", "Mac OS X, Unix, Cygwin", "25.26M"],
+  ["-main-windows", "scala-2.11.2.msi", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.msi", "Windows (msi installer)", "95.03M"],
+  ["-non-main-sys", "scala-2.11.2.zip", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.zip", "Windows", "25.27M"],
+  ["-non-main-sys", "scala-2.11.2.deb", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.deb", "Debian", "94.00M"],
+  ["-non-main-sys", "scala-2.11.2.rpm", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.rpm", "RPM package", "93.96M"],
+  ["-non-main-sys", "scala-docs-2.11.2.txz", "https://downloads.lightbend.com/scala/2.11.2/scala-docs-2.11.2.txz", "API docs", "40.48M"],
+  ["-non-main-sys", "scala-docs-2.11.2.zip", "https://downloads.lightbend.com/scala/2.11.2/scala-docs-2.11.2.zip", "API docs", "72.06M"],
   ["-non-main-sys", "scala-sources-2.11.2.tar.gz", "https://github.com/scala/scala/archive/v2.11.2.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2014-10-30-2.11.4.md
+++ b/download/_posts/2014-10-30-2.11.4.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.4.tgz", "http://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.tgz", "Mac OS X, Unix, Cygwin", "25.28M"],
-  ["-main-windows", "scala-2.11.4.msi", "http://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.msi", "Windows (msi installer)", "95.22M"],
-  ["-non-main-sys", "scala-2.11.4.zip", "http://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.zip", "Windows", "25.29M"],
-  ["-non-main-sys", "scala-2.11.4.deb", "http://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.deb", "Debian", "94.18M"],
-  ["-non-main-sys", "scala-2.11.4.rpm", "http://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.rpm", "RPM package", "94.14M"],
-  ["-non-main-sys", "scala-docs-2.11.4.txz", "http://downloads.lightbend.com/scala/2.11.4/scala-docs-2.11.4.txz", "API docs", "40.59M"],
-  ["-non-main-sys", "scala-docs-2.11.4.zip", "http://downloads.lightbend.com/scala/2.11.4/scala-docs-2.11.4.zip", "API docs", "72.24M"],
+  ["-main-unixsys", "scala-2.11.4.tgz", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.tgz", "Mac OS X, Unix, Cygwin", "25.28M"],
+  ["-main-windows", "scala-2.11.4.msi", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.msi", "Windows (msi installer)", "95.22M"],
+  ["-non-main-sys", "scala-2.11.4.zip", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.zip", "Windows", "25.29M"],
+  ["-non-main-sys", "scala-2.11.4.deb", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.deb", "Debian", "94.18M"],
+  ["-non-main-sys", "scala-2.11.4.rpm", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.rpm", "RPM package", "94.14M"],
+  ["-non-main-sys", "scala-docs-2.11.4.txz", "https://downloads.lightbend.com/scala/2.11.4/scala-docs-2.11.4.txz", "API docs", "40.59M"],
+  ["-non-main-sys", "scala-docs-2.11.4.zip", "https://downloads.lightbend.com/scala/2.11.4/scala-docs-2.11.4.zip", "API docs", "72.24M"],
   ["-non-main-sys", "scala-sources-2.11.4.tar.gz", "https://github.com/scala/scala/archive/v2.11.4.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-01-14-2.11.5.md
+++ b/download/_posts/2015-01-14-2.11.5.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.5.tgz", "http://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.tgz", "Mac OS X, Unix, Cygwin", "25.88M"],
-  ["-main-windows", "scala-2.11.5.msi", "http://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.msi", "Windows (msi installer)", "107.77M"],
-  ["-non-main-sys", "scala-2.11.5.zip", "http://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.zip", "Windows", "25.93M"],
-  ["-non-main-sys", "scala-2.11.5.deb", "http://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.deb", "Debian", "74.62M"],
-  ["-non-main-sys", "scala-2.11.5.rpm", "http://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.rpm", "RPM package", "106.63M"],
-  ["-non-main-sys", "scala-docs-2.11.5.txz", "http://downloads.lightbend.com/scala/2.11.5/scala-docs-2.11.5.txz", "API docs", "45.95M"],
-  ["-non-main-sys", "scala-docs-2.11.5.zip", "http://downloads.lightbend.com/scala/2.11.5/scala-docs-2.11.5.zip", "API docs", "83.94M"],
+  ["-main-unixsys", "scala-2.11.5.tgz", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.tgz", "Mac OS X, Unix, Cygwin", "25.88M"],
+  ["-main-windows", "scala-2.11.5.msi", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.msi", "Windows (msi installer)", "107.77M"],
+  ["-non-main-sys", "scala-2.11.5.zip", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.zip", "Windows", "25.93M"],
+  ["-non-main-sys", "scala-2.11.5.deb", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.deb", "Debian", "74.62M"],
+  ["-non-main-sys", "scala-2.11.5.rpm", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.rpm", "RPM package", "106.63M"],
+  ["-non-main-sys", "scala-docs-2.11.5.txz", "https://downloads.lightbend.com/scala/2.11.5/scala-docs-2.11.5.txz", "API docs", "45.95M"],
+  ["-non-main-sys", "scala-docs-2.11.5.zip", "https://downloads.lightbend.com/scala/2.11.5/scala-docs-2.11.5.zip", "API docs", "83.94M"],
   ["-non-main-sys", "scala-sources-2.11.5.tar.gz", "https://github.com/scala/scala/archive/v2.11.5.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-03-05-2.10.5.md
+++ b/download/_posts/2015-03-05-2.10.5.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.10.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.5.tgz", "http://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.tgz", "Mac OS X, Unix, Cygwin", "28.54M"],
-  ["-main-windows", "scala-2.10.5.msi", "http://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.msi", "Windows (msi installer)", "60.02M"],
-  ["-non-main-sys", "scala-2.10.5.zip", "http://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.zip", "Windows", "28.63M"],
-  ["-non-main-sys", "scala-2.10.5.deb", "http://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.deb", "Debian", "24.50M"],
-  ["-non-main-sys", "scala-2.10.5.rpm", "http://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.rpm", "RPM package", "24.86M"],
-  ["-non-main-sys", "scala-docs-2.10.5.txz", "http://downloads.lightbend.com/scala/2.10.5/scala-docs-2.10.5.txz", "API docs", "3.66M"],
-  ["-non-main-sys", "scala-docs-2.10.5.zip", "http://downloads.lightbend.com/scala/2.10.5/scala-docs-2.10.5.zip", "API docs", "32.45M"],
+  ["-main-unixsys", "scala-2.10.5.tgz", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.tgz", "Mac OS X, Unix, Cygwin", "28.54M"],
+  ["-main-windows", "scala-2.10.5.msi", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.msi", "Windows (msi installer)", "60.02M"],
+  ["-non-main-sys", "scala-2.10.5.zip", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.zip", "Windows", "28.63M"],
+  ["-non-main-sys", "scala-2.10.5.deb", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.deb", "Debian", "24.50M"],
+  ["-non-main-sys", "scala-2.10.5.rpm", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.rpm", "RPM package", "24.86M"],
+  ["-non-main-sys", "scala-docs-2.10.5.txz", "https://downloads.lightbend.com/scala/2.10.5/scala-docs-2.10.5.txz", "API docs", "3.66M"],
+  ["-non-main-sys", "scala-docs-2.10.5.zip", "https://downloads.lightbend.com/scala/2.10.5/scala-docs-2.10.5.zip", "API docs", "32.45M"],
   ["-non-main-sys", "scala-sources-2.10.5.tar.gz", "https://github.com/scala/scala/archive/v2.10.5.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-03-05-2.11.6.md
+++ b/download/_posts/2015-03-05-2.11.6.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.6.tgz", "http://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.tgz", "Mac OS X, Unix, Cygwin", "25.87M"],
-  ["-main-windows", "scala-2.11.6.msi", "http://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.msi", "Windows (msi installer)", "107.88M"],
-  ["-non-main-sys", "scala-2.11.6.zip", "http://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.zip", "Windows", "25.92M"],
-  ["-non-main-sys", "scala-2.11.6.deb", "http://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.deb", "Debian", "74.54M"],
-  ["-non-main-sys", "scala-2.11.6.rpm", "http://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.rpm", "RPM package", "106.73M"],
-  ["-non-main-sys", "scala-docs-2.11.6.txz", "http://downloads.lightbend.com/scala/2.11.6/scala-docs-2.11.6.txz", "API docs", "45.93M"],
-  ["-non-main-sys", "scala-docs-2.11.6.zip", "http://downloads.lightbend.com/scala/2.11.6/scala-docs-2.11.6.zip", "API docs", "84.06M"],
+  ["-main-unixsys", "scala-2.11.6.tgz", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.tgz", "Mac OS X, Unix, Cygwin", "25.87M"],
+  ["-main-windows", "scala-2.11.6.msi", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.msi", "Windows (msi installer)", "107.88M"],
+  ["-non-main-sys", "scala-2.11.6.zip", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.zip", "Windows", "25.92M"],
+  ["-non-main-sys", "scala-2.11.6.deb", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.deb", "Debian", "74.54M"],
+  ["-non-main-sys", "scala-2.11.6.rpm", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.rpm", "RPM package", "106.73M"],
+  ["-non-main-sys", "scala-docs-2.11.6.txz", "https://downloads.lightbend.com/scala/2.11.6/scala-docs-2.11.6.txz", "API docs", "45.93M"],
+  ["-non-main-sys", "scala-docs-2.11.6.zip", "https://downloads.lightbend.com/scala/2.11.6/scala-docs-2.11.6.zip", "API docs", "84.06M"],
   ["-non-main-sys", "scala-sources-2.11.6.tar.gz", "https://github.com/scala/scala/archive/v2.11.6.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-05-05-2.12.0-M1.md
+++ b/download/_posts/2015-05-05-2.12.0-M1.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-M1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M1.tgz", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.tgz", "Mac OS X, Unix, Cygwin", "23.85M"],
-  ["-main-windows", "scala-2.12.0-M1.msi", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.msi", "Windows (msi installer)", "102.77M"],
-  ["-non-main-sys", "scala-2.12.0-M1.zip", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.zip", "Windows", "23.90M"],
-  ["-non-main-sys", "scala-2.12.0-M1.deb", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.deb", "Debian", "70.35M"],
-  ["-non-main-sys", "scala-2.12.0-M1.rpm", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.rpm", "RPM package", "101.61M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M1.txz", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-docs-2.12.0-M1.txz", "API docs", "43.72M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M1.zip", "http://downloads.lightbend.com/scala/2.12.0-M1/scala-docs-2.12.0-M1.zip", "API docs", "81.12M"],
+  ["-main-unixsys", "scala-2.12.0-M1.tgz", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.tgz", "Mac OS X, Unix, Cygwin", "23.85M"],
+  ["-main-windows", "scala-2.12.0-M1.msi", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.msi", "Windows (msi installer)", "102.77M"],
+  ["-non-main-sys", "scala-2.12.0-M1.zip", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.zip", "Windows", "23.90M"],
+  ["-non-main-sys", "scala-2.12.0-M1.deb", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.deb", "Debian", "70.35M"],
+  ["-non-main-sys", "scala-2.12.0-M1.rpm", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.rpm", "RPM package", "101.61M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M1.txz", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-docs-2.12.0-M1.txz", "API docs", "43.72M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M1.zip", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-docs-2.12.0-M1.zip", "API docs", "81.12M"],
   ["-non-main-sys", "scala-sources-2.12.0-M1.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M1.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-06-23-2.11.7.md
+++ b/download/_posts/2015-06-23-2.11.7.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.7.tgz", "http://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.tgz", "Mac OS X, Unix, Cygwin", "27.14M"],
-  ["-main-windows", "scala-2.11.7.msi", "http://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.msi", "Windows (msi installer)", "110.71M"],
-  ["-non-main-sys", "scala-2.11.7.zip", "http://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.zip", "Windows", "27.19M"],
-  ["-non-main-sys", "scala-2.11.7.deb", "http://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.deb", "Debian", "76.66M"],
-  ["-non-main-sys", "scala-2.11.7.rpm", "http://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.rpm", "RPM package", "109.54M"],
-  ["-non-main-sys", "scala-docs-2.11.7.txz", "http://downloads.lightbend.com/scala/2.11.7/scala-docs-2.11.7.txz", "API docs", "47.05M"],
-  ["-non-main-sys", "scala-docs-2.11.7.zip", "http://downloads.lightbend.com/scala/2.11.7/scala-docs-2.11.7.zip", "API docs", "85.73M"],
+  ["-main-unixsys", "scala-2.11.7.tgz", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.tgz", "Mac OS X, Unix, Cygwin", "27.14M"],
+  ["-main-windows", "scala-2.11.7.msi", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.msi", "Windows (msi installer)", "110.71M"],
+  ["-non-main-sys", "scala-2.11.7.zip", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.zip", "Windows", "27.19M"],
+  ["-non-main-sys", "scala-2.11.7.deb", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.deb", "Debian", "76.66M"],
+  ["-non-main-sys", "scala-2.11.7.rpm", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.rpm", "RPM package", "109.54M"],
+  ["-non-main-sys", "scala-docs-2.11.7.txz", "https://downloads.lightbend.com/scala/2.11.7/scala-docs-2.11.7.txz", "API docs", "47.05M"],
+  ["-non-main-sys", "scala-docs-2.11.7.zip", "https://downloads.lightbend.com/scala/2.11.7/scala-docs-2.11.7.zip", "API docs", "85.73M"],
   ["-non-main-sys", "scala-sources-2.11.7.tar.gz", "https://github.com/scala/scala/archive/v2.11.7.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-07-14-2.12.0-M2.md
+++ b/download/_posts/2015-07-14-2.12.0-M2.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M2.tgz", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.tgz", "Mac OS X, Unix, Cygwin", "18.68M"],
-  ["-main-windows", "scala-2.12.0-M2.msi", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.msi", "Windows (msi installer)", "96.52M"],
-  ["-non-main-sys", "scala-2.12.0-M2.zip", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.zip", "Windows", "18.73M"],
-  ["-non-main-sys", "scala-2.12.0-M2.deb", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.deb", "Debian", "64.52M"],
-  ["-non-main-sys", "scala-2.12.0-M2.rpm", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.rpm", "RPM package", "95.31M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M2.txz", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-docs-2.12.0-M2.txz", "API docs", "42.95M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M2.zip", "http://downloads.lightbend.com/scala/2.12.0-M2/scala-docs-2.12.0-M2.zip", "API docs", "80.11M"],
+  ["-main-unixsys", "scala-2.12.0-M2.tgz", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.tgz", "Mac OS X, Unix, Cygwin", "18.68M"],
+  ["-main-windows", "scala-2.12.0-M2.msi", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.msi", "Windows (msi installer)", "96.52M"],
+  ["-non-main-sys", "scala-2.12.0-M2.zip", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.zip", "Windows", "18.73M"],
+  ["-non-main-sys", "scala-2.12.0-M2.deb", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.deb", "Debian", "64.52M"],
+  ["-non-main-sys", "scala-2.12.0-M2.rpm", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.rpm", "RPM package", "95.31M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M2.txz", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-docs-2.12.0-M2.txz", "API docs", "42.95M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M2.zip", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-docs-2.12.0-M2.zip", "API docs", "80.11M"],
   ["-non-main-sys", "scala-sources-2.12.0-M2.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M2.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-09-18-2.10.6.md
+++ b/download/_posts/2015-09-18-2.10.6.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.10.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.10.6.tgz", "http://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.tgz", "Max OS X, Unix, Cygwin", "28.54M"],
-  ["-main-windows", "scala.msi", "http://downloads.lightbend.com/scala/2.10.6/scala.msi", "Windows (msi installer)", "58.50M"],
-  ["-non-main-sys", "scala-2.10.6.zip", "http://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.zip", "Windows", "28.63M"],
-  ["-non-main-sys", "scala-2.10.6.deb", "http://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.deb", "Debian", "24.50M"],
-  ["-non-main-sys", "scala-2.10.6.rpm", "http://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.rpm", "RPM package", "24.86M"],
-  ["-non-main-sys", "scala-docs-2.10.6.txz", "http://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.txz", "API docs", "3.27M"],
-  ["-non-main-sys", "scala-docs-2.10.6.zip", "http://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.zip", "API docs", "30.94M"],
+  ["-main-unixsys", "scala-2.10.6.tgz", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.tgz", "Max OS X, Unix, Cygwin", "28.54M"],
+  ["-main-windows", "scala.msi", "https://downloads.lightbend.com/scala/2.10.6/scala.msi", "Windows (msi installer)", "58.50M"],
+  ["-non-main-sys", "scala-2.10.6.zip", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.zip", "Windows", "28.63M"],
+  ["-non-main-sys", "scala-2.10.6.deb", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.deb", "Debian", "24.50M"],
+  ["-non-main-sys", "scala-2.10.6.rpm", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.rpm", "RPM package", "24.86M"],
+  ["-non-main-sys", "scala-docs-2.10.6.txz", "https://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.txz", "API docs", "3.27M"],
+  ["-non-main-sys", "scala-docs-2.10.6.zip", "https://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.zip", "API docs", "30.94M"],
   ["-non-main-sys", "scala-sources-2.10.6.tar.gz", "https://github.com/scala/scala/archive/v2.10.6.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2015-10-06-2.12.0-M3.md
+++ b/download/_posts/2015-10-06-2.12.0-M3.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M3.tgz", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.tgz", "Mac OS X, Unix, Cygwin", "19.97M"],
-  ["-main-windows", "scala-2.12.0-M3.msi", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.msi", "Windows (msi installer)", "97.75M"],
-  ["-non-main-sys", "scala-2.12.0-M3.zip", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.zip", "Windows", "20.01M"],
-  ["-non-main-sys", "scala-2.12.0-M3.deb", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.deb", "Debian", "65.62M"],
-  ["-non-main-sys", "scala-2.12.0-M3.rpm", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.rpm", "RPM package", "96.55M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M3.txz", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-docs-2.12.0-M3.txz", "API docs", "42.99M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M3.zip", "http://downloads.lightbend.com/scala/2.12.0-M3/scala-docs-2.12.0-M3.zip", "API docs", "80.08M"],
+  ["-main-unixsys", "scala-2.12.0-M3.tgz", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.tgz", "Mac OS X, Unix, Cygwin", "19.97M"],
+  ["-main-windows", "scala-2.12.0-M3.msi", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.msi", "Windows (msi installer)", "97.75M"],
+  ["-non-main-sys", "scala-2.12.0-M3.zip", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.zip", "Windows", "20.01M"],
+  ["-non-main-sys", "scala-2.12.0-M3.deb", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.deb", "Debian", "65.62M"],
+  ["-non-main-sys", "scala-2.12.0-M3.rpm", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.rpm", "RPM package", "96.55M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M3.txz", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-docs-2.12.0-M3.txz", "API docs", "42.99M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M3.zip", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-docs-2.12.0-M3.zip", "API docs", "80.08M"],
   ["-non-main-sys", "scala-sources-2.12.0-M3.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M3.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-03-08-2.11.8.md
+++ b/download/_posts/2016-03-08-2.11.8.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.11.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.11.8.tgz", "http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.tgz", "Mac OS X, Unix, Cygwin", "27.35M"],
-  ["-main-windows", "scala-2.11.8.msi", "http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.msi", "Windows (msi installer)", "109.35M"],
-  ["-non-main-sys", "scala-2.11.8.zip", "http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.zip", "Windows", "27.40M"],
-  ["-non-main-sys", "scala-2.11.8.deb", "http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.deb", "Debian", "76.02M"],
-  ["-non-main-sys", "scala-2.11.8.rpm", "http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.rpm", "RPM package", "108.16M"],
-  ["-non-main-sys", "scala-docs-2.11.8.txz", "http://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.txz", "API docs", "46.00M"],
-  ["-non-main-sys", "scala-docs-2.11.8.zip", "http://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.zip", "API docs", "84.21M"],
+  ["-main-unixsys", "scala-2.11.8.tgz", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.tgz", "Mac OS X, Unix, Cygwin", "27.35M"],
+  ["-main-windows", "scala-2.11.8.msi", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.msi", "Windows (msi installer)", "109.35M"],
+  ["-non-main-sys", "scala-2.11.8.zip", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.zip", "Windows", "27.40M"],
+  ["-non-main-sys", "scala-2.11.8.deb", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.deb", "Debian", "76.02M"],
+  ["-non-main-sys", "scala-2.11.8.rpm", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.rpm", "RPM package", "108.16M"],
+  ["-non-main-sys", "scala-docs-2.11.8.txz", "https://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.txz", "API docs", "46.00M"],
+  ["-non-main-sys", "scala-docs-2.11.8.zip", "https://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.zip", "API docs", "84.21M"],
   ["-non-main-sys", "scala-sources-2.11.8.tar.gz", "https://github.com/scala/scala/archive/v2.11.8.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-04-11-2.12.0-M4.md
+++ b/download/_posts/2016-04-11-2.12.0-M4.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M4.tgz", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.tgz", "Mac OS X, Unix, Cygwin", "18.04M"],
-  ["-main-windows", "scala-2.12.0-M4.msi", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.msi", "Windows (msi installer)", "121.31M"],
-  ["-non-main-sys", "scala-2.12.0-M4.zip", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.zip", "Windows", "18.08M"],
-  ["-non-main-sys", "scala-2.12.0-M4.deb", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.deb", "Debian", "139.42M"],
-  ["-non-main-sys", "scala-2.12.0-M4.rpm", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.rpm", "RPM package", "120.90M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M4.txz", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-docs-2.12.0-M4.txz", "API docs", "52.77M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M4.zip", "http://downloads.lightbend.com/scala/2.12.0-M4/scala-docs-2.12.0-M4.zip", "API docs", "105.18M"],
+  ["-main-unixsys", "scala-2.12.0-M4.tgz", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.tgz", "Mac OS X, Unix, Cygwin", "18.04M"],
+  ["-main-windows", "scala-2.12.0-M4.msi", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.msi", "Windows (msi installer)", "121.31M"],
+  ["-non-main-sys", "scala-2.12.0-M4.zip", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.zip", "Windows", "18.08M"],
+  ["-non-main-sys", "scala-2.12.0-M4.deb", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.deb", "Debian", "139.42M"],
+  ["-non-main-sys", "scala-2.12.0-M4.rpm", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.rpm", "RPM package", "120.90M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M4.txz", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-docs-2.12.0-M4.txz", "API docs", "52.77M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M4.zip", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-docs-2.12.0-M4.zip", "API docs", "105.18M"],
   ["-non-main-sys", "scala-sources-2.12.0-M4.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M4.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-06-29-2.12.0-M5.md
+++ b/download/_posts/2016-06-29-2.12.0-M5.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M5.tgz", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.tgz", "Mac OS X, Unix, Cygwin", "17.53M"],
-  ["-main-windows", "scala-2.12.0-M5.msi", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.msi", "Windows (msi installer)", "120.72M"],
-  ["-non-main-sys", "scala-2.12.0-M5.zip", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.zip", "Windows", "17.57M"],
-  ["-non-main-sys", "scala-2.12.0-M5.deb", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.deb", "Debian", "138.34M"],
-  ["-non-main-sys", "scala-2.12.0-M5.rpm", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.rpm", "RPM package", "120.32M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M5.txz", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-docs-2.12.0-M5.txz", "API docs", "52.64M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M5.zip", "http://downloads.lightbend.com/scala/2.12.0-M5/scala-docs-2.12.0-M5.zip", "API docs", "105.09M"],
+  ["-main-unixsys", "scala-2.12.0-M5.tgz", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.tgz", "Mac OS X, Unix, Cygwin", "17.53M"],
+  ["-main-windows", "scala-2.12.0-M5.msi", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.msi", "Windows (msi installer)", "120.72M"],
+  ["-non-main-sys", "scala-2.12.0-M5.zip", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.zip", "Windows", "17.57M"],
+  ["-non-main-sys", "scala-2.12.0-M5.deb", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.deb", "Debian", "138.34M"],
+  ["-non-main-sys", "scala-2.12.0-M5.rpm", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.rpm", "RPM package", "120.32M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M5.txz", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-docs-2.12.0-M5.txz", "API docs", "52.64M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M5.zip", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-docs-2.12.0-M5.zip", "API docs", "105.09M"],
   ["-non-main-sys", "scala-sources-2.12.0-M5.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M5.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-09-06-2.12.0-RC1.md
+++ b/download/_posts/2016-09-06-2.12.0-RC1.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-RC1.tgz", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "17.65M"],
-  ["-main-windows", "scala-2.12.0-RC1.msi", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.msi", "Windows (msi installer)", "116.21M"],
-  ["-non-main-sys", "scala-2.12.0-RC1.zip", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.zip", "Windows", "17.69M"],
-  ["-non-main-sys", "scala-2.12.0-RC1.deb", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.deb", "Debian", "133.97M"],
-  ["-non-main-sys", "scala-2.12.0-RC1.rpm", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.rpm", "RPM package", "115.82M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC1.txz", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-docs-2.12.0-RC1.txz", "API docs", "50.75M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC1.zip", "http://downloads.lightbend.com/scala/2.12.0-RC1/scala-docs-2.12.0-RC1.zip", "API docs", "100.45M"],
+  ["-main-unixsys", "scala-2.12.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "17.65M"],
+  ["-main-windows", "scala-2.12.0-RC1.msi", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.msi", "Windows (msi installer)", "116.21M"],
+  ["-non-main-sys", "scala-2.12.0-RC1.zip", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.zip", "Windows", "17.69M"],
+  ["-non-main-sys", "scala-2.12.0-RC1.deb", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.deb", "Debian", "133.97M"],
+  ["-non-main-sys", "scala-2.12.0-RC1.rpm", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.rpm", "RPM package", "115.82M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC1.txz", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-docs-2.12.0-RC1.txz", "API docs", "50.75M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC1.zip", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-docs-2.12.0-RC1.zip", "API docs", "100.45M"],
   ["-non-main-sys", "scala-sources-2.12.0-RC1.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-RC1.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-10-18-2.12.0-RC2.md
+++ b/download/_posts/2016-10-18-2.12.0-RC2.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.0-RC2.tgz", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
-  ["-main-windows", "scala-2.12.0-RC2.msi", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.msi", "Windows (msi installer)", "117.88M"],
-  ["-non-main-sys", "scala-2.12.0-RC2.zip", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.zip", "Windows", "19.28M"],
-  ["-non-main-sys", "scala-2.12.0-RC2.deb", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.deb", "Debian", "137.24M"],
-  ["-non-main-sys", "scala-2.12.0-RC2.rpm", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.rpm", "RPM package", "117.49M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC2.txz", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-docs-2.12.0-RC2.txz", "API docs", "50.79M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC2.zip", "http://downloads.lightbend.com/scala/2.12.0-RC2/scala-docs-2.12.0-RC2.zip", "API docs", "100.52M"],
+  ["-main-unixsys", "scala-2.12.0-RC2.tgz", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
+  ["-main-windows", "scala-2.12.0-RC2.msi", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.msi", "Windows (msi installer)", "117.88M"],
+  ["-non-main-sys", "scala-2.12.0-RC2.zip", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.zip", "Windows", "19.28M"],
+  ["-non-main-sys", "scala-2.12.0-RC2.deb", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.deb", "Debian", "137.24M"],
+  ["-non-main-sys", "scala-2.12.0-RC2.rpm", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.rpm", "RPM package", "117.49M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC2.txz", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-docs-2.12.0-RC2.txz", "API docs", "50.79M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC2.zip", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-docs-2.12.0-RC2.zip", "API docs", "100.52M"],
   ["-non-main-sys", "scala-sources-2.12.0-RC2.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-RC2.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-11-03-2.12.0.md
+++ b/download/_posts/2016-11-03-2.12.0.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.0.html
 requirements: "Scala 2.12 requires version 8 of the Java platform, as provided by <a href='http://openjdk.java.net/install/'>OpenJDK</a> or <a href='http://www.oracle.com/technetwork/java/javase/downloads/index.html'>Oracle</a>. Java 9 is not yet supported."
 resources: [
-  ["-main-unixsys", "scala-2.12.0.tgz", "http://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
-  ["-main-windows", "scala-2.12.0.msi", "http://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.msi", "Windows (msi installer)", "117.78M"],
-  ["-non-main-sys", "scala-2.12.0.zip", "http://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.zip", "Windows", "19.28M"],
-  ["-non-main-sys", "scala-2.12.0.deb", "http://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.deb", "Debian", "137.14M"],
-  ["-non-main-sys", "scala-2.12.0.rpm", "http://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.rpm", "RPM package", "117.39M"],
-  ["-non-main-sys", "scala-docs-2.12.0.txz", "http://downloads.lightbend.com/scala/2.12.0/scala-docs-2.12.0.txz", "API docs", "50.74M"],
-  ["-non-main-sys", "scala-docs-2.12.0.zip", "http://downloads.lightbend.com/scala/2.12.0/scala-docs-2.12.0.zip", "API docs", "100.40M"],
+  ["-main-unixsys", "scala-2.12.0.tgz", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
+  ["-main-windows", "scala-2.12.0.msi", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.msi", "Windows (msi installer)", "117.78M"],
+  ["-non-main-sys", "scala-2.12.0.zip", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.zip", "Windows", "19.28M"],
+  ["-non-main-sys", "scala-2.12.0.deb", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.deb", "Debian", "137.14M"],
+  ["-non-main-sys", "scala-2.12.0.rpm", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.rpm", "RPM package", "117.39M"],
+  ["-non-main-sys", "scala-docs-2.12.0.txz", "https://downloads.lightbend.com/scala/2.12.0/scala-docs-2.12.0.txz", "API docs", "50.74M"],
+  ["-non-main-sys", "scala-docs-2.12.0.zip", "https://downloads.lightbend.com/scala/2.12.0/scala-docs-2.12.0.zip", "API docs", "100.40M"],
   ["-non-main-sys", "scala-sources-2.12.0.tar.gz", "https://github.com/scala/scala/archive/v2.12.0.tar.gz", "Sources", ""]
 ]
 ---

--- a/download/_posts/2016-12-05-2.12.1.md
+++ b/download/_posts/2016-12-05-2.12.1.md
@@ -8,13 +8,13 @@ show_resources: "true"
 permalink: /download/2.12.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
 resources: [
-  ["-main-unixsys", "scala-2.12.1.tgz", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
-  ["-main-windows", "scala-2.12.1.msi", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],
-  ["-non-main-sys", "scala-2.12.1.zip", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.zip", "Windows", "18.83M"],
-  ["-non-main-sys", "scala-2.12.1.deb", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.deb", "Debian", "144.65M"],
-  ["-non-main-sys", "scala-2.12.1.rpm", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.rpm", "RPM package", "125.29M"],
-  ["-non-main-sys", "scala-docs-2.12.1.txz", "http://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.txz", "API docs", "55.89M"],
-  ["-non-main-sys", "scala-docs-2.12.1.zip", "http://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.zip", "API docs", "109.10M"],
+  ["-main-unixsys", "scala-2.12.1.tgz", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
+  ["-main-windows", "scala-2.12.1.msi", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],
+  ["-non-main-sys", "scala-2.12.1.zip", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.zip", "Windows", "18.83M"],
+  ["-non-main-sys", "scala-2.12.1.deb", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.deb", "Debian", "144.65M"],
+  ["-non-main-sys", "scala-2.12.1.rpm", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.rpm", "RPM package", "125.29M"],
+  ["-non-main-sys", "scala-docs-2.12.1.txz", "https://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.txz", "API docs", "55.89M"],
+  ["-non-main-sys", "scala-docs-2.12.1.zip", "https://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.zip", "API docs", "109.10M"],
   ["-non-main-sys", "scala-sources-2.12.1.tar.gz", "https://github.com/scala/scala/archive/v2.12.1.tar.gz", "Sources", "5.99M"]
 ]
 ---

--- a/download/index.md
+++ b/download/index.md
@@ -12,13 +12,13 @@ other_releases: [
 ]
 requirements: "Scala 2.12 requires version 8 of the <a href='http://www.java.com/'>Java platform</a>. Older Scala versions are compatible with Java 6 and up. Java 9 is not yet supported."
 resources: [
-  ["-main-unixsys", "scala-2.12.1.tgz", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
-  ["-main-windows", "scala-2.12.1.msi", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],
-  ["-non-main-sys", "scala-2.12.1.zip", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.zip", "Windows", "18.83M"],
-  ["-non-main-sys", "scala-2.12.1.deb", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.deb", "Debian", "144.65M"],
-  ["-non-main-sys", "scala-2.12.1.rpm", "http://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.rpm", "RPM package", "125.29M"],
-  ["-non-main-sys", "scala-docs-2.12.1.txz", "http://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.txz", "API docs", "55.89M"],
-  ["-non-main-sys", "scala-docs-2.12.1.zip", "http://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.zip", "API docs", "109.10M"],
+  ["-main-unixsys", "scala-2.12.1.tgz", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
+  ["-main-windows", "scala-2.12.1.msi", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],
+  ["-non-main-sys", "scala-2.12.1.zip", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.zip", "Windows", "18.83M"],
+  ["-non-main-sys", "scala-2.12.1.deb", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.deb", "Debian", "144.65M"],
+  ["-non-main-sys", "scala-2.12.1.rpm", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.rpm", "RPM package", "125.29M"],
+  ["-non-main-sys", "scala-docs-2.12.1.txz", "https://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.txz", "API docs", "55.89M"],
+  ["-non-main-sys", "scala-docs-2.12.1.zip", "https://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.zip", "API docs", "109.10M"],
   ["-non-main-sys", "scala-sources-2.12.1.tar.gz", "https://github.com/scala/scala/archive/v2.12.1.tar.gz", "Sources", "5.99M"]
 ]
 ---


### PR DESCRIPTION
Since no redirect or HSTS is in place, these downloads are
vulnerable to being MitM'd. This commit changes all relevant
links to use "HTTPS" in the protocol part instead of "HTTP".

Ref #627 