### PR TITLE
remove Scalawags from community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -96,7 +96,6 @@ Official:
 Community:
 
 * [Scala Times](http://scalatimes.com) weekly Scala newspaper
-* [The Scalawags](http://scalawags.tv) monthly podcast
 
 Many Scala users are active on Twitter for sharing Scala-related news
 items and opinions.  Ask your Scala friends who they follow on Twitter


### PR DESCRIPTION
on the one hand, the podcast isn't officially terminated... but on the
other hand, we haven't done a new episode in quite a long time now.
better not to link to something stale, I think. the link could always
come back if we start up again.