### PR TITLE
Let Travis do the bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,7 @@ language: ruby
 rvm:
   - 2.3.1
 
-# for faster builds
 cache: bundler
-env: BUNDLE_PATH=bundle-vendor/bundle
-
-# we must override install, or Travis's default Gemfile support
-# will kick in and use `vendor`, ignoring our BUNDLE_PATH
-# declaration in `.bundle/config`
-install:
-- bundle update jekyll
-- bundle install
 
 script:
 - bundle exec jekyll build 2> error.log


### PR DESCRIPTION
To Jarrod's point in #844, Travis can do a lot of the necessary Ruby-isms to build the site automagically.

Travis will even run install with the appropriate settings:

```
bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
```

And the caching feature requires less rigamarole now a days:

https://docs.travis-ci.com/user/caching/