### PR TITLE
improve download/all page

### DIFF
--- a/_includes/download-resource-list.html
+++ b/_includes/download-resource-list.html
@@ -40,7 +40,14 @@
 <p>You can find the links to prior versions or the latest development version below.
 To see a detailed list of changes for each version of Scala please refer to the <a href="{{ site.baseurl }}/download/changelog.html">changelog</a>.</p>
 
-<p>Note that different major releases of Scala (e.g. Scala 2.11.x and Scala 2.12.x) are not binary compatible with each other.</p>
+<p>
+  Note that different major releases of Scala 2 (e.g. Scala 2.11.x and Scala 2.12.x) are not
+  <a href="https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html">binary compatible</a>
+  with each other. Scala 3 minor releases (e.g. 3.0.x and 3.1.x) follow a
+  <a href="https://docs.scala-lang.org/scala3/reference/language-versions/binary-compatibility.html">
+    different compatibility model
+  </a>.
+</p>
 
 <ul>
   {% for release in site.data.scala-releases %}

--- a/_includes/downloads-list.html
+++ b/_includes/downloads-list.html
@@ -1,19 +1,55 @@
-{% for top in (0..3) reversed %}
-  {% for major in (0..20) reversed %}
-    {% assign possibleVersionShort = top | append:'.' | append:major %}
-    {% assign sz = possibleVersionShort | size %}
-    {% if 3 == sz %}
-      {% assign possibleVersion = possibleVersionShort | append:'.' %}
-    {% else %}
-      {% assign possibleVersion = possibleVersionShort %}
-    {% endif %}
-    {% for page in site.downloads %}
-      {% assign releaseVersion = page.release_version | truncate:4, '' %}
-      {% if releaseVersion == possibleVersion %}
-<div>
-  <a href="{{ page.url }}">{{ page.title }}</a>
+<p>This page contains a comprehensive archive of previous Scala releases.</p>
+<div class="download-options">
+  <div class="download-left">
+      <h3>Current Releases</h3>
+      <br />
+      <ul>
+        {% for release in site.data.scala-releases %}
+        {% if release.category == "current_version" %}
+        <li>
+          <a href="/download/{{ release.version }}.html">
+            {{ release.title }}: <b>{{ release.version }}</b><br />Released on {{ release.release_date }}
+          </a>
+        </li>
+        {% endif %}
+        {% endfor %}
+      </ul>
+      <h3>Maintenance Releases</h3>
+      <br />
+      <ul>
+        {% for release in site.data.scala-releases %}
+        {% if release.category == "maintenance_version" %}
+        <li>
+          <a href="/download/{{ release.version }}.html">
+            {{ release.title }}: <b>{{ release.version }}</b><br />Released on {{ release.release_date }}
+          </a>
+        </li>
+        {% endif %}
+        {% endfor %}
+      </ul>
+  </div>
+  <div class="download-right">
+    <h3>All Releases</h3>
+    <div class="all-downloads">
+      {% for top in (0..3) reversed %}
+        {% for major in (0..20) reversed %}
+          {% assign possibleVersionShort = top | append:'.' | append:major %}
+          {% assign sz = possibleVersionShort | size %}
+          {% if 3 == sz %}
+            {% assign possibleVersion = possibleVersionShort | append:'.' %}
+          {% else %}
+            {% assign possibleVersion = possibleVersionShort %}
+          {% endif %}
+          {% for page in site.downloads reversed %}
+            {% assign releaseVersion = page.release_version | truncate:4, '' %}
+            {% if releaseVersion == possibleVersion %}
+              <div class="download-elem">
+                <a href="{{ page.url }}">{{ page.title }}</a>
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endfor %}
+      {% endfor %}
+    </div>
+  </div>
 </div>
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
-{% endfor %}

--- a/_layouts/download-all.html
+++ b/_layouts/download-all.html
@@ -1,0 +1,32 @@
+{% include headertop.html %}
+{% include headerbottom.html %}
+
+<div class="navigation-fade-screen"></div>
+
+{% include navbar-inner.html %}
+
+<main id="inner-main" class="download-page select-language">
+
+  <!-- Title -->
+  <section class="title-page">
+    <div class="wrap">
+      <h1>{{page.title}}</h1>
+    </div>
+  </section>
+
+  {% comment %}Specific content from child layouts{% endcomment %}
+
+  <section class="books">
+    <div class="wrap">
+      <div class="inner-box download">
+        <div class="main-download">
+          {{content}}
+        </div>
+      </div>
+    </div>
+  </section>
+
+
+</main>
+
+{% include footer.html %}

--- a/_sass/layout/download.scss
+++ b/_sass/layout/download.scss
@@ -279,10 +279,14 @@
       }
     }
 
-
-
     .download-right {
       padding-left: 10px;
+      .all-downloads {
+        margin-top: 0.7em;
+        .download-elem {
+          padding: 0px 8px;
+        }
+      }
     }
 
     .download-right {

--- a/download/all.md
+++ b/download/all.md
@@ -1,9 +1,7 @@
 ---
 title: All Available Versions
-layout: inner-page-no-masthead
+layout: download-all
 # permalink: /download/all/
 ---
-
-This page contains a comprehensive archive of previous Scala releases.
 
 {% include downloads-list.html %}


### PR DESCRIPTION
use a new layout and list the current/maintenance versions in left column, all releases in right column.

Also make so that runs of patch releases within a minor version begin with most recent release

<img width="1317" alt="Screenshot 2022-03-03 at 17 23 30" src="https://user-images.githubusercontent.com/13436592/156606886-75d8f2b0-71aa-4332-b862-fd9ae51ef9dc.png">
