### PR TITLE
CoC: clarify personal-information bullet

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -101,7 +101,7 @@ Behavior that will lead to exclusion includes the following points, inspired by 
 * Violence, threats of violence or violent language directed against another person.
 * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
 * Posting or displaying sexually explicit or violent material.
-* Posting or threatening to post other people’s personally identifying information (including so-called "doxing").
+* Posting or threatening to post other people’s personally identifying information.
 * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
 * Inappropriate photography or recording.
 * Inappropriate physical contact. You should have someone’s consent before touching them.

--- a/conduct.md
+++ b/conduct.md
@@ -101,7 +101,7 @@ Behavior that will lead to exclusion includes the following points, inspired by 
 * Violence, threats of violence or violent language directed against another person.
 * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
 * Posting or displaying sexually explicit or violent material.
-* Posting or threatening to post other people’s personally identifying information ("doxing").
+* Posting or threatening to post other people’s personally identifying information (including so-called "doxing").
 * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
 * Inappropriate photography or recording.
 * Inappropriate physical contact. You should have someone’s consent before touching them.


### PR DESCRIPTION
I think the word "doxing" is slang; the boundaries of its meaning are disputed; and accusing someone of "doxing" is potentially a very serious accusation.

So I think it's better to be clear that something could fall under this bullet without actually necessarily qualifying as "doxing" per se.