### PR TITLE
Fix the declared licenses on the download pages

### DIFF
--- a/_downloads/2007-05-21-2.5.0.final.md
+++ b/_downloads/2007-05-21-2.5.0.final.md
@@ -7,6 +7,7 @@ release_date: "May 21, 2007"
 show_resources: "true"
 permalink: /download/2.5.0.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.5.0-final.tar.gz",             "https://scala-lang.org/files/archive/scala-2.5.0-final.tar.gz",                "Mac OS X, Unix, Cygwin",  "12 MB"],
   ["-main-windows", "scala-2.5.0-final.zip",                "https://scala-lang.org/files/archive/scala-2.5.0-final.zip",                   "Windows",                 "13 MB"]

--- a/_downloads/2007-06-13-2.5.1.final.md
+++ b/_downloads/2007-06-13-2.5.1.final.md
@@ -7,6 +7,7 @@ release_date: "June 13, 2007"
 show_resources: "true"
 permalink: /download/2.5.1.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.5.1-final.tar.gz",             "https://scala-lang.org/files/archive/scala-2.5.1-final.tar.gz",                "Mac OS X, Unix, Cygwin",  "12 MB"],
   ["-main-windows", "scala-2.5.1-final.zip",                "https://scala-lang.org/files/archive/scala-2.5.1-final.zip",                   "Windows",                 "13 MB"]

--- a/_downloads/2007-09-11-2.6.0.final.md
+++ b/_downloads/2007-09-11-2.6.0.final.md
@@ -7,6 +7,7 @@ release_date: "September 11, 2007"
 show_resources: "true"
 permalink: /download/2.6.0.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.6.0-final.tar.gz",             "https://scala-lang.org/files/archive/scala-2.6.0-final.tar.gz",                "Mac OS X, Unix, Cygwin",  "13 MB"],
   ["-main-windows", "scala-2.6.0-final.zip",                "https://scala-lang.org/files/archive/scala-2.6.0-final.zip",                   "Windows",                 "15 MB"]

