### PR TITLE
Change "osx" references to "macos"

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -3,7 +3,7 @@ stepOne:
     text: "<p><code>java -version</code><span>(Make sure you have version 1.8.)</span></p>"
   - os: unix
     text: "<p><code>java -version</code><span>(Make sure you have version 1.8.)</span></p>"
-  - os: osx
+  - os: macos
     text: "<p><code>java -version</code><span>(Make sure you have version 1.8.)</span></p>"
   - os: windows
     text: "<p><ul><li>Launch the Windows Start menu</li><li>Click on <code>Programs</code></li><li>Find the <code>Java</code> program listing</li><li>Click <code>About Java</code> to see the Java version</li></ul></p>"
@@ -13,7 +13,7 @@ intellijUrls:
     url: https://www.jetbrains.com/idea
   - os: unix
     url: https://www.jetbrains.com/idea
-  - os: osx
+  - os: macos
     url: https://www.jetbrains.com/idea
   - os: windows
     url: https://www.jetbrains.com/idea
@@ -23,7 +23,7 @@ sbtUrls:
     url: http://www.scala-sbt.org/download.html
   - os: unix
     url: http://www.scala-sbt.org/download.html
-  - os: osx
+  - os: macos
     url: http://www.scala-sbt.org/download.html
   - os: windows
     url: http://www.scala-sbt.org/download.html

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -251,7 +251,7 @@ $(document).ready(function() {
 function getOS() {
   var osname = "linux";
   if (navigator.appVersion.indexOf("Win") != -1) osname = "windows";
-  if (navigator.appVersion.indexOf("Mac") != -1) osname = "osx";
+  if (navigator.appVersion.indexOf("Mac") != -1) osname = "macos";
   if (navigator.appVersion.indexOf("Linux") != -1) osname = "linux";
   if (navigator.appVersion.indexOf("X11") != -1) osname = "unix";
   return osname;


### PR DESCRIPTION
Apple has changed the name from "OS X" to "macOS":

https://www.businessinsider.com/wwdc-2016-os-x-becomes-macos-2016-6?r=US&IR=T

This isn't just internal plumbing: this is visible as "Download the
Scala binaries for osx" on
https://scala-lang.org/download/2.12.8.html#download-binaries.

Ideally it would be "Download the Scala binaries for macOS", but I
stopped at just changing it to "macos".

I didn't spend the time figuring out how to test this, so this needs checking.