### PR TITLE
Provide a direct link to Java 8 download page

### DIFF
--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -25,7 +25,7 @@ layout: inner-page-parent
               <h3>First, make sure you have the Java 8 JDK installed.</h3>
               <p>To check, open the terminal and type:</p>
               <p><code>java -version</code><span>(Make sure you have version 1.8.)</span></p>
-              <p><i>(If you don't have it installed, <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">download Java here</a>.)</i></p>
+              <p><i>(If you don't have it installed, <a href="https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html">download Java here</a>.)</i></p>
             </div>
           </div>
           <div class="step">


### PR DESCRIPTION
This is to prevent beginners from accidentally using Java 11, since it's not yet supported on mainstream Scala releases.
See also my comments on https://contributors.scala-lang.org/t/java-version-collision-for-beginners-weird-sbt-errors/2593