### PR TITLE
Remove slashes from the end of charset tags

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
     <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
     {% if page.title %}


### PR DESCRIPTION
For some reason, some scrapers (most notably Discord's OGP scraper) don't respect charset tags that do contain closing slashes.

Huge thanks to @adryd325 for taking the time to poke at Discord's scraper to figure this out.