### PR TITLE
Ignore htmlproofer of own GitHub repo

### DIFF
--- a/_includes/sidebar-toc.html
+++ b/_includes/sidebar-toc.html
@@ -6,7 +6,7 @@
 
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala-lang/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala-lang/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}" data-proofer-ignore><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>
 {% endif %}


### PR DESCRIPTION
HTMLProofer should skip checking links that say "Problem with this page?  Help us fix it!" which are links to the scala-lang repository.

When adding a new file, the link in the sidebar to its file in git doesn't exist yet!  So the build of the PR in Travis will fail because HTMLProofer complains.

This fixes #875.