### PR TITLE
Fix Atom namespace in feeds

### DIFF
--- a/feed/blog.xml
+++ b/feed/blog.xml
@@ -1,7 +1,7 @@
 ---
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="https://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <id>https://www.scala-lang.org/blog/</id>
   <title type="text" xml:lang="en">{{ site.title }} :: Blog</title>
   <link type="application/atom+xml" href="https://www.scala-lang.org/feed/blog.xml" rel="self"/>

--- a/feed/index.xml
+++ b/feed/index.xml
@@ -1,7 +1,7 @@
 ---
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="https://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <id>https://www.scala-lang.org/</id>
   <title type="text" xml:lang="en">{{ site.title }} :: News</title>
   <link type="application/atom+xml" href="https://www.scala-lang.org/feed/index.xml" rel="self"/>


### PR DESCRIPTION
Must be HTTP not HTTPS.

Closes #1197