### PR TITLE
Don't overwrite the HREFs for the Download IntelliJ/SBT buttons

### DIFF
--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -260,11 +260,7 @@ function getOS() {
 $(document).ready(function() {
     if ($(".main-download").length) {
         var os = getOS();
-        var intelliJlink = $("#intellij-" + os).text();
-        var sbtLink = $("#sbt-" + os).text();
-        var stepOneContent = $("#stepOne-" + os).html()
-        $("#download-intellij-link").attr("href", intelliJlink);
-        $("#download-sbt-link").attr("href", sbtLink);
+        var stepOneContent = $("#stepOne-" + os).html();
         $("#download-step-one").html(stepOneContent);
     }
 });


### PR DESCRIPTION
This should fix #1285 for good. In #1286, it was unbeknownst to me that there was JS that ended up editing the HREFs of the IntelliJ and SBT links, and so the code that was initially broken there remained broken.

I've tested this by making the relevant changes in the Chrome Debugger and verifying that the HREFs aren't overwritten.