### PR TITLE
Fix release notes link in 2.13.0-M2 announcement.

### DIFF
--- a/_posts/2017-08-08-release-notes-2.13.0-M2.md
+++ b/_posts/2017-08-08-release-notes-2.13.0-M2.md
@@ -7,4 +7,4 @@ title: "Scala 2.13.0-M2 is now available!"
 [Scala 2.13.0-M2](https://github.com/scala/scala/releases/tag/v2.13.0-M2) improves the [REPL](https://github.com/scala/scala/pull/5903) and catches up with [changes in Scala 2.12.3](https://github.com/scala/scala/releases/tag/v2.12.3).
 As a reminder, our [full 2.13 roadmap](https://github.com/scala/scala-dev/issues/324) is available for review on GitHub.
 
-For all the details, refer to the [https://github.com/scala/scala/releases/tag/v2.13.0-M2](release notes) on GitHub.
+For all the details, refer to the [release notes](https://github.com/scala/scala/releases/tag/v2.13.0-M2) on GitHub.


### PR DESCRIPTION
Looks like the Markdown got switched around on the link.