### PR TITLE
Less strict about version of ruby 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '~> 2.3'
 gem 'jekyll'
 gem 'kramdown'
 gem 'rack-jekyll'


### PR DESCRIPTION
I have 2.3.3 installed, and 2.3.4 is the latest, so might as well use the `~>` operator to specify Ruby version.  Otherwise,

```
$ bundle
Your Ruby version is 2.3.3, but your Gemfile specified 2.3.1
```