### PR TITLE
Security update: 2.12.4, 2.11.12, 2.10.7 (CVE-2017-15288)

### DIFF
--- a/_downloads/2017-11-09-2.10.7.md
+++ b/_downloads/2017-11-09-2.10.7.md
@@ -1,0 +1,20 @@
+---
+title: Scala 2.10.7
+start: 09 November 2017
+layout: downloadpage
+release_version: 2.10.7
+release_date: "November 09, 2017"
+show_resources: "true"
+permalink: /download/2.10.7.html
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+resources: [
+  ["-main-unixsys", "scala-2.10.7.tgz", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.tgz", "Mac OS X, Unix, Cygwin", "28.60M"],
+  ["-main-windows", "scala-2.10.7.msi", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.msi", "Windows (msi installer)", ""],
+  ["-non-main-sys", "scala-2.10.7.zip", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.zip", "Windows", "28.70M"],
+  ["-non-main-sys", "scala-2.10.7.deb", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.deb", "Debian", "24.56M"],
+  ["-non-main-sys", "scala-2.10.7.rpm", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.rpm", "RPM package", "24.93M"],
+  ["-non-main-sys", "scala-docs-2.10.7.txz", "https://downloads.lightbend.com/scala/2.10.7/scala-docs-2.10.7.txz", "API docs", "3.25M"],
+  ["-non-main-sys", "scala-docs-2.10.7.zip", "https://downloads.lightbend.com/scala/2.10.7/scala-docs-2.10.7.zip", "API docs", "30.95M"],
+  ["-non-main-sys", "scala-sources-2.10.7.tar.gz", "https://github.com/scala/scala/archive/v2.10.7.tar.gz", "Sources", ""]
+]
+---

--- a/_downloads/2017-11-09-2.11.12.md
+++ b/_downloads/2017-11-09-2.11.12.md
@@ -1,0 +1,20 @@
+---
+title: Scala 2.11.12
+start: 09 November 2017
+layout: downloadpage
+release_version: 2.11.12
+release_date: "November 09, 2017"
+show_resources: "true"
+permalink: /download/2.11.12.html
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+resources: [
+  ["-main-unixsys", "scala-2.11.12.tgz", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.tgz", "Mac OS X, Unix, Cygwin", "27.77M"],
+  ["-main-windows", "scala-2.11.12.msi", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.msi", "Windows (msi installer)", "109.82M"],
+  ["-non-main-sys", "scala-2.11.12.zip", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.zip", "Windows", "27.82M"],
+  ["-non-main-sys", "scala-2.11.12.deb", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.deb", "Debian", "76.44M"],
+  ["-non-main-sys", "scala-2.11.12.rpm", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.rpm", "RPM package", "108.60M"],
+  ["-non-main-sys", "scala-docs-2.11.12.txz", "https://downloads.lightbend.com/scala/2.11.12/scala-docs-2.11.12.txz", "API docs", "46.17M"],
+  ["-non-main-sys", "scala-docs-2.11.12.zip", "https://downloads.lightbend.com/scala/2.11.12/scala-docs-2.11.12.zip", "API docs", "84.26M"],
+  ["-non-main-sys", "scala-sources-2.11.12.tar.gz", "https://github.com/scala/scala/archive/v2.11.12.tar.gz", "Sources", ""]
+]
+---

--- a/_posts/2017-11-13-security-update.md
+++ b/_posts/2017-11-13-security-update.md
@@ -1,0 +1,34 @@
+---
+post-type: announcement
+permalink: /news/security-update-nov17
+title: "Security update: 2.12.4, 2.11.12, 2.10.7 (CVE-2017-15288)"
+---
+
+A privilege escalation vulnerability (CVE-2017-15288) has been identified in the Scala compilation daemon.
+
+The compile daemon is started explicitly by the `fsc` command, or implicitly by executing
+a Scala source file as a script (e.g `scala MyScript.scala`). The Scala REPL, started by `scala` is not affected as it does not use the compilation daemon, nor is running a pre-compiled class using the `scala` command.
+
+We recommend upgrading to the latest versions of Scala:
+  - [Scala 2.12.4](https://github.com/scala/scala/releases/tag/v2.12.4);
+  - [Scala 2.11.12](https://github.com/scala/scala/releases/tag/v2.11.12);
+  - [Scala 2.10.7](https://github.com/scala/scala/releases/tag/v2.10.7).
+
+# Impact
+
+While the compile daemon is running, an attacker with local access to the machine can
+execute code as the user that started the compile daemon, and can write arbitrary
+class files to any location on the filesystem that the user has access to.
+
+# Affected Versions
+
+  - Scala 2.1.6-2.10.6; 2.11.0-2.11.11; 2.12.0-2.12.3
+
+# Mitigation
+
+  - Use `scala -nocompdaemon MyScript.scala` rather than `scala MyScript.scala` to
+    disable the implicit startup and use of the daemon. 
+  - Avoid explicitly starting `fsc` 
+  - Upgrade to Scala 2.10.7 2.11.12, 2.12.4 or higher which restricts the sensitive file to be
+    readable only by the owner. These releases also change the location of the sensitive
+    file: it is written in the directory `$HOME/.scalac`.

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -15,17 +15,17 @@ includeTOC: true
     * [XML API](http://www.scala-lang.org/api/2.12.4/scala-xml/#scala.xml.package)
     * [Parser Combinators API](http://www.scala-lang.org/api/2.12.4/scala-parser-combinators/)
     * [Swing API](http://www.scala-lang.org/api/2.12.4/scala-swing/#scala.swing.package)
-* Scala 2.11.11
-  * [Library API](http://www.scala-lang.org/api/2.11.11/)
-  * [Compiler API](http://www.scala-lang.org/api/2.11.11/scala-compiler/)
-  * [Reflection API](http://www.scala-lang.org/api/2.11.11/scala-reflect/#scala.reflect.package)
+* Scala 2.11.12
+  * [Library API](http://www.scala-lang.org/api/2.11.12/)
+  * [Compiler API](http://www.scala-lang.org/api/2.11.12/scala-compiler/)
+  * [Reflection API](http://www.scala-lang.org/api/2.11.12/scala-reflect/#scala.reflect.package)
   * Scala Modules
-    * [XML API](http://www.scala-lang.org/api/2.11.11/scala-xml/#scala.xml.package)
-    * [Parser Combinators API](http://www.scala-lang.org/api/2.11.11/scala-parser-combinators/)
-    * [Actors API](http://www.scala-lang.org/api/2.11.11/scala-actors/#scala.actors.package) (deprecated)
-    * [Swing API](http://www.scala-lang.org/api/2.11.11/scala-swing/#scala.swing.package)
-    * [Continuations API](http://www.scala-lang.org/files/archive/api/2.11.11/scala-continuations-library/#scala.util.continuations.package)
-* [Scala 2.10.6](http://www.scala-lang.org/api/2.10.6/)
+    * [XML API](http://www.scala-lang.org/api/2.11.12/scala-xml/#scala.xml.package)
+    * [Parser Combinators API](http://www.scala-lang.org/api/2.11.12/scala-parser-combinators/)
+    * [Actors API](http://www.scala-lang.org/api/2.11.12/scala-actors/#scala.actors.package) (deprecated)
+    * [Swing API](http://www.scala-lang.org/api/2.11.12/scala-swing/#scala.swing.package)
+    * [Continuations API](http://www.scala-lang.org/files/archive/api/2.11.12/scala-continuations-library/#scala.util.continuations.package)
+* [Scala 2.10.7](http://www.scala-lang.org/api/2.10.7/)
 
 ## Nightly builds
 
@@ -64,6 +64,16 @@ includeTOC: true
     * [XML API](http://www.scala-lang.org/api/2.12.2/scala-xml/#scala.xml.package)
     * [Parser Combinators API](http://www.scala-lang.org/api/2.12.2/scala-parser-combinators/)
     * [Swing API](http://www.scala-lang.org/api/2.12.2/scala-swing/#scala.swing.package)
+* Scala 2.11.11
+  * [Library API](http://www.scala-lang.org/api/2.11.11/)
+  * [Compiler API](http://www.scala-lang.org/api/2.11.11/scala-compiler/)
+  * [Reflection API](http://www.scala-lang.org/api/2.11.11/scala-reflect/#scala.reflect.package)
+  * Scala Modules
+    * [XML API](http://www.scala-lang.org/api/2.11.11/scala-xml/#scala.xml.package)
+    * [Parser Combinators API](http://www.scala-lang.org/api/2.11.11/scala-parser-combinators/)
+    * [Actors API](http://www.scala-lang.org/api/2.11.11/scala-actors/#scala.actors.package) (deprecated)
+    * [Swing API](http://www.scala-lang.org/api/2.11.11/scala-swing/#scala.swing.package)
+    * [Continuations API](http://www.scala-lang.org/files/archive/api/2.11.11/scala-continuations-library/#scala.util.continuations.package)    
 * Scala 2.11.8
   * [Standard Library API](http://www.scala-lang.org/api/2.11.8/)
   * [Compiler API](http://www.scala-lang.org/api/2.11.8/scala-compiler/)
@@ -144,6 +154,7 @@ includeTOC: true
     * [Actors API](http://www.scala-lang.org/api/2.11.0/scala-actors/#scala.actors.package) (deprecated)
     * [Swing API](http://www.scala-lang.org/api/2.11.0/scala-swing/#scala.swing.package)
     * [Continuations API](http://www.scala-lang.org/files/archive/api/2.11.0/scala-continuations-library/#scala.util.continuations.package)
+* [Scala 2.10.6](http://www.scala-lang.org/api/2.10.6/)
 * [Scala 2.10.5](http://www.scala-lang.org/api/2.10.5/)
 * [Scala 2.10.4](http://www.scala-lang.org/api/2.10.4/)
 * [Scala 2.10.3](http://www.scala-lang.org/api/2.10.3/)


### PR DESCRIPTION
Also add 2.10.7 and 2.11.12 download pages. Not submitting a separate announcement about their release, since it's mostly about the security fix and java 9 compat backports