### PR TITLE
Make -Ystatistics flag explicit

### DIFF
--- a/blog/_posts/2018-06-04-scalac-profiling.md
+++ b/blog/_posts/2018-06-04-scalac-profiling.md
@@ -375,6 +375,7 @@ artifact from coursier. Replace `$BLOOP_CODEBASE_DIRECTORY` by the base
 directory of the cloned bloop repository.
 
 ```json
+  "-Ystatistics",
   "-Ycache-plugin-class-loader:last-modified",
   "-Xplugin:$PATH_TO_PLUGIN_JAR",
   "-P:scalac-profiling:no-profiledb",


### PR DESCRIPTION
While the document starts out saying to add -Ystatistics, I think it's clearer if that's repeated again when you provide the rest of the flags for scalac profiling.