### PR TITLE
update Scala Love conference URL

### DIFF
--- a/_events/2020-04-18-scala-love.md
+++ b/_events/2020-04-18-scala-love.md
@@ -4,7 +4,7 @@ title: Scala Love
 logo: /resources/img/scalalove.png
 location: Virtual
 description: "The most lovely conference"
-start: 18 April 2020 
+start: 18 April 2020
 end: 18 April 2020
-link-out: https://www.papercall.io/scalalove
+link-out: https://scala.love/conf/
 ---


### PR DESCRIPTION
initially only the CFP URL existed; now a more proper site exists