### PR TITLE
Fix example dependency to add to build.sbt

### DIFF
--- a/documentation/getting-started-sbt-track/getting-started-with-scala-and-sbt-in-the-command-line.md
+++ b/documentation/getting-started-sbt-track/getting-started-with-scala-and-sbt-in-the-command-line.md
@@ -71,7 +71,7 @@ extra functionality to our apps.
 1. Open up `build.sbt` and add the following line:
 
 ```
-"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
+"libraryDependencies += org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
 ```
 
 Here, `libraryDependencies` is a set of dependencies, and by using `+=`,


### PR DESCRIPTION
Following the example in the [Adding a Dependency](https://www.scala-lang.org//documentation/getting-started-sbt-track/getting-started-with-scala-and-sbt-in-the-command-line.html#adding-a-dependency) section of 'Getting started with scala and sbt on the command line' leads to an error because the `libraryDependencies +=` part of the line was left off of the example line to add to the `build.sbt`. 

This PR fixes that.