### PR TITLE
dotty announcement: Link to a Scastie that works

### DIFF
--- a/blog/_posts/2017-05-31-first-dotty-milestone-release.md
+++ b/blog/_posts/2017-05-31-first-dotty-milestone-release.md
@@ -119,4 +119,4 @@ Join our [community build](https://github.com/lampepfl/dotty-community-build)
 To get started, see <https://github.com/lampepfl/dotty>.
 
 
-[Scastie]: https://scastie.scala-lang.org/?target=dotty
+[Scastie]: https://scastie.scala-lang.org/R5kUfVbTRpmS4l4CrO1HlA


### PR DESCRIPTION
The default code shown by Scastie does not compile with Dotty
currently (https://github.com/scalacenter/scastie/issues/234), so this
commit replaces it by an example that does compile, and also showcases some
Dotty features (enums, union types).
/cc @MasseGuillaume 