### PR TITLE
Add effective scala to courses

### DIFF
--- a/_online_courses/effective_programming_in_scala.md
+++ b/_online_courses/effective_programming_in_scala.md
@@ -1,0 +1,28 @@
+---
+layout: inner-page-no-masthead
+title: Effective Programming in Scala
+coursera-page: https://www.coursera.org/learn/effective-scala
+paid: false
+showDate: false
+---
+
+Scala is an expressive, versatile, and safe programming language.
+
+In this course, you will learn how to get the most out of Scala to solve common programming tasks such as modeling business domains, breaking down complex problems into simpler problems, manipulating data, or running parallel tasks.
+
+Along the journey, you will also learn the best practices for writing high-quality code that scales to large applications, how to handle errors, how to write tests, and how to leverage a productive development environment.
+
+This comprehensive, hands-on, course aims at leveling up your programming skills by embracing both functional programming and object-oriented programming. You will become familiar with the standard library and the common patterns of code used in the real world.
+
+Each week contains about 1h30 of video lectures. Each lecture is a ~10 min video focused on a specific skill or concept. We always start by looking at concrete problems, and then explain how language features or libraries make you more productive to solve these problems in general.
+
+Lectures are generally followed by a quiz to assess your progress. At the end of each week, a graded assignment inspired by real-world applications will give you an opportunity to put things in practice.
+
+The course covers Scala 3, and it mentions the differences with Scala 2.
+
+You will learn to:
+
+ - Leverage Scala idioms to model business domains and implement business logic
+ - Fundamental concepts of the language, allowing you to read and understand Scala codebases
+ - Best practices and common patterns used in the real world
+ - Be comfortable working with asynchronous computations, handling failures, and manipulating recursive data structures


### PR DESCRIPTION
Effective Scala currently does not appear on scala-lang.org.
This PR adds it along to the other courses with the same description that is used on Coursera (the same is done for other courses).

See the screenshots
![before](https://user-images.githubusercontent.com/6325220/124892590-4a755480-dfda-11eb-961f-ac40053ddcdc.png)
![after](https://user-images.githubusercontent.com/6325220/124892704-611bab80-dfda-11eb-82f0-3667fb8bf390.png)
