### PR TITLE
strengthen wording about in-channel discussion of moderation

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -48,7 +48,7 @@ the [Scala Center](https://scala.epfl.ch/).
 - If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.
 - If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
 - Moderators may choose at their discretion to un-ban the user if it was a first offense and they if they make suitable amends with the offended party.
-- If you think a ban is unjustified, please take it up with that moderator, or with a different moderator, in private. Complaints about bans in-channel are not allowed.
+- If you think a moderator action is unjustified, please take it up with that moderator, or with a different moderator, in private. Complaints about moderation in-channel are not allowed.
 - Moderators are held to a higher standard than other community members. If a moderator acts inappropriately, they should expect less leeway than others.
 
 In the Scala community we strive to go the extra step to look out for each


### PR DESCRIPTION
```diff
-If you think a ban is unjustified
+If you think a moderator action is unjustified
-Complaints about bans in-channel are not allowed
+Complaints about moderation in-channel are not allowed
```

this is pretty minor change, but it is a change. we don't really have a process for changing the CoC, but I guess I'll ask for review for starters from: @adriaanm @sjrd 

I think the new wording better reflects the intent and goals (my understanding of them, anyway, as a co-drafter of the CoC, and a longtime community moderator) of this part of the code. The goal is to keep the channel on-topic and not allow meta-discussion to distract from the purpose of the channel. Discussion about a warning is equally off-topic as discussion of a ban.

This dovetails with the (soon-to-be-merged, I believe) #1011, which provides better guidance about where to take complaints about moderation instead.