### PR TITLE
Remove Dotty Gitter channel link

### DIFF
--- a/_data/chats-forums.yml
+++ b/_data/chats-forums.yml
@@ -25,5 +25,3 @@ gitterChannels:
     url: https://gitter.im/scala-native/scala-native
   - name: scala-js/scala-js
     url: https://gitter.im/scala-js/scala-js
-  - name: lampepfl/dotty
-    url: https://gitter.im/lampepfl/dotty


### PR DESCRIPTION
as discussions should go to https://gitter.im/scala/contributors﻿
