### PR TITLE
htmlproofer: ignore 401 and 429 results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# opt-in to Travis new infrastructure
-sudo: false
-
 language: ruby
 rvm:
   - 2.3.1
@@ -15,7 +12,7 @@ script:
 - find ./_site \( -type d \( -name events -o -name training \) -prune -false \) -o \( -type f ! -name error.log -empty \)
 - find ./_site \( -type d \( -name events -o -name training \) -prune -false \) -o \( -type f ! -name error.log -empty \) | ( ! read )
 - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then bundle exec htmlproofer ./_site/ --disable-external --only-4xx --empty-alt-ignore --allow-hash-href ; fi
-- if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then bundle exec htmlproofer ./_site/ --external_only --only-4xx --empty-alt-ignore --allow-hash-href --url-ignore "/trends.google.com/,/pgp.mit.edu/,/www.oracle.com/" ; fi
+- if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then bundle exec htmlproofer ./_site/ --external_only --only-4xx --http-status-ignore 401,429 --empty-alt-ignore --allow-hash-href --url-ignore "/trends.google.com/,/pgp.mit.edu/,/www.oracle.com/" ; fi
 
 notifications:
   email:


### PR DESCRIPTION
bringing this repo in line with docs.scala-lang

prompted by a lot of 429 errors turning up at
https://travis-ci.org/github/scala/scala-lang/builds/664541189