### PR TITLE
Fix links for older events

### DIFF
--- a/_events/2013-11-11-devoxx-belgium.md
+++ b/_events/2013-11-11-devoxx-belgium.md
@@ -6,5 +6,5 @@ location: Antwerp
 description: We code in peace
 start: 11 November 2013
 end: 15 November 2013
-link-out: http://www.devoxx.com/
+link-out: https://www.youtube.com/playlist?list=PLklQqdqnBkPjdiPGnXK-Yxc5WMLEyK1Ho
 ---

--- a/_events/2019-10-06-sphereit.md
+++ b/_events/2019-10-06-sphereit.md
@@ -6,5 +6,5 @@ location: Kraków, Poland
 description: "one conference, five spheres covering the emerging potential of software technology"
 start: 6 October 2019
 end: 9 October 2019
-link-out: https://sphere.it/sphere-it-2019-edition/
+link-out: https://archive.sphere.it/previous-editions/#2019
 ---


### PR DESCRIPTION
For devoxx belgium 2013 I could not find a website. The YouTube playlist was the closest thing.
Fixes https://github.com/scala/scala-lang/issues/1174.