### PR TITLE
Remove the spores announcement and add the roadmap to Scala 3 to the highlighted posts

### DIFF
--- a/_posts/2016-11-30-spores-release.md
+++ b/_posts/2016-11-30-spores-release.md
@@ -3,7 +3,6 @@
 category: blog
 by: Jorge Vicente Cantero
 title: "Releasing spores 0.4.3"
-isHighlight: true
 ---
 
 Today we at the Scala Center are happy to announce a new release of spores, now

--- a/_posts/2019-12-18-road-to-scala-3.md
+++ b/_posts/2019-12-18-road-to-scala-3.md
@@ -3,6 +3,7 @@ layout: blog-detail
 post-type: blog
 by: Lukas Rytz, Adriaan Moors, Martin Odersky
 title: "Scala 2 Roadmap Update: the Road to Scala 3"
+isHighlight: true
 ---
 
 Together with the Scala 3 team at EPFL (aka the Dotty team), led by Martin Odersky, we have decided that, rather than developing Scala 2.14, our efforts should go to Scala 3 instead.


### PR DESCRIPTION
When we go to https://scala-lang.org/blog, we see a panel on the right with very outdated highlights:

![Screenshot from 2020-02-24 12-35-29](https://user-images.githubusercontent.com/332812/75149594-b10a1300-5702-11ea-8c31-10610ae926cb.png)

This PR replaces them with the following:

![Screenshot from 2020-02-24 12-37-44](https://user-images.githubusercontent.com/332812/75149608-bebf9880-5702-11ea-989b-1043097b4fac.png)
