### PR TITLE
remove rack-jekyll (and do 'bundle update --patch')

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'kramdown'
-gem 'rack-jekyll'
 gem 'rake'
 gem 'jekyll-redirect-from'
 gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.13.1)
     forwardable-extended (2.6.0)
-    html-proofer (3.10.0)
+    html-proofer (3.10.2)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       colorize (~> 0.8)
@@ -61,17 +61,12 @@ GEM
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.12.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.5)
-    rack (1.6.13)
-    rack-jekyll (0.5.0)
-      jekyll (>= 1.3)
-      listen (>= 1.3)
-      rack (~> 1.5)
     rake (12.3.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -100,7 +95,6 @@ DEPENDENCIES
   jekyll-redirect-from
   kramdown
   kramdown-parser-gfm
-  rack-jekyll
   rake
 
 BUNDLED WITH


### PR DESCRIPTION
fixes #1150

as usual I don't understand Bundler and am just fumbling around. a full `bundle update` gave some error on CI about a version of mercenary being too new for our Ruby version. `bundle update --patch` avoids that while still letting bundler automatically bring things up to date for rack-jekyll no longer being present in `Gemfile`