### PR TITLE
Bad links according to htmlproofer 

### DIFF
--- a/_events/2014-03-01-nescala.md
+++ b/_events/2014-03-01-nescala.md
@@ -6,5 +6,5 @@ location: New York City
 description: community, volunteer-organized regional conference
 start: 1 March 2014
 end: 2 March 2014
-link-out: http://nescala.org
+link-out: http://www.nescala.org
 ---

--- a/_events/2015-01-30-nescala.md
+++ b/_events/2015-01-30-nescala.md
@@ -6,5 +6,5 @@ location: Boston
 description: "5th year! day 1, talks voted for by attendees; day 2, unconference"
 start: 30 January 2015
 end: 31 January 2015
-link-out: http://nescala.org/
+link-out: http://www.nescala.org/
 ---

--- a/_events/2016-03-04-nescala.md
+++ b/_events/2016-03-04-nescala.md
@@ -6,5 +6,5 @@ location: Philadelphia
 description: "6th year! day 1, talks voted for by attendees; day 2, unconference"
 start: 4 March 2016
 end: 5 March 2016
-link-out: http://nescala.org/
+link-out: http://www.nescala.org/
 ---

--- a/_events/2017-03-24-nescala.md
+++ b/_events/2017-03-24-nescala.md
@@ -6,5 +6,5 @@ location: New York
 description: "7th year!"
 start: 24 March 2017
 end: 25 March 2017
-link-out: http://nescala.org/
+link-out: http://www.nescala.org/
 ---

--- a/_posts/2015-06-25-bagwell-award-2015.md
+++ b/_posts/2015-06-25-bagwell-award-2015.md
@@ -7,7 +7,7 @@ We are pleased to announce that the Phil Bagwell Memorial Scala Community Award 
 
 Bill is known to Scala users as:
 
-* creator of [ScalaTest](http://scalatest.org), a popular open-source test framework first [released in 2008](http://www.artima.com/weblogs/viewpost.jsp?thread=222678), as well as other tools and libraries such as [Scalactic](http://www.scalactic.org)
+* creator of [ScalaTest](http://www.scalatest.org), a popular open-source test framework first [released in 2008](http://www.artima.com/weblogs/viewpost.jsp?thread=222678), as well as other tools and libraries such as [Scalactic](http://www.scalactic.org)
 * co-author of the first Scala book, [_Programming in Scala_](http://www.artima.com/shop/programming_in_scala_3ed) (Artima)
 * founder of [Artima](http://www.artima.com/aboutartima.html), which continues to publish [Scala-themed books](http://www.artima.com/shop/catalog), and hosted Scala-themed blogs and forums which were important in spreading the news about Scala in its early years
 * friendly and tireless conference-goer, presenter, and trainer


### PR DESCRIPTION
They are failing with "404 No error" on Travis cron jobs:

https://travis-ci.org/scala/scala-lang/builds/468673098

I can't reproduce it locally, so this is really just a desperate act.