### PR TITLE
Rebrand the top links, add Scastie

### DIFF
--- a/_data/nav-header.yml
+++ b/_data/nav-header.yml
@@ -1,10 +1,12 @@
-- title: Documentation
+- title: Learn
   url: https://docs.scala-lang.org
-- title: Download
+- title: Install
   url: /download/
+- title: Playground
+  url: https://scastie.scala-lang.org
+- title: Find a Library
+  url: https://index.scala-lang.org
 - title: Community
   url: /community/
-- title: Libraries
-  url: https://index.scala-lang.org
 - title: Blog
   url: /blog/

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -20,7 +20,7 @@
   <div class="wrap">
     <div class="inner-box download">
       <div class="main-download">
-        <h2>Download or Upgrade Scala</h2>
+        <h2>Install or Upgrade Scala</h2>
         <div class="install-steps">
           <div class="download-options">
             <div class="download-left">
@@ -44,8 +44,8 @@
                 <img src="/resources/img/download/arrow-right.png" alt="">
                 <p>Best if you have an advanced use case.</p>
               </div>
-              <a href="{{ site.baseurl }}/download/all.html" class="btn-plain-download">
-                <i class="fa fa-download"></i>
+              <a href="{{ site.baseurl }}/download/all.html" class="btn-download dl-find-all">
+                <i class="fa fa-list-ul"></i>
                 <span>Pick a Specific Release</span>
               </a>
               <ul>

--- a/_sass/layout/download.scss
+++ b/_sass/layout/download.scss
@@ -163,16 +163,6 @@
         margin-top: 38px;
     }
 
-    .btn-plain-download {
-        background: $gray-lighter;
-        display: block;
-        text-align: center;
-        text-transform: uppercase;
-        padding: 16px 0;
-        border-radius: 100px;
-        margin-bottom: 34px;
-    }
-
     .btn-download {
         background: $brand-primary;
         display: block;
@@ -204,6 +194,18 @@
         &:hover {
             text-decoration: none;
             background: darken($brand-tertiary-dotty, 10%);
+        }
+    }
+
+    .btn-download.dl-find-all {
+        background: $gray-lighter;
+        font-weight: 500;
+        color: $std-link;
+        &:active,
+        &:focus,
+        &:hover {
+            text-decoration: none;
+            background: darken($gray-lighter, 10%);
         }
     }
 

--- a/_sass/utils/_variables.scss
+++ b/_sass/utils/_variables.scss
@@ -17,7 +17,7 @@ $gray-li: #244E58;
 $gray-light: #E5EAEA;
 $gray-lighter: #F0F3F3;
 $apple-blue: #6dccf5;
-
+$std-link: #23aad1;
 
 //-------------------------------------------------
 $headings-font-color: $gray-dark;

--- a/download/index.md
+++ b/download/index.md
@@ -1,7 +1,8 @@
 ---
 layout: download
-title: Download
+title: Install
 redirect_from:
+  - /install/
   - /download/scala2.html
   - /download/scala3.html
 


### PR DESCRIPTION
Added new link:
- `Playground` (Scastie)

Renamed links (no change to url):
- `Documentation` => `Learn` 
- `Download` => `Install`
- `Libraries` => `Find A Library`

home page:
<img width="1227" alt="Screenshot 2022-03-31 at 11 11 41" src="https://user-images.githubusercontent.com/13436592/161020426-76ed5295-b3eb-49c0-9946-c6e2ce828b70.png">

Install page (still `/download` with redirect from `/install`):
<img width="1227" alt="Screenshot 2022-03-31 at 11 12 03" src="https://user-images.githubusercontent.com/13436592/161020502-d0eaa8a6-05c7-4b6e-a272-884e4ef5fec4.png">

