### PR TITLE
Add ScalaFiddle to the Downloads page

### DIFF
--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -84,6 +84,7 @@ layout: inner-page-parent
                   <br/><span class="install"><a href="{{ site.baseurl }}/download/install.html">Need help running the binaries?</a></span>
                 </li>
                 <li>Use <a href="https://scastie.scala-lang.org">Scastie</a> to run single-file Scala programs in your browser.</li>
+                <li>Try Scala in the browser via <a href="https://scalafiddle.io/">ScalaFiddle</a>. This lets you run code locally in the browser using Scala.js, including graphical/interactive examples such as <a href="https://scalafiddle.io/sf/KOsXSKv/0">Oscilloscope</a> or <a href="https://scalafiddle.io/sf/4beVrVc/1">Ray Tracer</a></li>
                 <li><a href="http://ammonite.io/">Get Ammonite</a>, a popular Scala REPL</li>
               </ul>
               <p>Or are you looking for <a href="{{ site.baseurl }}/download/all.html">previous releases</a> of Scala?</p>


### PR DESCRIPTION
While not as flexible in terms of SBT/scalaVersion configuration as Scastie is, and only running on Scala.js, ScalaFiddle is really fast (compile times typically 0.2-0.3 seconds) and allows cool graphical/interactive code snippets like those linked to in the diff.

Not sure what other people think of this diff, but if we're including Scastie and Ammonite I think ScalaFiddle definitely deserves a seat at the table.