### PR TITLE
Update numbers from macro analysis.

### DIFF
--- a/_posts/2017-11-27-macros.md
+++ b/_posts/2017-11-27-macros.md
@@ -36,93 +36,78 @@ The Scala ecosystem is rich as it is thanks to this wide range of applications
 that are enabled by scala-reflect macros.
 
 To get a better feel for how common each use-case is,
-we performed an analysis on a corpus of 20,906 source files containing ~3
-million lines of code from the Scala compiler community build.
+we performed an analysis on a corpus of 20,906 source files containing ~2
+million lines of code derived from the Scala compiler community build.
 The corpus includes sources for a diverse set of libraries such as
 Akka, Cats, Scalaz, Monocle, twitter/util, Spire, Scrooge, Blaze, Algebra, fastparse,
-Scanamo as well as applications like ornicar/lila (<https://lichess.org>).
+Scanamo as well as applications like ornicar/lila (<https://lichess.org>) and
+guardian/frontend (<https://www.theguardian.com/>).
 Our analysis tracks the number of call-sites to each def macro and groups them by
 whether the call-site comes from test or main sources.
 Here are the top results:
 
 **Main sources**
 ```
-       443: org.scalactic.source.Position.here()Lorg/scalactic/source/Position;.
-       356: org.parboiled2.Parser#rule(Lorg/parboiled2/Rule;)Lorg/parboiled2/Rule;.
-       334: spire.syntax.EqOps#`===`(Ljava/lang/Object;Lscala/Predef/$eq$colon$eq;)Z.
-       311: spire.syntax.CforSyntax#cfor(Ljava/lang/Object;Lscala/Function1;Lscala/Function1;Lscala/Function1;)V.
-       287: akka.parboiled2.Parser#rule(Lakka/parboiled2/Rule;)Lakka/parboiled2/Rule;.
-       267: spire.syntax.MultiplicativeSemigroupOps#`*`(Ljava/lang/Object;)Ljava/lang/Object;.
-       226: spire.syntax.AdditiveSemigroupOps#`+`(Ljava/lang/Object;)Ljava/lang/Object;.
-       170: slick.util.MacroSupportInterpolation#b(Lscala/collection/Seq;)V.
-       156: reactivemongo.bson.Macros.handler()Lreactivemongo/bson/BSONDocumentReader;.
-       152: spire.syntax.CforSyntax#cforRange(Lscala/collection/immutable/Range;Lscala/Function1;)V.
-       130: scala.reflect.api.Universe#reify(Ljava/lang/Object;)Lscala/reflect/api/Exprs/Expr;.
-       123: scalaxy.debug.package.require(ZLjava/lang/String;)V.
-       110: spire.syntax.MultiplicativeGroupOps#`/`(Ljava/lang/Object;)Ljava/lang/Object;.
-       108: play.api.libs.json.Json.format()Lplay/api/libs/json/OFormat;.
-       104: scala.StringContext#f(Lscala/collection/Seq;)Ljava/lang/String;.
-       102: play.api.libs.json.Json.writes()Lplay/api/libs/json/Writes;.
-        98: spire.syntax.AdditiveGroupOps#`unary_-`()Ljava/lang/Object;.
-        78: spire.syntax.AdditiveGroupOps#`-`(Ljava/lang/Object;)Ljava/lang/Object;.
-        71: play.api.libs.json.Json.reads()Lplay/api/libs/json/Reads;.
-        71: spire.syntax.OrderOps#compare(Ljava/lang/Object;)I.
-        59: spire.syntax.PartialOrderOps#`<=`(Ljava/lang/Object;)Z.
-        57: spire.syntax.PartialOrderOps#`<`(Ljava/lang/Object;)Z.
-        56: spire.syntax.ModuleOps#`*:`(Ljava/lang/Object;Lspire/algebra/Module;)Ljava/lang/Object;.
-        51: spire.syntax.SemiringOps#pow(I)Ljava/lang/Object;.
-        47: spire.syntax.NRootOps#sqrt()Ljava/lang/Object;.
-        46: org.log4s.Logger#error(Ljava/lang/Throwable;Ljava/lang/String;)V.
-        44: spire.syntax.SignedOps#sign()Lspire/algebra/Sign;.
-        44: spire.syntax.EqOps#`=!=`(Ljava/lang/Object;Lscala/Predef/$eq$colon$eq;)Z.
-        42: cats.syntax.EqOps#`===`(Ljava/lang/Object;)Z.
-        37: spire.macros.Checked.checked(Ljava/lang/Object;)Ljava/lang/Object;.
-        37: spire.syntax.PartialOrderOps#`>`(Ljava/lang/Object;)Z.
-        34: spire.syntax.PartialOrderOps#`>=`(Ljava/lang/Object;)Z.
-        33: spire.syntax.MultiplicativeGroupOps#reciprocal()Ljava/lang/Object;.
-        32: spire.syntax.NRootOps#nroot(I)Ljava/lang/Object;.
-        31: com.typesafe.scalalogging.Logger#info(Ljava/lang/String;)V.
-        30: spire.syntax.SemigroupoidOps#`|+|?`(Ljava/lang/Object;)Ljava/lang/Object;.
-        ... truncated
+442: org.scalactic.source.Position.here()Lorg/scalactic/source/Position;.
+345: org.parboiled2.Parser#rule(Lorg/parboiled2/Rule;)Lorg/parboiled2/Rule;.
+287: akka.parboiled2.Parser#rule(Lakka/parboiled2/Rule;)Lakka/parboiled2/Rule;.
+242: spire.syntax.CforSyntax#cfor(Ljava/lang/Object;Lscala/Function1;Lscala/Function1;Lscala/Function1;)V.
+173: spire.syntax.EqOps#`===`(Ljava/lang/Object;Lscala/Predef/$eq$colon$eq;)Z.
+170: slick.util.MacroSupportInterpolation#b(Lscala/collection/Seq;)V.
+156: reactivemongo.bson.Macros.handler()Lreactivemongo/bson/BSONDocumentReader;.
+149: spire.syntax.CforSyntax#cforRange(Lscala/collection/immutable/Range;Lscala/Function1;)V.
+141: spire.syntax.MultiplicativeSemigroupOps#`*`(Ljava/lang/Object;)Ljava/lang/Object;.
+128: spire.syntax.AdditiveSemigroupOps#`+`(Ljava/lang/Object;)Ljava/lang/Object;.
+123: scalaxy.debug.package.require(ZLjava/lang/String;)V.
+108: play.api.libs.json.Json.format()Lplay/api/libs/json/OFormat;.
+103: scala.StringContext#f(Lscala/collection/Seq;)Ljava/lang/String;.
+102: play.api.libs.json.Json.writes()Lplay/api/libs/json/Writes;.
+ 97: scala.reflect.api.Universe#reify(Ljava/lang/Object;)Lscala/reflect/api/Exprs/Expr;.
+ 71: play.api.libs.json.Json.reads()Lplay/api/libs/json/Reads;.
+ 56: spire.syntax.MultiplicativeGroupOps#`/`(Ljava/lang/Object;)Ljava/lang/Object;.
+ 49: spire.syntax.AdditiveGroupOps#`unary_-`()Ljava/lang/Object;.
+ 46: org.log4s.Logger#error(Ljava/lang/Throwable;Ljava/lang/String;)V.
+ 41: spire.syntax.AdditiveGroupOps#`-`(Ljava/lang/Object;)Ljava/lang/Object;.
+ 36: spire.syntax.OrderOps#compare(Ljava/lang/Object;)I.
+ 31: com.typesafe.scalalogging.Logger#info(Ljava/lang/String;)V.
+ 31: spire.syntax.PartialOrderOps#`<`(Ljava/lang/Object;)Z.
+ 30: spire.syntax.PartialOrderOps#`<=`(Ljava/lang/Object;)Z.
+ 30: scalaxy.debug.package.require(Z)V.
+ 28: spire.syntax.ModuleOps#`*:`(Ljava/lang/Object;Lspire/algebra/Module;)Ljava/lang/Object;.
+ 26: spire.syntax.SemiringOps#pow(I)Ljava/lang/Object;.
+     ... truncated
 ```
 
 **Test sources**
 ```
-      9499: org.scalatest.Assertions#assert(ZLorg/scalactic/Prettifier;Lorg/scalactic/source/Position;)Lorg/scalatest/compatible/Assertion;.
-      7590: org.scalactic.source.Position.here()Lorg/scalactic/source/Position;.
-      1822: minitest.api.Asserts#assertEquals(Ljava/lang/Object;Ljava/lang/Object;)V.
-       733: utest.asserts.Asserts#assert(Lscala/collection/Seq;)V.
-       521: minitest.api.Asserts#assert(Z)V.
-       384: minitest.api.Asserts#assert(ZLjava/lang/String;)V.
-       358: spire.syntax.EqOps#`===`(Ljava/lang/Object;Lscala/Predef/$eq$colon$eq;)Z.
-       307: org.specs2.specification.create.S2StringContextCreation#specificationInStringContext#s2(Lscala/collection/Seq;)Lorg/specs2/specification/core/Fragments;.
-       306: scodec.bits.package.HexStringSyntax#hex(Lscala/collection/Seq;)Lscodec/bits/ByteVector;.
-       288: org.scalatest.Assertions#assert(ZLjava/lang/Object;Lorg/scalactic/Prettifier;Lorg/scalactic/source/Position;)Lorg/scalatest/compatible/Assertion;.
-       286: org.parboiled2.Parser#rule(Lorg/parboiled2/Rule;)Lorg/parboiled2/Rule;.
-       270: spire.syntax.Literals#r()Lspire/math/Rational;.
-       206: records.Rec.applyDynamic(Ljava/lang/String;Lscala/collection/Seq;)Lrecords/Rec;.
-       186: spire.syntax.Literals#b()B.
-       115: scala.async.internal.AsyncId.async(Lscala/Function0;)Ljava/lang/Object;.
-        91: utest.asserts.Asserts#intercept(Lscala/runtime/BoxedUnit;Lscala/reflect/ClassTag;)Ljava/lang/Object;.
-        90: org.scalatest.Matchers#AnyShouldWrapper#shouldBe(Lorg/scalatest/words/ResultOfATypeInvocation;)Lorg/scalatest/compatible/Assertion;.
-        74: minitest.api.Asserts#intercept(Lscala/Function0;)V.
-        68: scala.async.Async.async(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-        66: spire.syntax.Literals#h()S.
-        65: slick.collection.heterogeneous.HList#apply(I)Ljava/lang/Object;.
-        63: org.specs2.specification.create.AutoExamples#eg(Lscala/Function0;Lorg/specs2/execute/AsResult;)Lorg/specs2/specification/core/Fragments;.
-        55: scala.StringContext#f(Lscala/collection/Seq;)Ljava/lang/String;.
-        53: org.scalatest.Matchers#StringShouldWrapper#shouldNot(Lorg/scalatest/words/CompileWord;Lorg/scalactic/source/Position;)Lorg/scalatest/compatible/Assertion;.
-        46: com.twitter.scalding.serialization.macros.LowerPriorityImplicit#primitiveOrderedBufferSupplier()Lcom/twitter/scalding/serialization/OrderedSerialization;.
-        42: spire.macros.Checked.checked(Ljava/lang/Object;)Ljava/lang/Object;.
-        37: records.Rec.fld(Lrecords/Rec;)Ljava/lang/Object;.
-        36: play.api.libs.json.Json.format()Lplay/api/libs/json/OFormat;.
-        36: utest.asserts.Asserts#compileError(Ljava/lang/String;)Lutest/CompileError;.
-        34: monix.execution.schedulers.ExecuteExtensions#executeAsync(Lscala/Function0;)V.
-        34: spire.syntax.CforSyntax#cfor(Ljava/lang/Object;Lscala/Function1;Lscala/Function1;Lscala/Function1;)V.
-        34: spire.util.Pack.longToByte(JI)B.
-        33: scodec.bits.package.BinStringSyntax#bin(Lscala/collection/Seq;)Lscodec/bits/BitVector;.
-        32: monix.execution.schedulers.ExecuteExtensions#executeTrampolined(Lscala/Function0;)V.
-        ... truncated
+8969: org.scalatest.Assertions#assert(ZLorg/scalactic/Prettifier;Lorg/scalactic/source/Position;)Lorg/scalatest/compatible/Assertion;.
+7070: org.scalactic.source.Position.here()Lorg/scalactic/source/Position;.
+1263: minitest.api.Asserts#assertEquals(Ljava/lang/Object;Ljava/lang/Object;)V.
+ 386: utest.asserts.Asserts#assert(Lscala/collection/Seq;)V.
+ 271: minitest.api.Asserts#assert(Z)V.
+ 270: org.scalatest.Assertions#assert(ZLjava/lang/Object;Lorg/scalactic/Prettifier;Lorg/scalactic/source/Position;)Lorg/scalatest/compatible/Assertion;.
+ 265: org.specs2.specification.create.S2StringContextCreation#specificationInStringContext#s2(Lscala/collection/Seq;)Lorg/specs2/specification/core/Fragments;.
+ 264: minitest.api.Asserts#assert(ZLjava/lang/String;)V.
+ 217: scodec.bits.package.HexStringSyntax#hex(Lscala/collection/Seq;)Lscodec/bits/ByteVector;.
+ 206: records.Rec.applyDynamic(Ljava/lang/String;Lscala/collection/Seq;)Lrecords/Rec;.
+ 179: spire.syntax.EqOps#`===`(Ljava/lang/Object;Lscala/Predef/$eq$colon$eq;)Z.
+ 143: org.parboiled2.Parser#rule(Lorg/parboiled2/Rule;)Lorg/parboiled2/Rule;.
+ 135: spire.syntax.Literals#r()Lspire/math/Rational;.
+ 115: scala.async.internal.AsyncId.async(Lscala/Function0;)Ljava/lang/Object;.
+  93: spire.syntax.Literals#b()B.
+  86: org.scalatest.Matchers#AnyShouldWrapper#shouldBe(Lorg/scalatest/words/ResultOfATypeInvocation;)Lorg/scalatest/compatible/Assertion;.
+  68: scala.async.Async.async(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+  65: slick.collection.heterogeneous.HList#apply(I)Ljava/lang/Object;.
+  55: scala.StringContext#f(Lscala/collection/Seq;)Ljava/lang/String;.
+  48: utest.asserts.Asserts#intercept(Lscala/runtime/BoxedUnit;Lscala/reflect/ClassTag;)Ljava/lang/Object;.
+  46: com.twitter.scalding.serialization.macros.LowerPriorityImplicit#primitiveOrderedBufferSupplier()Lcom/twitter/scalding/serialization/OrderedSerialization;.
+  43: minitest.api.Asserts#intercept(Lscala/Function0;)V.
+  43: org.scalatest.Matchers#StringShouldWrapper#shouldNot(Lorg/scalatest/words/CompileWord;Lorg/scalactic/source/Position;)Lorg/scalatest/compatible/Assertion;.
+  39: org.specs2.specification.create.AutoExamples#eg(Lscala/Function0;Lorg/specs2/execute/AsResult;)Lorg/specs2/specification/core/Fragments;.
+  37: records.Rec.fld(Lrecords/Rec;)Ljava/lang/Object;.
+  36: play.api.libs.json.Json.format()Lplay/api/libs/json/OFormat;.
+  33: spire.syntax.Literals#h()S.
+  ... truncated
 ```
 The complete list of results can be seen in [this gist](https://gist.github.com/olafurpg/be9d01afab4e2e54e51be620279507aa).
 Judging by the numbers, it seems that


### PR DESCRIPTION
I must have done something wrong when counting the number "3 million"
because I can only count 2.3 million lines now and when I deduplicate
cross-built jvm/js files then it's only 2 million lines of code.

The distribution of the results does not change too much however, so I don't think too much damage was done. js+jvm macros like those in spire/minitest get less usage.

See related discussion here
https://github.com/scala/community-builds/issues/59#issuecomment-347643985