### PR TITLE
Broken scala platform links

### DIFF
--- a/_posts/2016-11-28-spp.md
+++ b/_posts/2016-11-28-spp.md
@@ -33,8 +33,8 @@ alone.
 
 The infrastructure that the Scala Center provides includes:
 
-* [sbt-platform plugin](https://scalacenter.github.io/platform-staging/sbt-platform.html),
-* [continuous integration](https://scalacenter.github.io/platform-staging/ci-integration.html), and
+* [sbt-platform plugin](https://scalacenter.github.io/platform/sbt-platform.html),
+* [continuous integration](https://scalacenter.github.io/platform/ci-integration.html), and
 * a release manager.
 
 The sbt-platform plugin bundles together many tasks required for Scala Platform
@@ -63,10 +63,10 @@ The goals of these policies are to create and evolve friendly communities around
 the modules and to provide a way for libraries to synchronize on releases and
 updates while still providing stability guarantees to users. For that, the
 process offers contracts for maintaining and contributing to modules as well as
-a [predictable release process](https://scalacenter.github.io/platform-staging/policies.html#policies-on-release-and-stability).
+a [predictable release process](https://scalacenter.github.io/platform/policies.html#policies-on-release-and-stability).
 
 The aforementioned policies can be best summed up as a slightly [modified version
-of the C4 contract](https://scalacenter.github.io/platform-staging/policies.html#policies-on-committers-and-contributors), Pieter Hintjens’ set of rules that made ZeroMQ successful.
+of the C4 contract](https://scalacenter.github.io/platform/policies.html#policies-on-committers-and-contributors), Pieter Hintjens’ set of rules that made ZeroMQ successful.
 
 ### The Collective Code Construction Contract (C4) contract
 
@@ -165,7 +165,8 @@ The process has been designed to “give feedback early, give feedback often” 
 any proposal. We encourage you to [get your hands dirty and submit
 yours](https://scalacenter.github.io/platform/proposal-submission.html)!
 
-Stay tuned, our first SPP meeting is to be broadcasted on Monday, 17th January!
-[Tune in here](https://www.youtube.com/watch?v=eqSSXg7Up2I)!
+## SPP Meetings
+
+Stay tuned, you can follow our regular SPP meetings, which are broadcast live on YouTube at the [Scala Process YouTube Channel](https://www.youtube.com/channel/UCn_8OeZlf5S6sqCqntAvaIw)!
 
 [discourse]: https://contributors.scala-lang.org/

--- a/_posts/2016-11-28-spp.md
+++ b/_posts/2016-11-28-spp.md
@@ -163,7 +163,7 @@ To make the Scala Platform successful, we need the help from the Community. Here
 
 The process has been designed to “give feedback early, give feedback often” on
 any proposal. We encourage you to [get your hands dirty and submit
-yours](https://scalacenter.github.io/platform-staging/proposal-submission.html)!
+yours](https://scalacenter.github.io/platform/proposal-submission.html)!
 
 Stay tuned, our first SPP meeting is to be broadcasted on Monday, 17th January!
 [Tune in here](https://www.youtube.com/watch?v=eqSSXg7Up2I)!

--- a/_posts/2016-11-28-spp.md
+++ b/_posts/2016-11-28-spp.md
@@ -158,7 +158,7 @@ interest of the Scala community, not their personal or employers' viewpoints.
 To make the Scala Platform successful, we need the help from the Community. Here's how you can get involved!:
 
 1. Make suggestions to improve the Scala Platform policies on our [Scala Contributors Discourse Forum][discourse].
-2. [Create a Scala Platform proposal](https://scalacenter.github.io/platform-staging/proposal-submission.html);
+2. [Create a Scala Platform proposal](https://scalacenter.github.io/platform/proposal-submission.html);
 3. Discuss and give feedback on current proposals on our [Scala Contributors Discourse Forum][discourse];
 
 The process has been designed to “give feedback early, give feedback often” on


### PR DESCRIPTION
* Many links were pointing at some kind of staging site, they now point at the correct SPP links
* There was a link to the first SPP meeting which was said to be in the future but is now in the past. I replaced that with a link to the Scala Process youtube channel.