### PR TITLE
Replace references to SLIP with SIP

### DIFF
--- a/contribute/corelibs.md
+++ b/contribute/corelibs.md
@@ -13,11 +13,11 @@ There are several options for contributing to Scala's core libraries. You can:
 * [Fix Bugs or Issues](/contribute/guide.html) against the
   [reported library bugs/issues](https://github.com/scala/bug).
 * Contribute significant new functionality or a new API by submitting
-  a Scala Library Improvement Process (SLIP) Document.
+  a Scala Improvement Process (SIP) Document.
 
-### Submitting a SLIP
+### Submitting a SIP
 
 For significant new functionality or a whole new API to be considered for
-inclusion in the core Scala distribution, you will be asked to submit a SLIP (Scala Library Improvement Process) document.
+inclusion in the core Scala distribution, you will be asked to submit a SIP (Scala Improvement Process) document.
 
-Please see [instructions for submitting a new SLIP](https://web.archive.org/web/20180116192845/http://docs.scala-lang.org/sips/slip-submission.html) and familiarize yourself with the [SIP/SLIP](http://docs.scala-lang.org/sips/) section of the Scala documentation site. Also please pay particular attention to the pre-requisites in the instructions before submitting a SLIP.
+Please see [instructions for submitting a new SIP](https://docs.scala-lang.org/sips/sip-submission.html) and familiarize yourself with the [SIP](http://docs.scala-lang.org/sips/) section of the Scala documentation site. Also please pay particular attention to the pre-requisites in the instructions before submitting a SIP.

--- a/contribute/corelibs.md
+++ b/contribute/corelibs.md
@@ -12,12 +12,8 @@ There are several options for contributing to Scala's core libraries. You can:
 * [Report Bugs or Issues](/contribute/bug-reporting-guide.html) against the core libraries.
 * [Fix Bugs or Issues](/contribute/guide.html) against the
   [reported library bugs/issues](https://github.com/scala/bug).
-* Contribute significant new functionality or a new API by submitting
-  a Scala Improvement Process (SIP) Document.
 
-### Submitting a SIP
+### Significant changes
 
-For significant new functionality or a whole new API to be considered for
-inclusion in the core Scala distribution, you will be asked to submit a SIP (Scala Improvement Process) document.
-
-Please see [instructions for submitting a new SIP](https://docs.scala-lang.org/sips/sip-submission.html) and familiarize yourself with the [SIP](http://docs.scala-lang.org/sips/) section of the Scala documentation site. Also please pay particular attention to the pre-requisites in the instructions before submitting a SIP.
+For significant new functionality or a whole new API to be considered for inclusion in the core Scala distribution,
+please take into account [https://github.com/scala/scala-dev/issues/661] before doing so.


### PR DESCRIPTION
Applying this PR will replace the references to SLIP with SIP, as the SLIP process is no more I believe.