### PR TITLE
Update docs to refer to new property in VersionUtil

### DIFF
--- a/contribute/hacker-guide.md
+++ b/contribute/hacker-guide.md
@@ -177,7 +177,7 @@ Listening for transport dt_socket at address: 8002
 // skip docs for local publishing
 publishArtifact in (Compile, packageDoc) in ThisBuild := false
 // set version based on current sha, so that you can easily consume this build from another sbt project
-baseVersionSuffix := s"local-${Process("tools/get-scala-commit-sha").lines.head.substring(0, 7)}"
+baseVersionSuffix := s"local-${VersionUtil.gitProperties.value.sha}"
 // show more logging during a partest run
 testOptions in IntegrationTest in LocalProject("test") ++= Seq(Tests.Argument("--show-log"), Tests.Argument("--show-diff"))
 // if incremental compilation is compiling too much (should be fine under sbt 0.13.13)


### PR DESCRIPTION
The docs currently refer to a script that doesn't exist anymore that was used to calculate the current sha. Since that was refactored and moved into the VersionUtil, this change refers to a newly exposed sha property.