### PR TITLE
Move the examples of harassment to separate section in code of conduct

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -33,8 +33,7 @@ As a member of the community, you agree to the following:
 
 - Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
 - Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
-- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below.
-- We don’t tolerate behavior that excludes people based on their association with social, ethnic, religious, political, or similar groups.
+- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact the moderation team](#contact) immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 

--- a/conduct.md
+++ b/conduct.md
@@ -33,19 +33,7 @@ As a member of the community, you agree to the following:
 
 - Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
 - Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
-- We will exclude you from interaction if you insult, demean or harass anyone. Behavior that will lead to exclusion includes the following:
-  - Violence, threats of violence or violent language directed against another person.
-  - Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
-  - Posting or displaying sexually explicit or violent material.
-  - Posting or threatening to post other people’s personally identifying information ("doxing").
-  - Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
-  - Inappropriate photography or recording.
-  - Inappropriate physical contact. You should have someone’s consent before touching them.
-  - Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
-  - Deliberate intimidation, stalking or following (online or in person).
-  - Advocating for, or encouraging, any of the above behavior.
-  - Sustained disruption of community events, including talks and presentations.
-  - In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of harassment](#examples-of-harassment) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact the moderation team](#contact) immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
@@ -105,6 +93,23 @@ listed above,
   * Darja Jovanovic, Scala Center ([darja.jovanovic@epfl.ch](mailto:darja.jovanovic@epfl.ch))
   * Sébastien Doeraene, Scala Center ([sebastien.doeraene@epfl.ch](mailto:sebastien.doeraene@epfl.ch))
   * Kathleen Hayes, Lightbend ([kathleen.hayes@lightbend.com](mailto:kathleen.hayes@lightbend.com))
+
+### Examples of harassment
+
+The term “Harassment” includes “Unacceptable Behavior” described in the [Citizen Code of Conduct](http://citizencodeofconduct.org/).
+Examples from that resource, but not based on events in our community:
+
+- Violence, threats of violence or violent language directed against another person.
+- Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+- Posting or displaying sexually explicit or violent material.
+- Posting or threatening to post other people’s personally identifying information ("doxing").
+- Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+- Inappropriate photography or recording.
+- Inappropriate physical contact. You should have someone’s consent before touching them.
+- Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+- Deliberate intimidation, stalking or following (online or in person).
+- Advocating for, or encouraging, any of the above behavior.
+- Sustained disruption of community events, including talks and presentations.
 
 ### Credits
 

--- a/conduct.md
+++ b/conduct.md
@@ -33,7 +33,7 @@ As a member of the community, you agree to the following:
 
 - Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
 - Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
-- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of harassment](#examples-of-harassment) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact the moderation team](#contact) immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
@@ -94,7 +94,7 @@ listed above,
   * Sébastien Doeraene, Scala Center ([sebastien.doeraene@epfl.ch](mailto:sebastien.doeraene@epfl.ch))
   * Kathleen Hayes, Lightbend ([kathleen.hayes@lightbend.com](mailto:kathleen.hayes@lightbend.com))
 
-### Examples of harassment
+### Examples of unacceptable behavior
 
 Behavior that will lead to exclusion includes the following points, inspired by the definition of
 “Unacceptable Behavior” in the [Citizen Code of Conduct](http://citizencodeofconduct.org/):

--- a/conduct.md
+++ b/conduct.md
@@ -99,17 +99,17 @@ listed above,
 The term “Harassment” includes “Unacceptable Behavior” described in the [Citizen Code of Conduct](http://citizencodeofconduct.org/).
 Examples from that resource, but not based on events in our community:
 
-- Violence, threats of violence or violent language directed against another person.
-- Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
-- Posting or displaying sexually explicit or violent material.
-- Posting or threatening to post other people’s personally identifying information ("doxing").
-- Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
-- Inappropriate photography or recording.
-- Inappropriate physical contact. You should have someone’s consent before touching them.
-- Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
-- Deliberate intimidation, stalking or following (online or in person).
-- Advocating for, or encouraging, any of the above behavior.
-- Sustained disruption of community events, including talks and presentations.
+* Violence, threats of violence or violent language directed against another person.
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+* Posting or displaying sexually explicit or violent material.
+* Posting or threatening to post other people’s personally identifying information ("doxing").
+* Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, including talks and presentations.
 
 ### Credits
 

--- a/conduct.md
+++ b/conduct.md
@@ -33,7 +33,8 @@ As a member of the community, you agree to the following:
 
 - Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
 - Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
-- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+- We will exclude you from interaction if you insult, demean or harass anyone. See [examples of unacceptable behavior](#examples-of-unacceptable-behavior) below.
+- We don’t tolerate behavior that excludes people based on their association with social, ethnic, religious, political, or similar groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please [contact the moderation team](#contact) immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 

--- a/conduct.md
+++ b/conduct.md
@@ -96,8 +96,8 @@ listed above,
 
 ### Examples of harassment
 
-The term “Harassment” includes “Unacceptable Behavior” described in the [Citizen Code of Conduct](http://citizencodeofconduct.org/).
-Examples from that resource, but not based on events in our community:
+Behavior that will lead to exclusion includes the following points, inspired by the definition of
+“Unacceptable Behavior” in the [Citizen Code of Conduct](http://citizencodeofconduct.org/):
 
 * Violence, threats of violence or violent language directed against another person.
 * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.


### PR DESCRIPTION
This will make the Encouraged and Discouraged sections more
balanced.

The examples are from the Citizen Code of Conduct and would be
good to clarify that to avoid the misunderstanding that these were
based on incidents in our community.