### PR TITLE
change "Get Started" button text

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ headerButtonUrl: "/what-is-scala/"
 
 # Links of the Download / API Docs sections
 gettingStarted:
-  mainTitle: "Get Started"
+  mainTitle: "Setup Scala"
   mainUrl: "https://docs.scala-lang.org/getting-started.html"
   subtitle: "API Docs"
   subtitleLink: "https://docs.scala-lang.org/api/all.html"


### PR DESCRIPTION
Change to "Setup Scala"

people seem to be confused at the choice of "Get Started" and "Learn Scala", here's one option to try:

![Screenshot 2022-12-20 at 12 58 12](https://user-images.githubusercontent.com/13436592/208661965-3d66187f-8d23-43c5-a72a-89f43a259ca6.png)

the other option could be to change the text of "Learn Scala" to something else