### PR TITLE
upgrade nokogiri, because security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       addressable (~> 2.3)
       colorize (~> 0.8)
       mercenary (~> 0.3.2)
-      nokogiri (~> 1.8.1)
+      nokogiri (~> 1.8.2)
       parallel (~> 1.3)
       typhoeus (~> 1.3)
       yell (~> 2.0)


### PR DESCRIPTION
GitHub's "vulnerability alerts" feature recommended this change,
at https://github.com/scala/docs.scala-lang/network/dependencies

see also scala/docs.scala-lang#1083