### PR TITLE
Mention Oracle Java11 and AdoptOpenJDK 8/11 

### DIFF
--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -25,7 +25,7 @@ layout: inner-page-parent
               <h3>First, make sure you have the Java 8 JDK (or Java 11 JDK) installed.</h3>
               <p>To check, open the terminal and type:</p>
               <p><code>java -version</code><span>(Make sure you have version 1.8 or 11.)</span></p>
-              <p><i>(If you don't have it installed, download Java from <a href="https://www.oracle.com/java/technologies/javase-jdk8-downloads.html">Oracle Java 8</a>, <a href="https://www.oracle.com/java/technologies/javase-jdk11-downloads.html">Oracle Java 11</a>, or <a href="https://adoptopenjdk.net/">AdoptOpenJDK 8/11</a>. Refer <a href="{{ site.baseurl }}/overviews/jdk-compatibility/overview.html">JDK Compatibility</a> for Scala/Java compatiblity detail.</i></p>
+              <p><i>(If you don't have it installed, download Java from <a href="https://www.oracle.com/java/technologies/javase-jdk8-downloads.html">Oracle Java 8</a>, <a href="https://www.oracle.com/java/technologies/javase-jdk11-downloads.html">Oracle Java 11</a>, or <a href="https://adoptopenjdk.net/">AdoptOpenJDK 8/11</a>. Refer <a href="https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html">JDK Compatibility</a> for Scala/Java compatiblity detail.</i></p>
             </div>
           </div>
           <div class="step">

--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -22,10 +22,10 @@ layout: inner-page-parent
             <img src="/resources/img/download/arrow-asset.png" alt="">
             <div class="number-step">1</div>
             <div class="text-step">
-              <h3>First, make sure you have the Java 8 JDK installed.</h3>
+              <h3>First, make sure you have the Java 8 JDK (or Java 11 JDK) installed.</h3>
               <p>To check, open the terminal and type:</p>
-              <p><code>java -version</code><span>(Make sure you have version 1.8.)</span></p>
-              <p><i>(If you don't have it installed, <a href="https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html">download Java here</a>.)</i></p>
+              <p><code>java -version</code><span>(Make sure you have version 1.8 or 11.)</span></p>
+              <p><i>(If you don't have it installed, download Java from <a href="https://www.oracle.com/java/technologies/javase-jdk8-downloads.html">Oracle Java 8</a>, <a href="https://www.oracle.com/java/technologies/javase-jdk11-downloads.html">Oracle Java 11</a>, or <a href="https://adoptopenjdk.net/">AdoptOpenJDK 8/11</a>. Refer <a href="{{ site.baseurl }}/overviews/jdk-compatibility/overview.html">JDK Compatibility</a> for Scala/Java compatiblity detail.</i></p>
             </div>
           </div>
           <div class="step">


### PR DESCRIPTION
Closes #1002

Unfortunately it is true that some part of Scala ecosystem do not support Java 11+ yet.
But Oracle Java 8 is no longer maintained for free (there is commercial support though), so is unlikely to get vulnerability fix.

I think, the officlal Scala documentation should recommend Scala community to download other Java LTS alternatives.

