### PR TITLE
add versions back to front page

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -36,7 +36,16 @@
         <div class="inner-text">
           <h1>{{page.headerTitle}}</h1>
           <p>{{page.headerSubtitle}}</p>
-          <a href="{{page.headerButtonUrl}}" class="button">{{page.headerButtonTitle | upcase}}</a>
+          {% for release in site.data.scala-releases %}
+          {% if release.category == "current_version" %}
+          <a href="/download/{{ release.version }}.html" class="button">
+           Scala {{ release.version }}
+          </a>
+          {% endif %}
+          {% endfor %}
+          <a href="/download/all.html" class="button">
+            All Releases
+          </a>
         </div>
         <div id="position-marker" class="marker">
           <div class="info-marker">

--- a/_sass/components/buttons.scss
+++ b/_sass/components/buttons.scss
@@ -3,7 +3,7 @@
 //------------------------------------------------
 .button {
     padding: 8px 18px;
-    font-size: $font-size-small;
+    font-size: $font-size-large;
     font-weight: $font-bold;
     text-transform: uppercase;
     color: #fff;

--- a/_sass/layout/scala-main-resources.scss
+++ b/_sass/layout/scala-main-resources.scss
@@ -99,7 +99,7 @@
 
         .get-started {
             .sublinks {
-                max-width: 180px;
+                max-width: 220px;
             }
         }
 

--- a/index.md
+++ b/index.md
@@ -11,11 +11,11 @@ headerButtonUrl: "/what-is-scala/"
 gettingStarted:
   mainTitle: "Get Started"
   mainUrl: "https://docs.scala-lang.org/getting-started.html"
-  subtitle: "All Releases"
-  subtitleLink: "/download/all.html"
+  subtitle: "API Docs"
+  subtitleLink: "https://docs.scala-lang.org/api/all.html"
   links:
-    - title: "API Docs"
-      url: "https://docs.scala-lang.org/api/all.html"
+    - title: "Migrate to Scala 3"
+      url: "https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html"
 apiDocs:
   mainTitle: "Learn Scala"
   mainUrl: "https://docs.scala-lang.org"


### PR DESCRIPTION
I replaced the redundant "learn more" button with three buttons of current versions and all versions

![Screenshot 2022-11-10 at 11 53 22](https://user-images.githubusercontent.com/13436592/201072545-e4edf07b-b77b-47c9-a02d-875c493bb3cb.png)