--- a/_downloads/2007-12-19-2.6.1.final.md
+++ b/_downloads/2007-12-19-2.6.1.final.md
@@ -7,6 +7,7 @@ release_date: "December 19, 2007"
 show_resources: "true"
 permalink: /download/2.6.1.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.6.1-final.tar.gz",             "https://scala-lang.org/files/archive/scala-2.6.1-final.tar.gz",                "Mac OS X, Unix, Cygwin",  "14 MB"],
   ["-main-windows", "scala-2.6.1-final.zip",                "https://scala-lang.org/files/archive/scala-2.6.1-final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2008-03-06-2.7.0.final.md
+++ b/_downloads/2008-03-06-2.7.0.final.md
@@ -7,6 +7,7 @@ release_date: "March 6, 2008"
 show_resources: "true"
 permalink: /download/2.7.0.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.0.final.tar.gz",             "https://scala-lang.org/files/archive/scala-2.7.0-final.tar.gz",                "Mac OS X, Unix, Cygwin",  "13 MB"],
   ["-main-windows", "scala-2.7.0.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.0-final.zip",                   "Windows",                 "13 MB"]

--- a/_downloads/2008-05-05-2.7.1.final.md
+++ b/_downloads/2008-05-05-2.7.1.final.md
@@ -7,6 +7,7 @@ release_date: "May 5, 2008"
 show_resources: "true"
 permalink: /download/2.7.1.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.1.final.tar.gz",             "https://scala-lang.org/files/archive/scala-2.7.1.final.tar.gz",                "Mac OS X, Unix, Cygwin",  "13 MB"],
   ["-main-windows", "scala-2.7.1.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.1.final.zip",                   "Windows",                 "13 MB"]

--- a/_downloads/2008-11-10-2.7.2.final.md
+++ b/_downloads/2008-11-10-2.7.2.final.md
@@ -7,6 +7,7 @@ release_date: "November 10, 2008"
 show_resources: "true"
 permalink: /download/2.7.2.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.2.final.tgz",                "https://scala-lang.org/files/archive/scala-2.7.2.final.tgz",                   "Mac OS X, Unix, Cygwin",  "16 MB"],
   ["-main-windows", "scala-2.7.2.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.2.final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2009-01-13-2.7.3.final.md
+++ b/_downloads/2009-01-13-2.7.3.final.md
@@ -7,6 +7,7 @@ release_date: "January 13, 2009"
 show_resources: "true"
 permalink: /download/2.7.3.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.3.final.tgz",                "https://scala-lang.org/files/archive/scala-2.7.3.final.tgz",                   "Mac OS X, Unix, Cygwin",  "16 MB"],
   ["-main-windows", "scala-2.7.3.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.3.final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2009-04-24-2.7.4.final.md
+++ b/_downloads/2009-04-24-2.7.4.final.md
@@ -7,6 +7,7 @@ release_date: "April 24, 2009"
 show_resources: "true"
 permalink: /download/2.7.4.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.4.final.tgz",                "https://scala-lang.org/files/archive/scala-2.7.4.final.tgz",                   "Mac OS X, Unix, Cygwin",  "16 MB"],
   ["-main-windows", "scala-2.7.4.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.4.final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2009-06-02-2.7.5.final.md
+++ b/_downloads/2009-06-02-2.7.5.final.md
@@ -7,6 +7,7 @@ release_date: "June 2, 2009"
 show_resources: "true"
 permalink: /download/2.7.5.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.5.final.tgz",                "https://scala-lang.org/files/archive/scala-2.7.5.final.tgz",                   "Mac OS X, Unix, Cygwin",  "16 MB"],
   ["-main-windows", "scala-2.7.5.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.5.final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2009-09-10-2.7.6.final.md
+++ b/_downloads/2009-09-10-2.7.6.final.md
@@ -7,6 +7,7 @@ release_date: "September 10, 2009"
 show_resources: "true"
 permalink: /download/2.7.6.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.6.final.tgz",                "https://scala-lang.org/files/archive/scala-2.7.6.final.tgz",                   "Mac OS X, Unix, Cygwin",  "16 MB"],
   ["-main-windows", "scala-2.7.6.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.6.final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2009-12-28-2.7.7.final.md
+++ b/_downloads/2009-12-28-2.7.7.final.md
@@ -7,6 +7,7 @@ release_date: "December 28, 2009"
 show_resources: "true"
 permalink: /download/2.7.7.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.7.7.final.tgz",                "https://scala-lang.org/files/archive/scala-2.7.7.final.tgz",                   "Mac OS X, Unix, Cygwin",  "16 MB"],
   ["-main-windows", "scala-2.7.7.final.zip",                "https://scala-lang.org/files/archive/scala-2.7.7.final.zip",                   "Windows",                 "16 MB"]

--- a/_downloads/2010-07-14-2.8.0.final.md
+++ b/_downloads/2010-07-14-2.8.0.final.md
@@ -7,6 +7,7 @@ release_date: "July 14, 2010"
 show_resources: "true"
 permalink: /download/2.8.0.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.8.0.final.tgz",                "https://scala-lang.org/files/archive/scala-2.8.0.final.tgz",                   "Mac OS X, Unix, Cygwin",  "19 MB"],
   ["-main-windows", "scala-2.8.0.final.zip",                "https://scala-lang.org/files/archive/scala-2.8.0.final.zip",                   "Windows",                 "19 MB"]

--- a/_downloads/2010-11-09-2.8.1.final.md
+++ b/_downloads/2010-11-09-2.8.1.final.md
@@ -7,6 +7,7 @@ release_date: "November 9, 2010"
 show_resources: "true"
 permalink: /download/2.8.1.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.8.1.final.tgz",                "https://scala-lang.org/files/archive/scala-2.8.1.final.tgz",                   "Mac OS X, Unix, Cygwin",  "20 MB"],
   ["-main-windows", "scala-2.8.1.final.zip",                "https://scala-lang.org/files/archive/scala-2.8.1.final.zip",                   "Windows",                 "20 MB"]

--- a/_downloads/2011-05-12-2.9.0.final.md
+++ b/_downloads/2011-05-12-2.9.0.final.md
@@ -7,6 +7,7 @@ release_date: "May 12, 2011"
 show_resources: "true"
 permalink: /download/2.9.0.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.9.0.final.tgz",         "https://scala-lang.org/files/archive/scala-2.9.0.final.tgz",         "Mac OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.0.final.zip",         "https://scala-lang.org/files/archive/scala-2.9.0.final.zip",         "Windows",                 "25 MB"]

--- a/_downloads/2011-05-25-2.9.0.1.md
+++ b/_downloads/2011-05-25-2.9.0.1.md
@@ -7,6 +7,7 @@ release_date: "May 25, 2011"
 show_resources: "true"
 permalink: /download/2.9.0.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.9.0.1.tgz",         "https://scala-lang.org/files/archive/scala-2.9.0.1.tgz",         "Mac OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.0.1.zip",         "https://scala-lang.org/files/archive/scala-2.9.0.1.zip",         "Windows",                 "25 MB"]

--- a/_downloads/2011-08-31-2.9.1.final.md
+++ b/_downloads/2011-08-31-2.9.1.final.md
@@ -7,6 +7,7 @@ release_date: "August 31, 2011"
 show_resources: "true"
 permalink: /download/2.9.1.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.9.1.final.tgz",         "https://scala-lang.org/files/archive/scala-2.9.1.final.tgz",         "Mac OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.1.final.zip",         "https://scala-lang.org/files/archive/scala-2.9.1.final.zip",         "Windows",                 "25 MB"]

--- a/_downloads/2011-09-27-2.8.2.final.md
+++ b/_downloads/2011-09-27-2.8.2.final.md
@@ -7,6 +7,7 @@ release_date: "September 27, 2011"
 show_resources: "true"
 permalink: /download/2.8.2.final.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-one4all", "scala-2.8.2.final-installer.jar",      "https://scala-lang.org/files/archive/scala-2.8.2.final-installer.jar",         "All platforms",           "39 MB"],
   ["-main-unixsys", "scala-2.8.2.final.tgz",                "https://scala-lang.org/files/archive/scala-2.8.2.final.tgz",                   "Mac OS X, Unix, Cygwin",  "20 MB"],

--- a/_downloads/2012-03-04-2.9.1-1.md
+++ b/_downloads/2012-03-04-2.9.1-1.md
@@ -7,6 +7,7 @@ release_date: "March 4, 2012"
 show_resources: "true"
 permalink: /download/2.9.1-1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.9.1-1.tgz",         "https://scala-lang.org/files/archive/scala-2.9.1-1.tgz",         "Mac OS X, Unix, Cygwin",  "43 MB"],
   ["-main-windows", "scala-2.9.1-1.zip",         "https://scala-lang.org/files/archive/scala-2.9.1-1.zip",         "Windows",                 "46 MB"]

--- a/_downloads/2012-04-13-2.9.2.md
+++ b/_downloads/2012-04-13-2.9.2.md
@@ -7,6 +7,7 @@ release_date: "April 13, 2012"
 show_resources: "true"
 permalink: /download/2.9.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.9.2.tgz",         "https://scala-lang.org/files/archive/scala-2.9.2.tgz",         "Mac OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.2.msi",         "https://scala-lang.org/files/archive/scala-2.9.2.msi",         "Windows (msi installer)", "50 MB"],

--- a/_downloads/2013-02-28-2.9.3.md
+++ b/_downloads/2013-02-28-2.9.3.md
@@ -7,6 +7,7 @@ release_date: "February 28, 2013"
 show_resources: "true"
 permalink: /download/2.9.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or 1.7."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.9.3.tgz",         "https://scala-lang.org/files/archive/scala-2.9.3.tgz",         "Mac OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.9.3.msi",         "https://scala-lang.org/files/archive/scala-2.9.3.msi",         "Windows (msi installer)", "50 MB"],

--- a/_downloads/2013-03-13-2.10.1.md
+++ b/_downloads/2013-03-13-2.10.1.md
@@ -7,6 +7,7 @@ release_date: "March 13, 2013"
 show_resources: "true"
 permalink: /download/2.10.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.1.tgz",         "https://scala-lang.org/files/archive/scala-2.10.1.tgz",         "Mac OS X, Unix, Cygwin",  "23.9 MB"],
   ["-main-windows", "scala-2.10.1.msi",         "https://scala-lang.org/files/archive/scala-2.10.1.msi",         "Windows (msi installer)", "43.3 MB"],

--- a/_downloads/2013-03-14-2.11.0-M2.md
+++ b/_downloads/2013-03-14-2.11.0-M2.md
@@ -7,6 +7,7 @@ release_date: "March 14, 2013"
 show_resources: "true"
 permalink: /download/2.11.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-M2.tgz",         "https://scala-lang.org/files/archive/scala-2.11.0-M2.tgz",         "Mac OS X, Unix, Cygwin",  "25 MB"],
   ["-main-windows", "scala-2.11.0-M2.msi",         "https://scala-lang.org/files/archive/scala-2.11.0-M2.msi",         "Windows (msi installer)", "50 MB"],

--- a/_downloads/2013-05-29-2.11.0-M3.md
+++ b/_downloads/2013-05-29-2.11.0-M3.md
@@ -7,6 +7,7 @@ release_date: "May 29, 2013"
 show_resources: "true"
 permalink: /download/2.11.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-M3.tgz",                 "https://scala-lang.org/files/archive/scala-2.11.0-M3.tgz",                 "Mac OS X, Unix, Cygwin",     "25 MB"],
   ["-main-windows", "scala-2.11.0-M3.msi",                 "https://scala-lang.org/files/archive/scala-2.11.0-M3.msi",                 "Windows (msi installer)",    "50 MB"],

--- a/_downloads/2013-05-31-2.10.2-RC2.md
+++ b/_downloads/2013-05-31-2.10.2-RC2.md
@@ -7,6 +7,7 @@ release_date: "May 31, 2013"
 show_resources: "true"
 permalink: /download/2.10.2-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.2-RC2.tgz",                 "https://scala-lang.org/files/archive/scala-2.10.2-RC2.tgz",                           "Mac OS X, Unix, Cygwin",     "20 MB"],
   ["-main-windows", "scala-2.10.2-RC2.msi",                 "https://scala-lang.org/files/archive/scala-2.10.2-RC2.msi",                           "Windows (msi installer)",    "60 MB"],

--- a/_downloads/2013-06-06-2.10.2.md
+++ b/_downloads/2013-06-06-2.10.2.md
@@ -7,6 +7,7 @@ release_date: "June 6, 2013"
 show_resources: "true"
 permalink: /download/2.10.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.2.tgz",              "https://scala-lang.org/files/archive/scala-2.10.2.tgz",                       "Mac OS X, Unix, Cygwin",     "20 MB"],
   ["-main-windows", "scala-2.10.2.msi",              "https://scala-lang.org/files/archive/scala-2.10.2.msi",                       "Windows (msi installer)",    "60 MB"],

--- a/_downloads/2013-07-11-2.11.0-M4.md
+++ b/_downloads/2013-07-11-2.11.0-M4.md
@@ -7,6 +7,7 @@ release_date: "July 11, 2013"
 show_resources: "true"
 permalink: /download/2.11.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-M4.tgz",                 "https://scala-lang.org/files/archive/scala-2.11.0-M4.tgz",                 "Mac OS X, Unix, Cygwin",     "25 MB"],
   ["-main-windows", "scala-2.11.0-M4.msi",                 "https://scala-lang.org/files/archive/scala-2.11.0-M4.msi",                 "Windows (msi installer)",    "50 MB"],

--- a/_downloads/2013-09-18-2.10.3-RC2.md
+++ b/_downloads/2013-09-18-2.10.3-RC2.md
@@ -7,6 +7,7 @@ release_date: "September 18, 2013"
 show_resources: "true"
 permalink: /download/2.10.3-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.3-RC2.tgz",                 "https://scala-lang.org/files/archive/scala-2.10.3-RC2.tgz",                           "Mac OS X, Unix, Cygwin",     "20 MB"],
   ["-main-windows", "scala-2.10.3-RC2.msi",                 "https://scala-lang.org/files/archive/scala-2.10.3-RC2.msi",                           "Windows (msi installer)",    "60 MB"],

--- a/_downloads/2013-09-24-2.10.3-RC3.md
+++ b/_downloads/2013-09-24-2.10.3-RC3.md
@@ -7,6 +7,7 @@ release_date: "September 24, 2013"
 show_resources: "true"
 permalink: /download/2.10.3-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.3-RC3.tgz",                 "https://scala-lang.org/files/archive/scala-2.10.3-RC3.tgz",                           "Mac OS X, Unix, Cygwin",     "20 MB"],
   ["-main-windows", "scala-2.10.3-RC3.msi",                 "https://scala-lang.org/files/archive/scala-2.10.3-RC3.msi",                           "Windows (msi installer)",    "60 MB"],

--- a/_downloads/2013-09-27-2.11.0-M5.md
+++ b/_downloads/2013-09-27-2.11.0-M5.md
@@ -7,6 +7,7 @@ release_date: "September 27, 2013"
 show_resources: "true"
 permalink: /download/2.11.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   [-main-unixsys, "scala-2.11.0-M5.tgz", "https://scala-lang.org/files/archive/scala-2.11.0-M5.tgz", "Mac OS X, Unix, Cygwin", "28M"],
   [-main-windows, "scala-2.11.0-M5.msi", "https://scala-lang.org/files/archive/scala-2.11.0-M5.msi", "Windows (msi installer)", "52M"],

--- a/_downloads/2013-10-01-2.10.3.md
+++ b/_downloads/2013-10-01-2.10.3.md
@@ -7,6 +7,7 @@ release_date: "October 1, 2013"
 show_resources: "true"
 permalink: /download/2.10.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.3.tgz",                 "https://scala-lang.org/files/archive/scala-2.10.3.tgz",                           "Mac OS X, Unix, Cygwin",     "20 MB"],
   ["-main-windows", "scala-2.10.3.msi",                 "https://scala-lang.org/files/archive/scala-2.10.3.msi",                           "Windows (msi installer)",    "60 MB"],

--- a/_downloads/2013-11-27-2.11.0-M7.md
+++ b/_downloads/2013-11-27-2.11.0-M7.md
@@ -7,6 +7,7 @@ release_date: "November 27, 2013"
 show_resources: "true"
 permalink: /download/2.11.0-M7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the <a href='http://www.java.com/'>Java runtime version 1.6 or later</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   [-main-unixsys, "scala-2.11.0-M7.tgz", "https://scala-lang.org/files/archive/scala-2.11.0-M7.tgz", "Mac OS X, Unix, Cygwin", "28M"],
   [-main-windows, "scala-2.11.0-M7.msi", "https://scala-lang.org/files/archive/scala-2.11.0-M7.msi", "Windows (msi installer)", "52M"],

--- a/_downloads/2013-12-20-2.10.4-RC1.md
+++ b/_downloads/2013-12-20-2.10.4-RC1.md
@@ -7,6 +7,7 @@ release_date: "December 20, 2013"
 show_resources: "true"
 permalink: /download/2.10.4-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.4-RC1.tgz", "https://scala-lang.org/files/archive/scala-2.10.4-RC1.tgz", "Mac OS X, Unix, Cygwin", "28.55M"],
   ["-main-windows", "scala-2.10.4-RC1.msi", "https://scala-lang.org/files/archive/scala-2.10.4-RC1.msi", "Windows (msi installer)", "60.00M"],

--- a/_downloads/2014-01-28-2.11.0-M8.md
+++ b/_downloads/2014-01-28-2.11.0-M8.md
@@ -7,6 +7,7 @@ release_date: "January 28, 2014"
 show_resources: "true"
 permalink: /download/2.11.0-M8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-M8.tgz", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.tgz", "Mac OS X, Unix, Cygwin", "28.32M"],
   ["-main-windows", "scala-2.11.0-M8.msi", "https://downloads.lightbend.com/scala/2.11.0-M8/scala-2.11.0-M8.msi", "Windows (msi installer)", "91.31M"],

--- a/_downloads/2014-02-04-2.10.4-RC2.md
+++ b/_downloads/2014-02-04-2.10.4-RC2.md
@@ -7,6 +7,7 @@ release_date: "Feburary 4, 2014"
 show_resources: "true"
 permalink: /download/2.10.4-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.4-RC2.tgz", "https://scala-lang.org/files/archive/scala-2.10.4-RC2.tgz", "Mac OS X, Unix, Cygwin", "28.55M"],
   ["-main-windows", "scala-2.10.4-RC2.msi", "https://scala-lang.org/files/archive/scala-2.10.4-RC2.msi", "Windows (msi installer)", "60.00M"],

--- a/_downloads/2014-02-25-2.10.4-RC3.md
+++ b/_downloads/2014-02-25-2.10.4-RC3.md
@@ -7,6 +7,7 @@ release_date: "February 25, 2014"
 show_resources: "true"
 permalink: /download/2.10.4-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.4-RC3.tgz", "https://scala-lang.org/files/archive/scala-2.10.4-RC3.tgz", "Mac OS X, Unix, Cygwin", "28.55M"],
   ["-main-windows", "scala-2.10.4-RC3.msi", "https://scala-lang.org/files/archive/scala-2.10.4-RC3.msi", "Windows (msi installer)", "60.00M"],

--- a/_downloads/2014-03-06-2.11.0-RC1.md
+++ b/_downloads/2014-03-06-2.11.0-RC1.md
@@ -7,6 +7,7 @@ release_date: "March 06, 2014"
 show_resources: "true"
 permalink: /download/2.11.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "24.73M"],
   ["-main-windows", "scala-2.11.0-RC1.msi", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.msi", "Windows (msi installer)", "88.88M"],

--- a/_downloads/2014-03-20-2.11.0-RC3.md
+++ b/_downloads/2014-03-20-2.11.0-RC3.md
@@ -7,6 +7,7 @@ release_date: "March 20, 2014"
 show_resources: "true"
 permalink: /download/2.11.0-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-RC3.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "24.77M"],
   ["-main-windows", "scala-2.11.0-RC3.msi", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.msi", "Windows (msi installer)", "88.95M"],

--- a/_downloads/2014-03-24-2.10.4.md
+++ b/_downloads/2014-03-24-2.10.4.md
@@ -7,6 +7,7 @@ release_date: "March 24, 2014"
 show_resources: "true"
 permalink: /download/2.10.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.4.tgz", "https://scala-lang.org/files/archive/scala-2.10.4.tgz", "Mac OS X, Unix, Cygwin", "28.55M"],
   ["-main-windows", "scala-2.10.4.msi", "https://scala-lang.org/files/archive/scala-2.10.4.msi", "Windows (msi installer)", "60.00M"],

--- a/_downloads/2014-04-08-2.11.0-RC4.md
+++ b/_downloads/2014-04-08-2.11.0-RC4.md
@@ -7,6 +7,7 @@ release_date: "April 08, 2014"
 show_resources: "true"
 permalink: /download/2.11.0-RC4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0-RC4.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.tgz", "Mac OS X, Unix, Cygwin", "24.79M"],
   ["-main-windows", "scala-2.11.0-RC4.msi", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.msi", "Windows (msi installer)", "89.02M"],

--- a/_downloads/2014-04-21-2.11.0.md
+++ b/_downloads/2014-04-21-2.11.0.md
@@ -7,6 +7,7 @@ release_date: "April 21, 2014"
 show_resources: "true"
 permalink: /download/2.11.0.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.0.tgz", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.tgz", "Mac OS X, Unix, Cygwin", "24.80M"],
   ["-main-windows", "scala-2.11.0.msi", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.msi", "Windows (msi installer)", "89.00M"],

--- a/_downloads/2014-05-21-2.11.1.md
+++ b/_downloads/2014-05-21-2.11.1.md
@@ -7,6 +7,7 @@ release_date: "May 21, 2014"
 show_resources: "true"
 permalink: /download/2.11.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.1.tgz", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.tgz", "Mac OS X, Unix, Cygwin", "24.50M"],
   ["-main-windows", "scala-2.11.1.msi", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.msi", "Windows (msi installer)", "93.05M"],

--- a/_downloads/2014-07-24-2.11.2.md
+++ b/_downloads/2014-07-24-2.11.2.md
@@ -7,6 +7,7 @@ release_date: "July 24, 2014"
 show_resources: "true"
 permalink: /download/2.11.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.2.tgz", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.tgz", "Mac OS X, Unix, Cygwin", "25.26M"],
   ["-main-windows", "scala-2.11.2.msi", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.msi", "Windows (msi installer)", "95.03M"],

--- a/_downloads/2014-10-30-2.11.4.md
+++ b/_downloads/2014-10-30-2.11.4.md
@@ -7,6 +7,7 @@ release_date: "October 30, 2014"
 show_resources: "true"
 permalink: /download/2.11.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.4.tgz", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.tgz", "Mac OS X, Unix, Cygwin", "25.28M"],
   ["-main-windows", "scala-2.11.4.msi", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.msi", "Windows (msi installer)", "95.22M"],

--- a/_downloads/2015-01-14-2.11.5.md
+++ b/_downloads/2015-01-14-2.11.5.md
@@ -7,6 +7,7 @@ release_date: "January 14, 2015"
 show_resources: "true"
 permalink: /download/2.11.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.5.tgz", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.tgz", "Mac OS X, Unix, Cygwin", "25.88M"],
   ["-main-windows", "scala-2.11.5.msi", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.msi", "Windows (msi installer)", "107.77M"],

--- a/_downloads/2015-03-05-2.10.5.md
+++ b/_downloads/2015-03-05-2.10.5.md
@@ -7,6 +7,7 @@ release_date: "March 05, 2015"
 show_resources: "true"
 permalink: /download/2.10.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.5.tgz", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.tgz", "Mac OS X, Unix, Cygwin", "28.54M"],
   ["-main-windows", "scala-2.10.5.msi", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.msi", "Windows (msi installer)", "60.02M"],

--- a/_downloads/2015-03-05-2.11.6.md
+++ b/_downloads/2015-03-05-2.11.6.md
@@ -7,6 +7,7 @@ release_date: "March 05, 2015"
 show_resources: "true"
 permalink: /download/2.11.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.6.tgz", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.tgz", "Mac OS X, Unix, Cygwin", "25.87M"],
   ["-main-windows", "scala-2.11.6.msi", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.msi", "Windows (msi installer)", "107.88M"],

--- a/_downloads/2015-05-05-2.12.0-M1.md
+++ b/_downloads/2015-05-05-2.12.0-M1.md
@@ -7,6 +7,7 @@ release_date: "May 05, 2015"
 show_resources: "true"
 permalink: /download/2.12.0-M1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-M1.tgz", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.tgz", "Mac OS X, Unix, Cygwin", "23.85M"],
   ["-main-windows", "scala-2.12.0-M1.msi", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.msi", "Windows (msi installer)", "102.77M"],

--- a/_downloads/2015-06-23-2.11.7.md
+++ b/_downloads/2015-06-23-2.11.7.md
@@ -7,6 +7,7 @@ release_date: "June 23, 2015"
 show_resources: "true"
 permalink: /download/2.11.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.7.tgz", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.tgz", "Mac OS X, Unix, Cygwin", "27.14M"],
   ["-main-windows", "scala-2.11.7.msi", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.msi", "Windows (msi installer)", "110.71M"],

--- a/_downloads/2015-07-14-2.12.0-M2.md
+++ b/_downloads/2015-07-14-2.12.0-M2.md
@@ -7,6 +7,7 @@ release_date: "July 14, 2015"
 show_resources: "true"
 permalink: /download/2.12.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-M2.tgz", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.tgz", "Mac OS X, Unix, Cygwin", "18.68M"],
   ["-main-windows", "scala-2.12.0-M2.msi", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.msi", "Windows (msi installer)", "96.52M"],

--- a/_downloads/2015-09-18-2.10.6.md
+++ b/_downloads/2015-09-18-2.10.6.md
@@ -7,6 +7,7 @@ release_date: "September 18, 2015"
 show_resources: "true"
 permalink: /download/2.10.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.6.tgz", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.tgz", "Max OS X, Unix, Cygwin", "28.54M"],
   ["-main-windows", "scala.msi", "https://downloads.lightbend.com/scala/2.10.6/scala.msi", "Windows (msi installer)", "58.50M"],

--- a/_downloads/2015-10-06-2.12.0-M3.md
+++ b/_downloads/2015-10-06-2.12.0-M3.md
@@ -7,6 +7,7 @@ release_date: "October 06, 2015"
 show_resources: "true"
 permalink: /download/2.12.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-M3.tgz", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.tgz", "Mac OS X, Unix, Cygwin", "19.97M"],
   ["-main-windows", "scala-2.12.0-M3.msi", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.msi", "Windows (msi installer)", "97.75M"],

--- a/_downloads/2016-03-08-2.11.8.md
+++ b/_downloads/2016-03-08-2.11.8.md
@@ -7,6 +7,7 @@ release_date: "March 08, 2016"
 show_resources: "true"
 permalink: /download/2.11.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.8.tgz", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.tgz", "Mac OS X, Unix, Cygwin", "27.35M"],
   ["-main-windows", "scala-2.11.8.msi", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.msi", "Windows (msi installer)", "109.35M"],

--- a/_downloads/2016-04-11-2.12.0-M4.md
+++ b/_downloads/2016-04-11-2.12.0-M4.md
@@ -7,6 +7,7 @@ release_date: "April 11, 2016"
 show_resources: "true"
 permalink: /download/2.12.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-M4.tgz", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.tgz", "Mac OS X, Unix, Cygwin", "18.04M"],
   ["-main-windows", "scala-2.12.0-M4.msi", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.msi", "Windows (msi installer)", "121.31M"],

--- a/_downloads/2016-06-29-2.12.0-M5.md
+++ b/_downloads/2016-06-29-2.12.0-M5.md
@@ -7,6 +7,7 @@ release_date: "June 29, 2016"
 show_resources: "true"
 permalink: /download/2.12.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-M5.tgz", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.tgz", "Mac OS X, Unix, Cygwin", "17.53M"],
   ["-main-windows", "scala-2.12.0-M5.msi", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.msi", "Windows (msi installer)", "120.72M"],

--- a/_downloads/2016-09-06-2.12.0-RC1.md
+++ b/_downloads/2016-09-06-2.12.0-RC1.md
@@ -7,6 +7,7 @@ release_date: "September 06, 2016"
 show_resources: "true"
 permalink: /download/2.12.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "17.65M"],
   ["-main-windows", "scala-2.12.0-RC1.msi", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.msi", "Windows (msi installer)", "116.21M"],

--- a/_downloads/2016-10-18-2.12.0-RC2.md
+++ b/_downloads/2016-10-18-2.12.0-RC2.md
@@ -7,6 +7,7 @@ release_date: "October 18, 2016"
 show_resources: "true"
 permalink: /download/2.12.0-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0-RC2.tgz", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
   ["-main-windows", "scala-2.12.0-RC2.msi", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.msi", "Windows (msi installer)", "117.88M"],

--- a/_downloads/2016-11-03-2.12.0.md
+++ b/_downloads/2016-11-03-2.12.0.md
@@ -7,6 +7,7 @@ release_date: "November 03, 2016"
 show_resources: "true"
 permalink: /download/2.12.0.html
 requirements: "Scala 2.12 requires version 8 of the Java platform, as provided by <a href='http://openjdk.java.net/install/'>OpenJDK</a> or <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html'>Oracle</a>. Java 9 is not yet supported."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.0.tgz", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
   ["-main-windows", "scala-2.12.0.msi", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.msi", "Windows (msi installer)", "117.78M"],

--- a/_downloads/2016-12-05-2.12.1.md
+++ b/_downloads/2016-12-05-2.12.1.md
@@ -7,6 +7,7 @@ release_date: "December 05, 2016"
 show_resources: "true"
 permalink: /download/2.12.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.1.tgz", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
   ["-main-windows", "scala-2.12.1.msi", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],

--- a/_downloads/2017-04-17-2.13.0-M1.md
+++ b/_downloads/2017-04-17-2.13.0-M1.md
@@ -7,6 +7,7 @@ release_date: "April 18, 2017"
 show_resources: "true"
 permalink: /download/2.13.0-M1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M1.tgz", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.tgz", "Mac OS X, Unix, Cygwin", "16.95M"],
   ["-main-windows", "scala-2.13.0-M1.msi", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.msi", "Windows (msi installer)", "112.80M"],

--- a/_downloads/2017-04-17-2.13.0-M1.md
+++ b/_downloads/2017-04-17-2.13.0-M1.md
@@ -7,7 +7,7 @@ release_date: "April 18, 2017"
 show_resources: "true"
 permalink: /download/2.13.0-M1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
-license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
+license: <a href="!SITE_BASE_URL!/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M1.tgz", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.tgz", "Mac OS X, Unix, Cygwin", "16.95M"],
   ["-main-windows", "scala-2.13.0-M1.msi", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.msi", "Windows (msi installer)", "112.80M"],

--- a/_downloads/2017-04-18-2.11.11.md
+++ b/_downloads/2017-04-18-2.11.11.md
@@ -7,6 +7,7 @@ release_date: "April 18, 2017"
 show_resources: "true"
 permalink: /download/2.11.11.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.11.tgz", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz", "Mac OS X, Unix, Cygwin", "27.74M"],
   ["-main-windows", "scala-2.11.11.msi", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.msi", "Windows (msi installer)", "110.04M"],

--- a/_downloads/2017-04-18-2.12.2.md
+++ b/_downloads/2017-04-18-2.12.2.md
@@ -7,6 +7,7 @@ release_date: "April 18, 2017"
 show_resources: "true"
 permalink: /download/2.12.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.2.tgz", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.tgz", "Mac OS X, Unix, Cygwin", "18.69M"],
   ["-main-windows", "scala-2.12.2.msi", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.msi", "Windows (msi installer)", "126.44M"],

--- a/_downloads/2017-07-26-2.12.3.md
+++ b/_downloads/2017-07-26-2.12.3.md
@@ -7,6 +7,7 @@ release_date: "July 26, 2017"
 show_resources: "true"
 permalink: /download/2.12.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.3.tgz", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.tgz", "Mac OS X, Unix, Cygwin", "18.85M"],
   ["-main-windows", "scala-2.12.3.msi", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.msi", "Windows (msi installer)", "126.93M"],

--- a/_downloads/2017-08-08-2.13.0-M2.md
+++ b/_downloads/2017-08-08-2.13.0-M2.md
@@ -7,6 +7,7 @@ release_date: "August 08, 2017"
 show_resources: "true"
 permalink: /download/2.13.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M2.tgz", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.tgz", "Mac OS X, Unix, Cygwin", "16.85M"],
   ["-main-windows", "scala-2.13.0-M2.msi", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.msi", "Windows (msi installer)", "111.91M"],

--- a/_downloads/2017-08-08-2.13.0-M2.md
+++ b/_downloads/2017-08-08-2.13.0-M2.md
@@ -7,7 +7,7 @@ release_date: "August 08, 2017"
 show_resources: "true"
 permalink: /download/2.13.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
-license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
+license: <a href="!SITE_BASE_URL!/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M2.tgz", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.tgz", "Mac OS X, Unix, Cygwin", "16.85M"],
   ["-main-windows", "scala-2.13.0-M2.msi", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.msi", "Windows (msi installer)", "111.91M"],

--- a/_downloads/2017-10-17-2.12.4.md
+++ b/_downloads/2017-10-17-2.12.4.md
@@ -7,6 +7,7 @@ release_date: "October 17, 2017"
 show_resources: "true"
 permalink: /download/2.12.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.4.tgz", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.tgz", "Mac OS X, Unix, Cygwin", "18.83M"],
   ["-main-windows", "scala-2.12.4.msi", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.msi", "Windows (msi installer)", "126.38M"],

--- a/_downloads/2017-11-09-2.10.7.md
+++ b/_downloads/2017-11-09-2.10.7.md
@@ -7,6 +7,7 @@ release_date: "November 09, 2017"
 show_resources: "true"
 permalink: /download/2.10.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.10.7.tgz", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.tgz", "Mac OS X, Unix, Cygwin", "28.60M"],
   ["-main-windows", "scala.msi", "https://downloads.lightbend.com/scala/2.10.7/scala.msi", "Windows (msi installer)", "58.58M"],

--- a/_downloads/2017-11-09-2.11.12.md
+++ b/_downloads/2017-11-09-2.11.12.md
@@ -7,6 +7,7 @@ release_date: "November 09, 2017"
 show_resources: "true"
 permalink: /download/2.11.12.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.11.12.tgz", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.tgz", "Mac OS X, Unix, Cygwin", "27.77M"],
   ["-main-windows", "scala-2.11.12.msi", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.msi", "Windows (msi installer)", "109.82M"],

--- a/_downloads/2018-01-31-2.13.0-M3.md
+++ b/_downloads/2018-01-31-2.13.0-M3.md
@@ -7,6 +7,7 @@ release_date: "January 31, 2018"
 show_resources: "true"
 permalink: /download/2.13.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M3.tgz", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.tgz", "Mac OS X, Unix, Cygwin", "17.31M"],
   ["-main-windows", "scala-2.13.0-M3.msi", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.msi", "Windows (msi installer)", "114.28M"],

--- a/_downloads/2018-01-31-2.13.0-M3.md
+++ b/_downloads/2018-01-31-2.13.0-M3.md
@@ -7,7 +7,7 @@ release_date: "January 31, 2018"
 show_resources: "true"
 permalink: /download/2.13.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
-license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
+license: <a href="!SITE_BASE_URL!/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M3.tgz", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.tgz", "Mac OS X, Unix, Cygwin", "17.31M"],
   ["-main-windows", "scala-2.13.0-M3.msi", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.msi", "Windows (msi installer)", "114.28M"],

--- a/_downloads/2018-03-15-2.12.5.md
+++ b/_downloads/2018-03-15-2.12.5.md
@@ -7,6 +7,7 @@ release_date: "March 19, 2018"
 show_resources: "true"
 permalink: /download/2.12.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.5.tgz", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.tgz", "Mac OS X, Unix, Cygwin", "19.36M"],
   ["-main-windows", "scala-2.12.5.msi", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.msi", "Windows (msi installer)", "123.65M"],

--- a/_downloads/2018-04-27-2.12.6.md
+++ b/_downloads/2018-04-27-2.12.6.md
@@ -7,6 +7,7 @@ release_date: "April 27, 2018"
 show_resources: "true"
 permalink: /download/2.12.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.6.tgz", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.tgz", "Mac OS X, Unix, Cygwin", "19.39M"],
   ["-main-windows", "scala-2.12.6.msi", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.msi", "Windows (msi installer)", "123.67M"],

--- a/_downloads/2018-05-15-2.13.0-M4.md
+++ b/_downloads/2018-05-15-2.13.0-M4.md
@@ -7,6 +7,7 @@ release_date: "May 15, 2018"
 show_resources: "true"
 permalink: /download/2.13.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M4.tgz", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.tgz", "Mac OS X, Unix, Cygwin", "16.54M"],
   ["-main-windows", "scala-2.13.0-M4.msi", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.msi", "Windows (msi installer)", "97.55M"],

--- a/_downloads/2018-05-15-2.13.0-M4.md
+++ b/_downloads/2018-05-15-2.13.0-M4.md
@@ -7,7 +7,7 @@ release_date: "May 15, 2018"
 show_resources: "true"
 permalink: /download/2.13.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
-license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
+license: <a href="!SITE_BASE_URL!/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M4.tgz", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.tgz", "Mac OS X, Unix, Cygwin", "16.54M"],
   ["-main-windows", "scala-2.13.0-M4.msi", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.msi", "Windows (msi installer)", "97.55M"],

--- a/_downloads/2018-08-30-2.13.0-M5.md
+++ b/_downloads/2018-08-30-2.13.0-M5.md
@@ -7,7 +7,7 @@ release_date: "August 30, 2018"
 show_resources: "true"
 permalink: /download/2.13.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
-license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
+license: <a href="!SITE_BASE_URL!/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M5.tgz", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.tgz", "Mac OS X, Unix, Cygwin", "16.90M"],
   ["-main-windows", "scala-2.13.0-M5.msi", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.msi", "Windows (msi installer)", "103.19M"],

--- a/_downloads/2018-08-30-2.13.0-M5.md
+++ b/_downloads/2018-08-30-2.13.0-M5.md
@@ -7,6 +7,7 @@ release_date: "August 30, 2018"
 show_resources: "true"
 permalink: /download/2.13.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.13.0-M5.tgz", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.tgz", "Mac OS X, Unix, Cygwin", "16.90M"],
   ["-main-windows", "scala-2.13.0-M5.msi", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.msi", "Windows (msi installer)", "103.19M"],

--- a/_downloads/2018-09-27-2.12.7.md
+++ b/_downloads/2018-09-27-2.12.7.md
@@ -7,6 +7,7 @@ release_date: "September 27, 2018"
 show_resources: "true"
 permalink: /download/2.12.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
   ["-main-unixsys", "scala-2.12.7.tgz", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.tgz", "Mac OS X, Unix, Cygwin", "19.47M"],
   ["-main-windows", "scala-2.12.7.msi", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.msi", "Windows (msi installer)", "123.87M"],

--- a/_downloads/2018-12-04-2.12.8.md
+++ b/_downloads/2018-12-04-2.12.8.md
@@ -7,6 +7,7 @@ release_date: "December 04, 2018"
 show_resources: "true"
 permalink: /download/2.12.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
+license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.12.8.tgz", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.tgz", "Mac OS X, Unix, Cygwin", "19.52M"],
   ["-main-windows", "scala-2.12.8.msi", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.msi", "Windows (msi installer)", "123.96M"],

--- a/_downloads/2018-12-04-2.12.8.md
+++ b/_downloads/2018-12-04-2.12.8.md
@@ -7,7 +7,7 @@ release_date: "December 04, 2018"
 show_resources: "true"
 permalink: /download/2.12.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='http://www.java.com/'>here</a>."
-license: <a href="{{ site.baseurl }}/license/">Apache License, Version 2.0</a>
+license: <a href="!SITE_BASE_URL!/license/">Apache License, Version 2.0</a>
 resources: [
   ["-main-unixsys", "scala-2.12.8.tgz", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.tgz", "Mac OS X, Unix, Cygwin", "19.52M"],
   ["-main-windows", "scala-2.12.8.msi", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.msi", "Windows (msi installer)", "123.96M"],

--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -101,7 +101,7 @@ layout: inner-page-parent
 
           {% include download-resource-list.html %}
           <h3>License</h3>
-          <p>The Scala distribution is released under the {{page.license}}.</p>
+          <p>The Scala distribution is released under the {{ page.license | replace: '!SITE_BASE_URL!', site.baseurl }}.</p>
         </div>
 
       </div>

--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -101,7 +101,7 @@ layout: inner-page-parent
 
           {% include download-resource-list.html %}
           <h3>License</h3>
-          <p>The Scala distribution is released under the <a href="{{ site.baseurl }}/license/">3-clause BSD license</a>.</p>
+          <p>The Scala distribution is released under the {{page.license}}.</p>
         </div>
 
       </div>


### PR DESCRIPTION
For Scala <2.12.8 & <2.13 the license is BSD-3-Clause
For Scala >2.12.7 & 2.13+ the license is Apache-2.0

I didn't spend the time figuring out how to test this, so this needs checking.

Also it seems a bit repetative, so let me know if there's a better way.