### PR TITLE
License under Creative Commons BY-SA 3.0

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -102,3 +102,7 @@ Adapted from and/or inspired by multiple successful Codes of Conduct, including:
 * [The Contributor Covenant v1.4.0](http://contributor-covenant.org/version/1/4/)
 * [The Recurse Center's User Manual](https://www.recurse.com/manual#sec-environment)
 * [The 18F Code of Conduct](https://18f.gsa.gov/code-of-conduct/)
+
+### License
+
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/3.0/).


### PR DESCRIPTION
This is a follow-up from my comment here: https://github.com/scala/scala-lang/pull/1079#discussion_r328876505

My interpretation is that the Scala Code of Conduct builds on the [Citizen Code of Conduct](http://citizencodeofconduct.org/), at least implicitly by referencing it. Since the Citizen CoC uses this license, it requires that derived works use the same license. This will cascade to other derivatives of the Scala CoC.

I don't want to argue for or against the merits of this license, or its appropriateness for this purpose. I have no strong personal opinion on that. The main question is whether the Scala CoC is obligated to adopt it by being derived from Citizen CoC.

I'd say it's a grey area in the Scala CoC as currently written, whether it would be considered a derived work. With the inlining of text from Citizen CoC in #1079, it would be clearly required to adopt the BY-SA 3.0 license (or a [compatible one](https://creativecommons.org/share-your-work/licensing-considerations/compatible-licenses)). So, if this change isn't accepted, I'll revert that change in #1079.