### PR TITLE
Ignore www.oracle.com in htmlproofer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - find ./_site \( -type d \( -name events -o -name training \) -prune -false \) -o \( -type f ! -name error.log -empty \)
 - find ./_site \( -type d \( -name events -o -name training \) -prune -false \) -o \( -type f ! -name error.log -empty \) | ( ! read )
 - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then bundle exec htmlproofer ./_site/ --disable-external --only-4xx --empty-alt-ignore --allow-hash-href ; fi
-- if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then bundle exec htmlproofer ./_site/ --external_only --only-4xx --empty-alt-ignore --allow-hash-href --url-ignore "/trends.google.com/,/pgp.mit.edu/" ; fi
+- if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then bundle exec htmlproofer ./_site/ --external_only --only-4xx --empty-alt-ignore --allow-hash-href --url-ignore "/trends.google.com/,/pgp.mit.edu/,/www.oracle.com/" ; fi
 
 notifications:
   email:


### PR DESCRIPTION
These links can't be helped.  They just keep failing intermittently.

If these break, I'm pretty sure we'll hear about it, unlike a lot of the many other obscure links on the site.  I believe it only affects 3 links on 3 pages:

```
- ./_site/documentation/your-first-lines-of-scala.html
  *  External link https://www.oracle.com/technetwork/java/index.html failed: 403 No error
- ./_site/download/2.12.7.html
  *  External link http://www.oracle.com/technetwork/java/javase/downloads/index.html failed: 403 No error
- ./_site/news/2.12.0/index.html
  *  External link https://www.oracle.com/technetwork/java/javase/downloads/index.html failed: 403 No error
```

Fixes #945.