### PR TITLE
Generate copyright year dynamically

### DIFF
--- a/_data/common.yml
+++ b/_data/common.yml
@@ -16,5 +16,3 @@ texts:
   scalaSupportersTitle: Scala Center is supported by
   frontpageMarker: "Scala began life in 2003, created by Martin Odersky and his research group at EPFL, next to Lake Geneva and the Alps, in Lausanne, Switzerland. Scala has since grown into a mature open source programming language, used by hundreds of thousands of developers, and is developed and maintained by scores of people all over the world."
   booksBy: "by"
-
-copyrightText: "Copyright © 2002-2016 École Polytechnique Fédérale <br>Lausanne (EPFL) Lausanne, Switzerland"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,7 @@
         {% endfor %}
       </div>
       <div class="site-footer-bottom">
-        <p>{{site.data.common.copyrightText}}</p>
+        <p>Copyright © 2002-{{ site.time | date:"%Y" }} École Polytechnique Fédérale <br>Lausanne (EPFL) Lausanne, Switzerland</p>
         <img src="/resources/img/frontpage/scala-logo-white.png" alt="">
       </div>
     </div>


### PR DESCRIPTION
I found the copyright year of bottom footer is not up-to-date, so I changed it to generate copyright year dynamically.