### PR TITLE
Add release date to download list

### DIFF
--- a/_includes/download-resource-list.html
+++ b/_includes/download-resource-list.html
@@ -9,7 +9,10 @@ To see a detailed list of changes for each version of Scala please refer to the 
 
 <ul>
   {% for release in page.other_releases %}
-  <li><a href="/download/{{ release[2] }}.html">{{ release[1] }} - Scala {{ release[2] }}</a></li>
+  <li>{{ release[1] }}:
+    <ul>
+      <li><a href="/download/{{ release[2] }}.html">Scala {{ release[2] }}</a> - Released on {{ release[3] }}</li>
+    </ul></li>
   {% endfor %}
   <li><a href="/files/archive/nightly/">Nightly builds</a></li>
   <li><a href="/download/changelog.html">Changelog</a></li>


### PR DESCRIPTION
On the download page, the historical release links look a little clumsy and are hard to visually scan:

http://scala-lang.org/download/#other-releases

![screen shot 2017-12-07 at 12 19 43 pm](https://user-images.githubusercontent.com/358615/33728789-98b3ae4c-db49-11e7-84e2-441a8beabc4d.png)