### PR TITLE
podcasts: add Tooling Talks, remove Scala Love

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -135,7 +135,7 @@ Community:
 
 * [Scala Times](https://scalatimes.com) weekly Scala newspaper
 * [#ThisWeekInScala](https://medium.com/disney-streaming/tagged/thisweekinscala) weekly Scala newspaper
-* [Scala Love](https://scala.love/) Podcast about the Scala programming language and its community
+* [Tooling Talks](https://www.tooling-talks.com) A series of talks about Scala and tooling.
 * [The Scala Logs](https://twitter.com/thescalalogs) Podcast with interviews with developers, open source contributors, subject matter experts, and the like
 
 Many Scala users are active on Twitter for sharing Scala-related news


### PR DESCRIPTION
Scala Love hasn't done an episode since 2020

I considered also removing The Scala Logs since it's been about a year since the last episode, but maybe a year isn't so long