### PR TITLE
describe Discourse primarily as a forum

### DIFF
--- a/_includes/masthead-community.html
+++ b/_includes/masthead-community.html
@@ -4,7 +4,7 @@
 			<div class="community">
 				<div class="discourse">
 					<h3>Discourse</h3>
-					<span>Mailing list</span>
+					<span>Forums / mailing lists</span>
 					<ul>
 						{% for forum in site.data.chats-forums.discourseForums %}
 							<li>


### PR DESCRIPTION
this brings the wording at the top of
https://www.scala-lang.org/community/ in line with the other wordings
farther down the page