### PR TITLE
Fix the margins in the maintainers section

### DIFF
--- a/_sass/layout/maintenance.scss
+++ b/_sass/layout/maintenance.scss
@@ -27,7 +27,7 @@
         margin-bottom: 40px;
 
         li {
-            &:first-child {
+            &:not(:last-child) {
                 margin-right: 32px;
             }
 


### PR DESCRIPTION
This PR adds the margin that was missing between the Lightbend and VirtusLab logos on the home page.

Previously, the margin was added only after the first element. It is now added between all the elements.

### Visual Comparison
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/7029582/128775403-03a6e349-f250-4ea3-9ac3-7a8f1436bc24.png" alt="" width="400">
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/7029582/128775411-62ac0c4b-2b44-4996-8590-0a330ebfac68.png" alt="" width="400">
    </td>
  </tr>
</table>