### PR TITLE
excluded /bin from being served up

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ highlighter:
 
 exclude:
   - bundle-vendor/
+  - bin/
   - blog/README.md
   - training/README.md
   - README.md


### PR DESCRIPTION
This stops https://scala-lang.org/bin/ from being served up.