### PR TITLE
Fix broken links to Jenkins

### DIFF
--- a/_posts/2014-03-06-release-notes-2.11.0-RC1.md
+++ b/_posts/2014-03-06-release-notes-2.11.0-RC1.md
@@ -72,7 +72,7 @@ Here's how we recommend handling this in sbt 0.13. For the full build, see [[@gk
     }
 
 ### Important changes
-For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a sizeable number of open source projects in the Scala community build.
+For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/) a sizeable number of open source projects in the Scala community build.
 
 Changes to the reflection API may cause breakages, but these breakages can be easily fixed in a manner that is source-compatible with Scala 2.10.x. Follow our reflection/macro changelog for [detailed instructions](http://docs.scala-lang.org/overviews/macros/changelog211.html#how_to_make_your_210x_macros_work_in_2110).
 

--- a/_posts/2014-03-20-release-notes-2.11.0-RC3.md
+++ b/_posts/2014-03-20-release-notes-2.11.0-RC3.md
@@ -81,7 +81,7 @@ Here's how we recommend handling this in sbt 0.13. For the full build and Maven 
     }
 
 ### Important changes
-For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a sizeable number of open source projects in the Scala community build.
+For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/) a sizeable number of open source projects in the Scala community build.
 
 Changes to the reflection API may cause breakages, but these breakages can be easily fixed in a manner that is source-compatible with Scala 2.10.x. Follow our reflection/macro changelog for [detailed instructions](http://docs.scala-lang.org/overviews/macros/changelog211.html#how_to_make_your_210x_macros_work_in_2110).
 

--- a/_posts/2014-04-21-release-notes-2.11.0.md
+++ b/_posts/2014-04-21-release-notes-2.11.0.md
@@ -146,7 +146,7 @@ Here's how we recommend handling this in sbt 0.13. For the full build and Maven 
     }
 
 ### Important changes
-For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a sizeable number of open source projects in the Scala community build.
+For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/) a sizeable number of open source projects in the Scala community build.
 
 Changes to the reflection API may cause breakages, but these breakages can be easily fixed in a manner that is source-compatible with Scala 2.10.x. Follow our reflection/macro changelog for [detailed instructions](http://docs.scala-lang.org/overviews/macros/changelog211.html#how_to_make_your_210x_macros_work_in_2110).
 

--- a/_posts/2014-05-21-release-notes-2.11.1.md
+++ b/_posts/2014-05-21-release-notes-2.11.1.md
@@ -169,7 +169,7 @@ Here's how we recommend handling this in sbt 0.13. For the full build and Maven 
     }
 
 ### Important changes
-For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a sizeable number of open source projects in the Scala community build.
+For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/) a sizeable number of open source projects in the Scala community build.
 
 Changes to the reflection API may cause breakages, but these breakages can be easily fixed in a manner that is source-compatible with Scala 2.10.x. Follow our reflection/macro changelog for [detailed instructions](http://docs.scala-lang.org/overviews/macros/changelog211.html#how_to_make_your_210x_macros_work_in_2110).
 

--- a/_posts/2014-06-30-2.12-roadmap.md
+++ b/_posts/2014-06-30-2.12-roadmap.md
@@ -67,7 +67,7 @@ Scala 2.10.5 (Q4 2014) will be the last 2.10 release. We’re planning five 2.11
 | 2.12.0          | *Jan 2016*      |                                    |
 
 
-During the development of Scala 2.11, we've made big steps forward in automating our release process and regression testing via our [Community Build](https://jenkins-dbuild.typesafe.com:8499/view/Shared/) which builds 1M LOC of popular open source projects. Both the release script and the community builds are also run on a nightly basis.
+During the development of Scala 2.11, we've made big steps forward in automating our release process and regression testing via our [Community Build](https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/) which builds 1M LOC of popular open source projects. Both the release script and the community builds are also run on a nightly basis.
 
 As such, as of Scala 2.11.1, we've decided to skip Release Candidates for 2.x.y releases where y > 0. This enables more frequent minor releases on a predictable schedule.
 

--- a/_posts/2015-05-05-release-notes-2.12.0-M1.md
+++ b/_posts/2015-05-05-release-notes-2.12.0-M1.md
@@ -50,7 +50,7 @@ With the release of 2.12.0, backports to 2.11 will be dialed back.
 <!-- Notes from 2.11.0
 #### Important Changes
 
-For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x) a [sizeable number of open source projects](https://github.com/scala/community-builds/blob/2.11.x/common.conf#L20).
+For most cases, code that compiled under 2.10.x without deprecation warnings should not be affected. We've verified this by [compiling](https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/) a [sizeable number of open source projects](https://github.com/scala/community-builds/blob/2.11.x/common.conf#L20).
 
 Changes to the reflection API may cause breakages...
 


### PR DESCRIPTION
I guess htmlproofer only checks for 400-level errors.  This means it ignores network failures.  I think it was done that way because there were a lot of holes to plug, but it it was a way to enable htmlproofer in the meantime.  This is just a reminder that the boat is leaking.  htmlproofer may also respect the robots.txt protocol, which see https://scala-ci.typesafe.com/robots.txt