### PR TITLE
Jekyll 3.9.0 upgrade, also kramdown upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rack-jekyll'
 gem 'rake'
 gem 'jekyll-redirect-from'
 gem 'html-proofer'
+gem 'kramdown-parser-gfm'
 
 # group :jekyll_plugins do
 #   gem 'hawkins'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     colorize (0.8.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -31,14 +31,14 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.7)
+    jekyll (3.9.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 0.7)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (>= 1.17, < 3)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
@@ -50,7 +50,10 @@ GEM
       sass (~> 3.4)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -73,7 +76,8 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.20.0)
+    rexml (3.2.4)
+    rouge (3.22.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -95,5 +99,9 @@ DEPENDENCIES
   jekyll
   jekyll-redirect-from
   kramdown
+  kramdown-parser-gfm
   rack-jekyll
   rake
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
this is comparable to scala/docs.scala-lang#1756.  the motivation is
the same: we got a security alert about kramdown.

but it went a bit differently in this repo. if I did `bundle update
jekyll` that went all the way to some 4.x version. I don't know why.
but it seems safer to do a smaller upgrade first. `bundle update
--minor jekyll` got us to 3.9.0, but then kramdown didn't get updated,
so I followed it with `bundle update kramdown` (after adding
`kramdown-parser-gfm` to `Gemfile`, as in the other PR)

since I didn't do a full `bundle update`, I didn't need to revert
any version bump of jekyll-redirect-from

so.... it's not great that this doesn't bring the two repos exactly
in sync, but oh well. I'm trying to resolve the security issue without
putting excess effort into it.

I wouldn't oppose followup PR(s) that reduce the deltas between the
repos.