### PR TITLE
Add SDKMAN to the Scala 3 download page

### DIFF
--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -65,7 +65,7 @@
           <a id="download-binaries">Download the Scala binaries for <span id="users-os"></span></a>
           <br/><span class="install"><a href="{{ site.baseurl }}/download/install.html">Need help running the binaries?</a></span>
         </li>
-        <li>Using <a href="https://sdkman.io/">SDKMAN!</a>, you can easily <a href="https://sdkman.io/sdks#scala">install specific versions of Scala</a> on any platform with <code>sdk install scala 2.13.6</code></li>
+        <li>Using <a href="https://sdkman.io/">SDKMAN!</a>, you can easily <a href="https://sdkman.io/sdks#scala">install specific versions of Scala</a> on any platform with <code>sdk install scala {{ site.scalaversion }}</code></li>
         <li>On macOS you can also use <a href="https://brew.sh/">Homebrew</a> and existing <a href="https://formulae.brew.sh/formula/scala">Scala Formulae</a><br/><code>brew update</code><br/><code>brew install scala</code></li>
         <li>With <a href="https://www.macports.org/">MacPorts</a>, you can get Scala using <code>sudo port install scala2.x</code>command.<br/> For example to install Scala 2.12 simply use<code>sudo port install scala2.12</code></li>
         <li>Use <a href="https://scastie.scala-lang.org">Scastie</a> to run single-file Scala programs in your browser using multiple Scala compilers; the production Scala 2.x compilers, Scala.js, Dotty, and Typelevel Scala. Save and share executable Scala code snippets.</li>

--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -65,7 +65,7 @@
           <a id="download-binaries">Download the Scala binaries for <span id="users-os"></span></a>
           <br/><span class="install"><a href="{{ site.baseurl }}/download/install.html">Need help running the binaries?</a></span>
         </li>
-        <li>Using <a href="https://sdkman.io/">SDKMAN!</a>, you can easily <a href="https://sdkman.io/sdks#scala">install Scala</a> with <code>sdk install scala</code></li>
+        <li>Using <a href="https://sdkman.io/">SDKMAN!</a>, you can easily <a href="https://sdkman.io/sdks#scala">install specific versions of Scala</a> on any platform with <code>sdk install scala 2.13.6</code></li>
         <li>On macOS you can also use <a href="https://brew.sh/">Homebrew</a> and existing <a href="https://formulae.brew.sh/formula/scala">Scala Formulae</a><br/><code>brew update</code><br/><code>brew install scala</code></li>
         <li>With <a href="https://www.macports.org/">MacPorts</a>, you can get Scala using <code>sudo port install scala2.x</code>command.<br/> For example to install Scala 2.12 simply use<code>sudo port install scala2.12</code></li>
         <li>Use <a href="https://scastie.scala-lang.org">Scastie</a> to run single-file Scala programs in your browser using multiple Scala compilers; the production Scala 2.x compilers, Scala.js, Dotty, and Typelevel Scala. Save and share executable Scala code snippets.</li>

--- a/_includes/downloads-scala3.html
+++ b/_includes/downloads-scala3.html
@@ -119,7 +119,10 @@ Scala binaries for <strong>{{page.release_version}}</strong> are available at <a
           Download the Scala binaries for <strong>{{page.release_version}}</strong> at <a href="https://github.com/lampepfl/dotty/releases/tag/{{page.release_version}}">github</a>.
           <br/><span class="install"><a href="{{ site.baseurl }}/download/install.html">Need help running the binaries?</a></span>
         </li>
-        <li>On macOS you can also use <a href="https://brew.sh/">Homebrew</a> and runthe following commands<br>
+        <li>Using <a href="https://sdkman.io/">SDKMAN!</a>, you can easily <a href="https://sdkman.io/sdks#scala">install the latest version of Scala</a> on any platform by running the following command:<br>
+            <code>sdk install scala</code>
+        </li>
+        <li>On macOS you can also use <a href="https://brew.sh/">Homebrew</a> and run the following commands:<br>
             <code>brew update</code><br/><code>brew install lampepfl/brew/dotty</code></li>
         <li>Use <a href="https://scastie.scala-lang.org/?target=scala3">Scastie</a> to run single-file Scala programs in your browser using multiple Scala compilers; the production Scala 2.x compilers, Scala.js, Scala 3, and Typelevel Scala. Save and share executable Scala code snippets.</li>
       </ul>


### PR DESCRIPTION
Hi folks,

This PR adds a small section to the Scala 3 download page which is similar to that found on the Scala 2 page. Since Scala 3.0.1 is now the default for Scala on SDKMAN, I've also updated the Scala 2 download page appropriately. Please shout if there is anything you would like me to change.

Thanks!