### PR TITLE
Add default HTML-Proofer Typhoeus configuration to the CI command line

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: Proofing (all links)
         if: github.event_name != 'pull_request'
         run: |
-          bundle exec htmlproofer ./_site/ --external_only --only-4xx --http-status-ignore "400,401,429" --empty-alt-ignore --allow-hash-href --url-ignore "/trends.google.com/,/pgp.mit.edu/,/www.oracle.com/,/scalafiddle.io/" --typhoeus-config='{"headers":{"Accept-Encoding":"gzip, deflate"}}'
+          bundle exec htmlproofer ./_site/ --external_only --only-4xx --http-status-ignore "400,401,429" --empty-alt-ignore --allow-hash-href --url-ignore "/trends.google.com/,/pgp.mit.edu/,/www.oracle.com/,/scalafiddle.io/" --typhoeus-config='{"headers":{"Accept-Encoding":"gzip, deflate", "Accept":"application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5", "User-Agent":"Mozilla/5.0 (compatible; HTML Proofer/#{HTMLProofer::VERSION}; +https://github.com/gjtorikian/html-proofer)"}, "followlocation":"true", "connecttimeout":"10", "timeout":"30"}'


### PR DESCRIPTION
Apparently when specifying `--typhoeus-config` on the command line, all the defaults are discarded, and must be re-specified if desired.

The default values were taken from:
https://github.com/gjtorikian/html-proofer/blob/1bab3a1a18e95a10378371ddf000df9bea01740e/lib/html-proofer/configuration.rb#L36-L44

This should hopefully fix the rash of 403s since #1376 and #1378 were merged.