### PR TITLE
Add Scala Native Gitter channel

### DIFF
--- a/_data/chats-forums.yml
+++ b/_data/chats-forums.yml
@@ -21,6 +21,8 @@ gitterChannels:
     url: https://gitter.im/scala/job-board
   - name: spark-scala/Lobby
     url: https://gitter.im/spark-scala/Lobby
+  - name: scala-native/scala-native
+    url: https://gitter.im/scala-native/scala-native
   - name: scala-js/scala-js
     url: https://gitter.im/scala-js/scala-js
 

--- a/community/index.md
+++ b/community/index.md
@@ -63,6 +63,7 @@ Other, more specialized rooms include:
 * **[scala/contributors](https://gitter.im/scala/contributors)**: for contributors to discuss work on changes to Scala.
 * **[scala/moocs](https://gitter.im/scala/moocs)**: for talking about the Scala Center's online courses
 * **[scala/job-board](https://gitter.im/scala/job-board)**: for employers and job seekers to connect with each other
+* **[scala-native/scala-native](https://gitter.im/scala-native/scala-native)**: for discussion about the Scala to LLVM compiler.
 * **[scala-js/scala-js](https://gitter.im/scala-js/scala-js)**: for discussion about the Scala to JavaScript compiler.
 
 International rooms are available as well:


### PR DESCRIPTION
Add Scala Native Gitter channel in `_data/chats-forums.yml` and `community/index.md`.

Refs: scala/docs.scala-lang#1139
Closes: scala/docs.scala-lang#1139