### PR TITLE
in footer, point GitHub link to whole org

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -49,7 +49,7 @@
   class: social
   links:
     - title: GitHub
-      url: "https://github.com/scala/scala"
+      url: "https://github.com/scala"
     - title: Twitter
       url: "https://twitter.com/scala_lang"
     - title: Gitter


### PR DESCRIPTION
with Scala 3 arriving soon, and the dotty repo likely moving
to the Scala org, this seems better to me

scala/scala remains the top pinned repo behind the org link,
so I don't think people will have any trouble finding it

and this change increases the chance that people will find
scala/bug, which is also pinned