### PR TITLE
Add link to online courses (by Classpert)

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -145,6 +145,7 @@ items and opinions.  Ask your Scala friends who they follow on Twitter
 * [Scala Cookbook](http://www.scalacookbook.com/)
 * [Interactive Tour](http://scalatutorials.com/tour)
 * [Functional programming course/exercises](https://github.com/dehun/learn-fp)
+* [Scala Online Courses](https://classpert.com/scala-programming)
 
 ## Community Libraries and Tools
 


### PR DESCRIPTION
This is a curated list of Scala online courses by Classpert (an online course search engine). These are ~ 80 courses from top e-learning platforms like Udemy, Pluralsight, Coursera, Skillshare... it's also a growing list as well.