### PR TITLE
Remove deprecated sample from the 'concurrency&distribution' example

### DIFF
--- a/_scala_items/3-concurrency-distribution.md
+++ b/_scala_items/3-concurrency-distribution.md
@@ -7,8 +7,8 @@ scastieUrl:
                                 <div class="scala-code">
                                     <div class="code-element">
                                         <div class="bar-code"><span>Concurrent/Distributed</span></div>
-                                        <pre><code>val x = future { someExpensiveComputation() }
-val y = future { someOtherExpensiveComputation() }
+                                        <pre><code>val x = Future { someExpensiveComputation() }
+val y = Future { someOtherExpensiveComputation() }
 val z = for (a &lt;- x; b &lt;- y) yield a*b
 for (c &lt;- z) println("Result: " + c)
 println("Meanwhile, the main thread goes on!")</code></pre>
@@ -18,7 +18,7 @@ println("Meanwhile, the main thread goes on!")</code></pre>
                                     <h3>Go Concurrent or Distributed with Futures &amp; Promises</h3>
                                     <p>In Scala, futures and promises can be used to process data <i>asynchronously</i>, making it easier to parallelize or even distribute your application.</p>
 <p>
-In this example, the <code>future{}</code> construct evaluates its argument asynchronously, and returns
+In this example, the <code>Future{}</code> construct evaluates its argument asynchronously, and returns
 a handle to the asynchronous result as a <code>Future[Int]</code>.
 For-comprehensions can be used to register new callbacks (to post new things to do) when the future is
 completed, i.e., when the computation is finished.


### PR DESCRIPTION
Fixes https://github.com/scala/scala-lang/issues/876

Related: https://github.com/scala/scala-lang/pull/642