### PR TITLE
Reword 'Scala runs'

### DIFF
--- a/_data/common.yml
+++ b/_data/common.yml
@@ -6,7 +6,7 @@ scastieUrl: https://scastie.scala-lang.org
 courseraMoocsUrl: https://www.coursera.org/specializations/scala
 
 texts:
-  scalaBackendsTitle: Scala runs on...
+  scalaBackendsTitle: Scala runs...
   scalaBackendsMore: with more backends on the way.
   metalsSupportedInIDE: Language server support via Metals
   onlineCoursesFree: Free (optional paid certificate)

--- a/index.md
+++ b/index.md
@@ -36,12 +36,12 @@ currentScalaVersion: "2.13.4"
 # Scala backends
 scalaBackends:
   - icon: /resources/img/frontpage/java-logo.png
-    description: JVM
+    description: on the JVM
   - icon: /resources/img/frontpage/js-logo.png
-    description: JavaScript in your browser
+    description: on JavaScript in your browser
     link: https://www.scala-js.org/
   - icon: /resources/img/frontpage/llvm-logo.png
-    description: Natively with LLVM
+    description: natively with LLVM
     link: https://scala-native.readthedocs.io/
     beta: 1
 


### PR DESCRIPTION
Applying this PR will change the 'Scala runs'-wording to 'Scala runs...'
- on the JVM
- on JavaScript in your browser
- natively with LLVM