### PR TITLE
dotty 0.2 announcement: Working Scastie link

### DIFF
--- a/blog/_posts/2017-07-12-second-dotty-milestone-release.md
+++ b/blog/_posts/2017-07-12-second-dotty-milestone-release.md
@@ -366,5 +366,5 @@ Join our [community build](https://github.com/lampepfl/dotty-community-build)
 To get started, see [https://github.com/lampepfl/dotty](https://github.com/lampepfl/dotty).
 
 
-[Scastie]: https://scastie.scala-lang.org/?target=dotty
+[Scastie]: https://scastie.scala-lang.org/R5kUfVbTRpmS4l4CrO1HlA
 


### PR DESCRIPTION
See https://github.com/scala/scala-lang/pull/661 for why this is needed.