### PR TITLE
Make the front-page title less jargony

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,8 +2,8 @@
 layout: frontpage
 
 # Header texts
-headerTitle: "Object-Oriented Meets Functional"
-headerSubtitle: "Have the best of both worlds. Construct elegant class hierarchies for maximum code reuse and extensibility, implement their behavior using higher-order functions. Or anything in-between."
+headerTitle: "The Scala Programming Language"
+headerSubtitle: "Scala is a typed high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and it's runtime is suitable for building efficient, high-performance systems."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its fast runtime lets you build building efficient, high-performance systems."
+headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, its fast runtime lets you build building efficient, high-performance systems, with easy access to a huge ecosystem of library"
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its runtime is suitable for building efficient, high-performance systems."
+headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its fast runtime lets you build building efficient, high-performance systems."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, its fast runtime lets you build building efficient, high-performance systems, with easy access to a huge ecosystem of libraries."
+headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, its fast runtime lets you build efficient, high-performance systems, with easy access to a huge ecosystem of libraries."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a typed high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and it's runtime is suitable for building efficient, high-performance systems."
+headerSubtitle: "Scala is a typed high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its runtime is suitable for building efficient, high-performance systems."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a typed high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its runtime is suitable for building efficient, high-performance systems."
+headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its runtime is suitable for building efficient, high-performance systems."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, its fast runtime lets you build building efficient, high-performance systems, with easy access to a huge ecosystem of library"
+headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, its fast runtime lets you build building efficient, high-performance systems, with easy access to a huge ecosystem of libraries."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: frontpage
 
 # Header texts
 headerTitle: "The Scala Programming Language"
-headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, its fast runtime lets you build efficient, high-performance systems, with easy access to a huge ecosystem of libraries."
+headerSubtitle: "Scala is a concise high-level programming language. Scala's compiler helps you avoid bugs when writing complex applications, and its fast runtime lets you build efficient, high-performance systems, with easy access to a huge ecosystem of libraries."
 headerButtonTitle: "Learn More"
 headerButtonUrl: "/what-is-scala/"
 


### PR DESCRIPTION
The current title is pretty strange; it really doesn't mean anything to me, someone who has been using Scala for a long time, and would mean even less to a newcomer. We should dispense with the jargon and say what people would be interested in hearing, in plain language that any programmer can understand.