### PR TITLE
Use headings for Scala 3 questions

### DIFF
--- a/blog/_posts/2018-04-19-scala-3.md
+++ b/blog/_posts/2018-04-19-scala-3.md
@@ -15,18 +15,18 @@ Of course, this statement invites many follow-up questions. Here are
 some answers we can already give today. We expect there will be more
 questions and answers as things shape up.
 
-_When will it come out?_
+### When will it come out?
 
 The intent is to publish the final Scala 3.0 soon after Scala 2.14. At the
 current release schedule (which might still change), that means early 2020.
 
-_What is Scala 2.14 for?_
+### What is Scala 2.14 for?
 
 Scala 2.14's main focus will be on smoothing the migration to Scala 3.
 It will do this by defining migration tools, shim libraries, and
 targeted deprecations, among others.
 
-_What's new in Scala 3?_
+### What's new in Scala 3?
 
 Scala has pioneered the fusion of object-oriented and functional
 programming in a typed setting. Scala 3 will be a big step towards
@@ -50,7 +50,7 @@ programmers already know about Scala 2 applies to Scala 3 as well, and
 most ordinary Scala 2 code will also work on Scala 3 with only minor
 changes.
 
-_What about migration?_
+### What about migration?
 
 As with previous Scala upgrades, Scala 3 is not binary compatible with Scala 2.
 They are mostly source compatible, but differences exist. However:
@@ -65,7 +65,7 @@ They are mostly source compatible, but differences exist. However:
  - The compiler can perform many of the rewritings automatically using a `-rewrite` option.
  - Migration through automatic rewriting will also be offered through the [scalafix](https://github.com/scalacenter/scalafix) tool, which can convert sources to the cross-buildable language subset without requiring Scala 3 to be installed.
 
-_What’s the expected state of tool support?_
+### What’s the expected state of tool support?
 
  - Compiler: The Scala 3 compiler `dotc` has been used to compile itself and a growing set of libraries for a number of years now.
  - IDEs: IDE support is provided by having `dotc` implement LSP, the [Language Server Protocol](https://langserver.org),
@@ -76,7 +76,7 @@ _What’s the expected state of tool support?_
  - Docs: A revamped Scaladoc tool generates docs for viewing in a browser and (in the future) also in the IDE..
  - Build tools: There is a Dotty/Scala 3 plugin for [sbt](https://www.scala-sbt.org), and we will also work on Scala 3 integration in other build tools.
 
-_What about stability?_
+### What about stability?
 
  - A [community build](https://github.com/lampepfl/dotty-community-build) contains some [initial open source projects](https://github.com/lampepfl/dotty-community-build/blob/master/src/test/scala/dotty/communitybuild/CommunityBuildTest.scala) that are compiled nightly using Scala 3. We plan to add a lot more projects to the build between now and the final release.
  - We plan to use the period of developer previews to ensure that core projects are published for Scala 3.
@@ -86,7 +86,7 @@ _What about stability?_
    Basing the build exclusively on Scala 3 has the advantage that it lets us “eat our own dog food”
    and try out the usability of Scala 3’s new language feature on a larger scale.
 
-_When can I try it out?_
+### When can I try it out?
 
 You can start working with Dotty now. See the [getting
 started](http://dotty.epfl.ch/docs/contributing/getting-started.html)
@@ -94,12 +94,12 @@ guide. Dotty releases are published every 6 weeks. We expect to be in
 feature-freeze and to release developer previews for Scala 3.0 in the
 first half of 2019.
 
-_What about macros?_
+### What about macros?
 
 Stay tuned! We are about to release another blog post specifically
 about that issue.
 
-_How can I help?_
+### How can I help?
 
 Scala 3 is developed completely in the open at
 [https://github.com/lampepfl/dotty](https://github.com/lampepfl/dotty).


### PR DESCRIPTION
Makes the questions more prominent and makes them clickable from the "contents" menu in the sidebar.