### PR TITLE
Update hover effect for online course icon

### DIFF
--- a/_includes/online-courses.html
+++ b/_includes/online-courses.html
@@ -57,12 +57,12 @@
         <div class="card-text">
           <h4>
             {% if course.coursera-page %}
-              <a href="{{course.coursera-page}}">
+              <a class="course-icon" href="{{course.coursera-page}}">
                 <img src="/resources/img/frontpage/coursera-icon.png" alt="">
               </a>
             {% endif %}
             {% if course.edx-page %}
-              <a href="{{course.edx-page}}">
+              <a class="course-icon" href="{{course.edx-page}}">
                 <img src="/resources/img/frontpage/edx-icon.png" alt="">
               </a>
             {% endif %}

--- a/_sass/components/card.scss
+++ b/_sass/components/card.scss
@@ -62,6 +62,12 @@
 
         line-height: normal;
 
+        &:hover {
+            .course-icon {
+                transform: scale(1.2);
+            }
+        }
+
         .card-text {
 
             margin-left: 0;


### PR DESCRIPTION
Fix #1266 

- Scale the online course icon when user hovers over the card.

![Aug-12-2021 19-00-07](https://user-images.githubusercontent.com/28077042/129185987-2fefe556-0f0e-4db5-b456-67bbd17b6170.gif)
