### PR TITLE
Update sbt-missinglink plugin version

### DIFF
--- a/_posts/2019-10-17-dependency-management.md
+++ b/_posts/2019-10-17-dependency-management.md
@@ -152,7 +152,7 @@ The readme explains how to use it, but the basics are simple.
 First, add the following line in `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % "0.1.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % "0.3.1")
 ```
 
 then simply run the following task for the project you want to test:


### PR DESCRIPTION
update plugin version to the current latest `0.3.1` . Older one failed with java 11

```
[debug] derived bootclasspath: null
[error] scala.NotImplementedError: an implementation is missing
[error]         at scala.Predef$.$qmark$qmark$qmark(Predef.scala:288)
[error]         at ch.epfl.scala.sbtmissinglink.MissingLinkPlugin$.loadBootstrapArtifacts(MissingLinkPlugin.scala:104)
[error]         at ch.epfl.scala.sbtmissinglink.MissingLinkPlugin$.loadArtifactsAndCheckConflicts(MissingLinkPlugin.scala:58)
[error]         at ch.epfl.scala.sbtmissinglink.MissingLinkPlugin$.$anonfun$configSettings$1(MissingLinkPlugin.scala:38)
[error]         at ch.epfl.scala.sbtmissinglink.MissingLinkPlugin$.$anonfun$configSettings$1$adapted(MissingLinkPlugin.scala:33)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error]         at sbt.Execute.work(Execute.scala:290)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error]         at java.base/java.lang.Thread.run(Thread.java:834)
[error] (Compile / missinglinkCheck) scala.NotImplementedError: an implementation is missing``` 