### PR TITLE
Update Northeast Scala Symposium events

### DIFF
--- a/_events/2011-02-18-nescala.md
+++ b/_events/2011-02-18-nescala.md
@@ -1,0 +1,10 @@
+---
+category: event
+title: Northeast Scala Symposium
+logo: /resources/img/nescala.png
+location: New York, NY, USA
+description: Make some friends and have higher-kinded conversations
+start: 18 February 2011
+end: 18 February 2011
+link-out: https://nescala.io/2011/index.html
+---

--- a/_events/2012-03-09-nescala.md
+++ b/_events/2012-03-09-nescala.md
@@ -1,0 +1,10 @@
+---
+category: event
+title: Northeast Scala Symposium
+logo: /resources/img/nescala.png
+location: Boston, MA, USA
+description: functionally typed party
+start: 9 March 2012
+end: 11 March 2012
+link-out: https://nescala.io/2012/index.html
+---

--- a/_events/2013-02-08-nescala.md
+++ b/_events/2013-02-08-nescala.md
@@ -1,0 +1,10 @@
+---
+category: event
+title: Northeast Scala Symposium
+logo: /resources/img/nescala.png
+location: Philadelphia, PA, USA
+description: Scala community liberation in Philly
+start: 8 February 2013
+end: 9 February 2013
+link-out: https://nescala.io/2013/index.html
+---

--- a/_events/2014-03-01-nescala.md
+++ b/_events/2014-03-01-nescala.md
@@ -2,9 +2,9 @@
 category: event
 title: Northeast Scala Symposium
 logo: /resources/img/nescala.png
-location: New York City
+location: New York, NY, USA
 description: community, volunteer-organized regional conference
 start: 1 March 2014
 end: 2 March 2014
-link-out: http://www.nescala.org
+link-out: https://nescala.io/2014/index.html
 ---

--- a/_events/2015-01-30-nescala.md
+++ b/_events/2015-01-30-nescala.md
@@ -2,9 +2,9 @@
 category: event
 title: Northeast Scala Symposium
 logo: /resources/img/nescala.png
-location: Boston
+location: Boston, MA, USA
 description: "5th year! day 1, talks voted for by attendees; day 2, unconference"
 start: 30 January 2015
 end: 31 January 2015
-link-out: http://www.nescala.org/
+link-out: https://nescala.io/2015/index.html
 ---

--- a/_events/2016-03-04-nescala.md
+++ b/_events/2016-03-04-nescala.md
@@ -2,9 +2,9 @@
 category: event
 title: Northeast Scala Symposium
 logo: /resources/img/nescala.png
-location: Philadelphia
+location: Philadelphia, PA, USA
 description: "6th year! day 1, talks voted for by attendees; day 2, unconference"
 start: 4 March 2016
 end: 5 March 2016
-link-out: http://www.nescala.org/
+link-out: https://nescala.io/2016/index.html
 ---

--- a/_events/2017-03-24-nescala.md
+++ b/_events/2017-03-24-nescala.md
@@ -2,9 +2,9 @@
 category: event
 title: Northeast Scala Symposium
 logo: /resources/img/nescala.png
-location: New York
+location: New York, NY, USA
 description: "7th year!"
 start: 24 March 2017
 end: 25 March 2017
-link-out: http://www.nescala.org/
+link-out: https://nescala.io/2017/index.html
 ---

--- a/_events/2018-03-18-nescala.md
+++ b/_events/2018-03-18-nescala.md
@@ -2,9 +2,9 @@
 category: event
 title: Northeast Scala Symposium
 logo: /resources/img/nescala.png
-location: Cambridge, MA
+location: Cambridge, MA, USA
 description: "The Scala conference of the Northeastern US - Unconference + NE Scala + Typelevel Summit"
 start: 18 March 2018
 end: 20 March 2018
-link-out: http://www.nescala.org/
+link-out: https://nescala.io/2018/index.html
 ---

--- a/_events/2019-04-02-nescala.md
+++ b/_events/2019-04-02-nescala.md
@@ -2,9 +2,9 @@
 category: event
 title: Northeast Scala Symposium
 logo: /resources/img/nescala.png
-location: Philadelphia, PA
+location: Philadelphia, PA, USA
 description: "The Scala conference of the Northeastern US"
 start: 2 April 2019
 end: 3 April 2019
-link-out: http://www.nescala.org/
+link-out: https://nescala.io/
 ---


### PR DESCRIPTION
https://nescala.io/ is the new url, hosting all previous editions