### PR TITLE
link api docs from release page

### DIFF
--- a/_downloads/2016-11-03-2.12.0.md
+++ b/_downloads/2016-11-03-2.12.0.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.0.html
 requirements: "Scala 2.12 requires version 8 of the Java platform, as provided by <a href='https://openjdk.java.net/install/'>OpenJDK</a> or <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html'>Oracle</a>. Java 9 is not yet supported."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.0/
 resources: [
   ["-main-unixsys", "scala-2.12.0.tgz", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
   ["-main-windows", "scala-2.12.0.msi", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.msi", "Windows (msi installer)", "117.78M"],

--- a/_downloads/2016-12-05-2.12.1.md
+++ b/_downloads/2016-12-05-2.12.1.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.1/
 resources: [
   ["-main-unixsys", "scala-2.12.1.tgz", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
   ["-main-windows", "scala-2.12.1.msi", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],

--- a/_downloads/2017-04-18-2.12.2.md
+++ b/_downloads/2017-04-18-2.12.2.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.2/
 resources: [
   ["-main-unixsys", "scala-2.12.2.tgz", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.tgz", "Mac OS X, Unix, Cygwin", "18.69M"],
   ["-main-windows", "scala-2.12.2.msi", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.msi", "Windows (msi installer)", "126.44M"],

--- a/_downloads/2017-07-26-2.12.3.md
+++ b/_downloads/2017-07-26-2.12.3.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.3/
 resources: [
   ["-main-unixsys", "scala-2.12.3.tgz", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.tgz", "Mac OS X, Unix, Cygwin", "18.85M"],
   ["-main-windows", "scala-2.12.3.msi", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.msi", "Windows (msi installer)", "126.93M"],

--- a/_downloads/2017-10-17-2.12.4.md
+++ b/_downloads/2017-10-17-2.12.4.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.4/
 resources: [
   ["-main-unixsys", "scala-2.12.4.tgz", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.tgz", "Mac OS X, Unix, Cygwin", "18.83M"],
   ["-main-windows", "scala-2.12.4.msi", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.msi", "Windows (msi installer)", "126.38M"],

--- a/_downloads/2017-11-09-2.10.7.md
+++ b/_downloads/2017-11-09-2.10.7.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.10.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.10.7/
 resources: [
   ["-main-unixsys", "scala-2.10.7.tgz", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.tgz", "Mac OS X, Unix, Cygwin", "28.60M"],
   ["-main-windows", "scala.msi", "https://downloads.lightbend.com/scala/2.10.7/scala.msi", "Windows (msi installer)", "58.58M"],

--- a/_downloads/2017-11-09-2.11.12.md
+++ b/_downloads/2017-11-09-2.11.12.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.11.12.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.11.12/
 resources: [
   ["-main-unixsys", "scala-2.11.12.tgz", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.tgz", "Mac OS X, Unix, Cygwin", "27.77M"],
   ["-main-windows", "scala-2.11.12.msi", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.msi", "Windows (msi installer)", "109.82M"],

--- a/_downloads/2018-03-15-2.12.5.md
+++ b/_downloads/2018-03-15-2.12.5.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.5/
 resources: [
   ["-main-unixsys", "scala-2.12.5.tgz", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.tgz", "Mac OS X, Unix, Cygwin", "19.36M"],
   ["-main-windows", "scala-2.12.5.msi", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.msi", "Windows (msi installer)", "123.65M"],

--- a/_downloads/2018-04-27-2.12.6.md
+++ b/_downloads/2018-04-27-2.12.6.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.6/
 resources: [
   ["-main-unixsys", "scala-2.12.6.tgz", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.tgz", "Mac OS X, Unix, Cygwin", "19.39M"],
   ["-main-windows", "scala-2.12.6.msi", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.msi", "Windows (msi installer)", "123.67M"],

--- a/_downloads/2018-09-27-2.12.7.md
+++ b/_downloads/2018-09-27-2.12.7.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
+api_docs: https://www.scala-lang.org/api/2.12.7/
 resources: [
   ["-main-unixsys", "scala-2.12.7.tgz", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.tgz", "Mac OS X, Unix, Cygwin", "19.47M"],
   ["-main-windows", "scala-2.12.7.msi", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.msi", "Windows (msi installer)", "123.87M"],

--- a/_downloads/2018-12-04-2.12.8.md
+++ b/_downloads/2018-12-04-2.12.8.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.8/
 resources: [
   ["-main-unixsys", "scala-2.12.8.tgz", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.tgz", "Mac OS X, Unix, Cygwin", "19.52M"],
   ["-main-windows", "scala-2.12.8.msi", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.msi", "Windows (msi installer)", "123.96M"],

--- a/_downloads/2019-06-11-2.13.0.md
+++ b/_downloads/2019-06-11-2.13.0.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.0.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.0/
 resources: [
   ["-main-unixsys", "scala-2.13.0.tgz", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
   ["-main-windows", "scala-2.13.0.msi", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.msi", "Windows (msi installer)", "114.63M"],

--- a/_downloads/2019-08-05-2.12.9.md
+++ b/_downloads/2019-08-05-2.12.9.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.9.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.9/
 resources: [
   ["-main-unixsys", "scala-2.12.9.tgz", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.tgz", "Mac OS X, Unix, Cygwin", "19.69M"],
   ["-main-windows", "scala-2.12.9.msi", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.msi", "Windows (msi installer)", "124.01M"],

--- a/_downloads/2019-09-10-2.12.10.md
+++ b/_downloads/2019-09-10-2.12.10.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.10.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.10/
 resources: [
   ["-main-unixsys", "scala-2.12.10.tgz", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz", "Mac OS X, Unix, Cygwin", "19.71M"],
   ["-main-windows", "scala-2.12.10.msi", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.msi", "Windows (msi installer)", "124M"],

--- a/_downloads/2019-09-18-2.13.1.md
+++ b/_downloads/2019-09-18-2.13.1.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.1/
 resources: [
   ["-main-unixsys", "scala-2.13.1.tgz", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.tgz", "Mac OS X, Unix, Cygwin", "18.77M"],
   ["-main-windows", "scala-2.13.1.msi", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.msi", "Windows (msi installer)", "115.13M"],

--- a/_downloads/2020-03-16-2.12.11.md
+++ b/_downloads/2020-03-16-2.12.11.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.11.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.11/
 resources: [
   ["-main-unixsys", "scala-2.12.11.tgz", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.tgz", "Mac OS X, Unix, Cygwin", "19.83M"],
   ["-main-windows", "scala-2.12.11.msi", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.msi", "Windows (msi installer)", "124.33M"],

--- a/_downloads/2020-04-22-2.13.2.md
+++ b/_downloads/2020-04-22-2.13.2.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.2/
 resources: [
   ["-main-unixsys", "scala-2.13.2.tgz", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.tgz", "Mac OS X, Unix, Cygwin", "21.07M"],
   ["-main-windows", "scala-2.13.2.msi", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.msi", "Windows (msi installer)", "126.89M"],

--- a/_downloads/2020-06-25-2.13.3.md
+++ b/_downloads/2020-06-25-2.13.3.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.3/
 resources: [
   ["-main-unixsys", "scala-2.13.3.tgz", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.tgz", "Mac OS X, Unix, Cygwin", "21.38M"],
   ["-main-windows", "scala-2.13.3.msi", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.msi", "Windows (msi installer)", "125.76M"],

--- a/_downloads/2020-07-13-2.12.12.md
+++ b/_downloads/2020-07-13-2.12.12.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.12.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.12/
 resources: [
   ["-main-unixsys", "scala-2.12.12.tgz", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.tgz", "Mac OS X, Unix, Cygwin", "19.87M"],
   ["-main-windows", "scala-2.12.12.msi", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.msi", "Windows (msi installer)", "124.70M"],

--- a/_downloads/2020-11-19-2.13.4.md
+++ b/_downloads/2020-11-19-2.13.4.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.4/
 resources: [
   ["-main-unixsys", "scala-2.13.4.tgz", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.tgz", "Mac OS X, Unix, Cygwin", "21.91M"],
   ["-main-windows", "scala-2.13.4.msi", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.msi", "Windows (msi installer)", "128.68M"],

--- a/_downloads/2021-01-12-2.12.13.md
+++ b/_downloads/2021-01-12-2.12.13.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.13.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.13/
 resources: [
   ["-main-unixsys", "scala-2.12.13.tgz", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.tgz", "Mac OS X, Unix, Cygwin", "20.03M"],
   ["-main-windows", "scala-2.12.13.msi", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.msi", "Windows (msi installer)", "125.69M"],

--- a/_downloads/2021-02-22-2.13.5.md
+++ b/_downloads/2021-02-22-2.13.5.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.5/
 resources: [
   ["-main-unixsys", "scala-2.13.5.tgz", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.tgz", "Mac OS X, Unix, Cygwin", "21.98M"],
   ["-main-windows", "scala-2.13.5.msi", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.msi", "Windows (msi installer)", "130.48M"],

--- a/_downloads/2021-05-14-3.0.0.md
+++ b/_downloads/2021-05-14-3.0.0.md
@@ -6,4 +6,5 @@ release_version: 3.0.0
 release_date: "May 14, 2021"
 permalink: /download/3.0.0.html
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/3.0.0/
 ---

--- a/_downloads/2021-05-17-2.13.6.md
+++ b/_downloads/2021-05-17-2.13.6.md
@@ -7,6 +7,7 @@ release_date: "May 17, 2021"
 show_resources: "true"
 permalink: /download/2.13.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
+api_docs: https://www.scala-lang.org/api/2.13.6/
 resources: [
   ["-main-unixsys", "scala-2.13.6.tgz", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.tgz", "Mac OS X, Unix, Cygwin", "22.32M"],
   ["-main-windows", "scala-2.13.6.msi", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.msi", "Windows (msi installer)", "131.46M"],

--- a/_downloads/2021-05-28-2.12.14.md
+++ b/_downloads/2021-05-28-2.12.14.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.14.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.14/
 resources: [
   ["-main-unixsys", "scala-2.12.14.tgz", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.tgz", "Mac OS X, Unix, Cygwin", "20.11M"],
   ["-main-windows", "scala-2.12.14.msi", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.msi", "Windows (msi installer)", "125.83M"],

--- a/_downloads/2021-07-09-3.0.1.md
+++ b/_downloads/2021-07-09-3.0.1.md
@@ -6,4 +6,5 @@ release_version: 3.0.1
 release_date: "July 9, 2021"
 permalink: /download/3.0.1.html
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/3.0.1/
 ---

--- a/_downloads/2021-09-01-3.0.2.md
+++ b/_downloads/2021-09-01-3.0.2.md
@@ -6,4 +6,5 @@ release_version: 3.0.2
 release_date: "September 1, 2021"
 permalink: /download/3.0.2.html
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/3.0.2/
 ---

--- a/_downloads/2021-09-14-2.12.15.md
+++ b/_downloads/2021-09-14-2.12.15.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.12.15.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.12.15/
 resources: [
   ["-main-unixsys", "scala-2.12.15.tgz", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.tgz", "Mac OS X, Unix, Cygwin", "20.11M"],
   ["-main-windows", "scala-2.12.15.msi", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.msi", "Windows (msi installer)", "125.48M"],

--- a/_downloads/2021-10-18-3.1.0.md
+++ b/_downloads/2021-10-18-3.1.0.md
@@ -6,4 +6,5 @@ release_version: 3.1.0
 release_date: "October 18, 2021"
 permalink: /download/3.1.0.html
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/3.1.0/
 ---

--- a/_downloads/2021-11-01-2.13.7.md
+++ b/_downloads/2021-11-01-2.13.7.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.7/
 resources: [
   ["-main-unixsys", "scala-2.13.7.tgz", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.tgz", "Mac OS X, Unix, Cygwin", "22.64M"],
   ["-main-windows", "scala-2.13.7.msi", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.msi", "Windows (msi installer)", "134.43M"],

--- a/_downloads/2022-01-12-2.13.8.md
+++ b/_downloads/2022-01-12-2.13.8.md
@@ -8,6 +8,7 @@ show_resources: "true"
 permalink: /download/2.13.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/2.13.8/
 resources: [
   ["-main-unixsys", "scala-2.13.8.tgz", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.tgz", "Mac OS X, Unix, Cygwin", "22.65M"],
   ["-main-windows", "scala-2.13.8.msi", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.msi", "Windows (msi installer)", "134.43M"],

--- a/_downloads/2022-02-01-3.1.1.md
+++ b/_downloads/2022-02-01-3.1.1.md
@@ -6,4 +6,5 @@ release_version: 3.1.1
 release_date: "February 1, 2022"
 permalink: /download/3.1.1.html
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
+api_docs: https://www.scala-lang.org/api/3.1.1/
 ---

--- a/_layouts/downloadpage.html
+++ b/_layouts/downloadpage.html
@@ -32,19 +32,21 @@
         <div class="ribbon-version">
           <span>{{page.release_version}}</span>
         </div>
-        {% if scala_edition == "3" %}
-          <ul>
+        <ul>
+          {% if scala_edition == "3" %}
             <li><a href="https://github.com/lampepfl/dotty/releases/tag/{{page.release_version}}">Release Notes</a></li>
             <li class="dot">•</li>
             <li><a href="https://github.com/lampepfl/dotty/releases/tag/{{page.release_version}}">Changelog</a></li>
-          </ul>
-        {% else %}
-        <ul>
-          <li><a href="https://github.com/scala/scala/releases">Release Notes</a></li>
+          {% else %}
+            <li><a href="https://github.com/scala/scala/releases">Release Notes</a></li>
+            <li class="dot">•</li>
+            <li><a href="{{ site.baseurl }}/blog/announcements/">Changelog</a></li>
+          {% endif %}
+          {% if page.api_docs %}
           <li class="dot">•</li>
-          <li><a href="{{ site.baseurl }}/blog/announcements/">Changelog</a></li>
+          <li><a href="{{ page.api_docs }}">API Docs</a></li>
+          {% endif %}
         </ul>
-        {% endif %}
 
       </div>
       <div class="main-download">


### PR DESCRIPTION
I've added API docs link to the "ribbon" of a release if there is a known API docs for it.

![Screenshot 2022-03-14 at 15 01 09](https://user-images.githubusercontent.com/13436592/158187797-73383169-c22e-4c41-9b64-23d2c0b309c9.png)

open questions:
- will old API docs get deleted eventually, making dead links (I guess a CI check may fail here)
- is the ribbon appropriate, alternatively we could have a section in the main body to link also the compiler and reflect APIs