### PR TITLE
docs: add a description to the previous post

### DIFF
--- a/blog/_posts/2022-12-14-scala-developer-survey-results-2022.md
+++ b/blog/_posts/2022-12-14-scala-developer-survey-results-2022.md
@@ -3,6 +3,7 @@ layout: blog-detail
 post-type: blog
 by: Scala Center team
 title: Scala Developer Survey 2022 Results
+description: A glance at the results of the 2022 Scala Developer Survey. We'll dive into how we collected the data, briefly look at some takeaways, and share some interesting statistics.
 ---
 
 The Scala Developer Survey 2022 was launched in October, and in ten days it attracted over 2200 responses. Today we are pleased to share the results with you.


### PR DESCRIPTION
The main reason for this is SEO which will add a meta description tags. This will also help the display preview at times. For example currently when you see the preview for this you just see:'

<img width="591" alt="Screenshot 2022-12-14 at 17 06 19" src="https://user-images.githubusercontent.com/13974112/207646876-8f202900-4b79-4828-ad98-67df4fb97dbb.png">

I think having that empty space contain a description would be nice. I wasn't able to verify this locally as I couldn't build the site.

An aside, as a rule of thumb, we should also try to include a `description` for the blog posts.