### PR TITLE
Bad nescala link by adding "www"

### DIFF
--- a/_events/2018-03-18-nescala.md
+++ b/_events/2018-03-18-nescala.md
@@ -6,5 +6,5 @@ location: Cambridge, MA
 description: "The Scala conference of the Northeastern US - Unconference + NE Scala + Typelevel Summit"
 start: 18 March 2018
 end: 20 March 2018
-link-out: http://nescala.org/
+link-out: http://www.nescala.org/
 ---


### PR DESCRIPTION
Doing this worked for the other links.  Seems one snuck by me or got added before the fix was merged in #990.