### PR TITLE
Update JDK link

### DIFF
--- a/documentation/your-first-lines-of-scala.md
+++ b/documentation/your-first-lines-of-scala.md
@@ -54,7 +54,7 @@ The shortcut `:q` stands for the internal shell command `:quit` used to exit the
 
 ### Compile it!
 
-The `scalac` command compiles one (or more) Scala source file(s) and generates Java bytecode which can be executed on any [standard JVM](http://java.sun.com/docs/books/jvms/). The Scala compiler works similarly to `javac`, the Java compiler of the [Java SDK](http://java.sun.com/javase/).
+The `scalac` command compiles one (or more) Scala source file(s) and generates Java bytecode which can be executed on any [standard JVM](http://java.sun.com/docs/books/jvms/). The Scala compiler works similarly to `javac`, the Java compiler of the [Java SDK](http://www.oracle.com/technetwork/java/index.html).
 
     > scalac HelloWorld.scala
 


### PR DESCRIPTION
The previous URL is a 301 Redirect to this one, which makes htmlproofer
unhappy. Not sure why it thinks the response is a 403 - I don't get that
when I hit it with curl.