### PR TITLE
Update link for Scala Native, remove beta flag

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,8 +37,7 @@ scalaBackends:
     link: https://www.scala-js.org/
   - icon: /resources/img/frontpage/llvm-logo.png
     description: natively with LLVM
-    link: https://scala-native.readthedocs.io/
-    beta: 1
+    link: https://scala-native.org/
 
 # Scala IDEs
 scalaIDEs:


### PR DESCRIPTION
The link is straightforward, whether it's "beta" or not is subject to definition and opinion :)