### PR TITLE
Increase color contrast of page title and link.

### DIFF
--- a/_sass/utils/_variables.scss
+++ b/_sass/utils/_variables.scss
@@ -6,11 +6,11 @@
 //------------------------------------------------
 $brand-primary: #DC322F;
 $brand-secondary: #859900;
-$brand-tertiary: #5CC6E4;
+$brand-tertiary: #0080A3;
 //-------------------------------------------------
 $gray-darker: #002B36;
 $gray-dark: #073642;
-$gray: #15414C;
+$gray: #133942;
 $gray-li: #244E58;
 $gray-light: #E5EAEA;
 $gray-lighter: #F0F3F3;
@@ -53,7 +53,7 @@ $font-black: 900;
 
 // Link Colors
 //------------------------------------------------
-$base-link-color: darken($brand-tertiary, 15%);
+$base-link-color: $brand-tertiary;
 $hover-link-color: $brand-primary;
 
 // Border


### PR DESCRIPTION
Addresses the issue https://github.com/scala/docs.scala-lang/issues/941 along with PR https://github.com/scala/docs.scala-lang/pull/1065


# Before

![lang-before](https://user-images.githubusercontent.com/127635/39609308-f9870874-4f82-11e8-8d5f-3de612363064.jpg)

# After

![lang-after](https://user-images.githubusercontent.com/127635/39609309-f9af9398-4f82-11e8-87a7-ecf7aa9c1a8d.jpg)
