### PR TITLE
Correct a date for ScalaSphere

### DIFF
--- a/_events/2018-04-15-scalasphere.md
+++ b/_events/2018-04-15-scalasphere.md
@@ -4,7 +4,7 @@ title: ScalaSphere
 logo: /resources/img/scalasphere.png
 location: Kraków, Poland
 description: "Let’s immerse ourselves into Scala Dev Tools"
-start: 16 April 2018
+start: 15 April 2018
 end: 17 April 2018
 link-out: http://scala.sphere.it
 ---


### PR DESCRIPTION
There's another day (workshops, hackathons) before the conference itself which we count as an integral part of a whole event.