### PR TITLE
Add carousel of code snippets to front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,8 @@ defaults:
 collections:
   install_tabs:
     output: false
+  scala_carousel_items:
+    output: false
   scala_items:
     output: false
   online_courses:

--- a/_includes/code-carousel.html
+++ b/_includes/code-carousel.html
@@ -1,7 +1,11 @@
 {% assign firstOption = true %}
 {% assign darkClassOpt = '' %}
+{% assign compactClassOpt = '' %}
 {% if page.darkmodeCode %}
   {% assign darkClassOpt = 'dark' %}
+{% endif %}
+{% if include.compact %}
+  {% assign compactClassOpt = 'compact' %}
 {% endif %}
 <div id="{{include.id}}" class="code-carousel">
   {% assign totalSize = 0 %}
@@ -22,9 +26,9 @@
   <div class="content-area">
     {% for example in include.collection %}
     <section id="{{example.optionId}}_content">
-      <div class="code-element {{darkClassOpt}}">
+      <div class="code-element {{darkClassOpt}} {{compactClassOpt}}">
         <div class="bar-code"><span>{{example.codeTitle}}</span></div>
-        <div class="code-background {{darkClassOpt}} code-snippet-buttons">
+        <div class=" {{darkClassOpt}} code-snippet-buttons {{compactClassOpt}}">
           <button class="code-snippet-button">
             <a href="{{ example.scastieLink }}" target="_blank">
               Run in playground <i class="fa-solid fa-play"></i>

--- a/_includes/code-carousel.html
+++ b/_includes/code-carousel.html
@@ -1,0 +1,68 @@
+{% assign firstOption = true %}
+{% assign darkClassOpt = '' %}
+{% if page.darkmodeCode %}
+  {% assign darkClassOpt = 'dark' %}
+{% endif %}
+<div id="{{include.id}}" class="code-carousel">
+  {% assign totalSize = 0 %}
+  {% for example in include.collection %}
+  <input
+    type="radio"
+    name="{{include.id}}_tabs"
+    id="{{example.optionId}}_description"
+    data-target="{{example.optionId}}"
+    class="code-carousel_control"
+    hidden
+    aria-hidden="true"
+    {% if firstOption %}checked{% endif %}
+  >
+  {% assign firstOption = false %}
+  {% assign totalSize = totalSize | plus: 1 %}
+  {% endfor %}
+  <div class="content-area">
+    {% for example in include.collection %}
+    <section id="{{example.optionId}}_content">
+      <div class="code-element {{darkClassOpt}}">
+        <div class="bar-code"><span>{{example.codeTitle}}</span></div>
+        <div class="code-background {{darkClassOpt}} code-snippet-buttons">
+          <button class="code-snippet-button">
+            <a href="{{ example.scastieLink }}" target="_blank">
+              Run in playground <i class="fa-solid fa-play"></i>
+            </a>
+          </button>
+        </div>
+        <div class="code-snippet-area">
+          <div class="progress-label code-background {{darkClassOpt}}">
+            {{forloop.index}}<span class="progress-out-of"> /{{totalSize}}</span>
+          </div>
+          {% if forloop.first %}
+            {% assign previousIdx = include.collection.length | minus: 1 %}
+          {% else %}
+            {% assign previousIdx = forloop.index0 | minus: 1 %}
+          {% endif %}
+          {% if forloop.last %}
+            {% assign nextIdx = 0 %}
+          {% else %}
+            {% assign nextIdx = forloop.index %}
+          {% endif %}
+          <div class="arrow-switcher arrow-switcher_left {{darkClassOpt}}">
+            <label for="{{include.collection[previousIdx].optionId}}_description">
+              <i class="fa-solid fa-chevron-left"></i>
+            </label>
+          </div>
+          <div class="arrow-switcher arrow-switcher_right {{darkClassOpt}}">
+            <label for="{{include.collection[nextIdx].optionId}}_description">
+              <i class="fa-solid fa-chevron-right"></i>
+            </label>
+          </div>
+          <div class="code-background {{darkClassOpt}}">
+            <!-- the code snippet should be a raw markdown code block -->
+            {{example.content}}
+          </div>
+        </div>
+      </div>
+      <p>{{example.description}}</p>
+    </section>
+    {% endfor %}
+  </div>
+</div>

--- a/_includes/code-snippet.html
+++ b/_includes/code-snippet.html
@@ -1,7 +1,7 @@
 <div class="code-snippet-area">
   {% unless include.nocopy %}
   <div class="code-snippet-buttons">
-    <button class="copy-button"><i class="fa fa-clone"></i></button>
+    <button class="code-snippet-button copy-button"><i class="far fa-clone"></i></button>
   </div>
   {% endunless %}
   <pre class="code-snippet-display"><code class="{{include.language}}">{{include.codeSnippet}}</code></pre>

--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -19,7 +19,7 @@
     <meta name="twitter:creator" content="@scala_lang"/>
     {% if page.url %}
     <meta property="og:url" content="{{ site.url }}{{ page.url }}"/>
-    {% endif %}    
+    {% endif %}
     <meta property="og:image" content="{{ site.url }}/resources/img/scala-spiral-3d-2-toned-down.png"/>
 
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -34,7 +34,9 @@
     <meta name="msapplication-TileColor" content="#15a9ce">
     <meta name="theme-color" content="#ffffff">
 
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
+      integrity="sha512-1sCRPdkRXhBV2PBLUdRb4tMg1w2YPf37qatUFeS7zlBy7jJI8Lf4VHwWfZZfpXtYSLy85pkm9GaYVYMfw5BC1A=="
+      crossorigin="anonymous" referrerpolicy="no-referrer">
 
     <!-- Custom stylesheet -->
     <link href="{{ site.baseurl }}/resources/css/unslider-dots.css" rel="stylesheet" type="text/css">

--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -41,7 +41,11 @@
     <!-- Custom stylesheet -->
     <link href="{{ site.baseurl }}/resources/css/unslider-dots.css" rel="stylesheet" type="text/css">
     <link href="{{ site.baseurl }}/resources/css/unslider.css" rel="stylesheet" type="text/css">
+    {% if page.darkmodeCode %}
+    <link rel="stylesheet" href="{{ site.baseurl }}/resources/css/highlightjs-dark.css" type="text/css" />
+    {% else %}
     <link rel="stylesheet" href="{{ site.baseurl }}/resources/css/highlightjs.css" type="text/css" />
+    {% endif %}
     <link rel="stylesheet" href="{{ site.baseurl }}/resources/css/style.css" type="text/css" />
     <link rel="stylesheet" href="{{ site.baseurl }}/resources/css/vendor/codemirror.css" type="text/css" />
     <link rel="stylesheet" href="{{ site.baseurl }}/resources/css/vendor/monokai.css" type="text/css" />

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -52,7 +52,7 @@
           </div>
         </div>
         <div class="col-lg-6">
-          {% include code-carousel.html id='scala-main-carousel' collection=site.scala_carousel_items %}
+          {% include code-carousel.html id='scala-main-carousel' collection=site.scala_carousel_items compact=true %}
         </div>
       </div>
     </div>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -32,28 +32,27 @@
             {% endfor %}
           </ul>
         </nav>
+      </div>
+      <div class="wrap">
         <!-- Inner Text -->
-        <div class="inner-text">
-          <h1>{{page.headerTitle}}</h1>
-          <p>{{page.headerSubtitle}}</p>
-          {% for release in site.data.scala-releases %}
-          {% if release.category == "current_version" %}
-          <a href="/download/{{ release.version }}.html" class="button">
-           Scala {{ release.version }}
-          </a>
-          {% endif %}
-          {% endfor %}
-          <a href="/download/all.html" class="button">
-            All Releases
-          </a>
-        </div>
-        <div id="position-marker" class="marker">
-          <div class="info-marker">
-              <span class="arrow">
-              <img src="/resources/img/frontpage/arrow.png" alt="pushpin">
-              </span>
-            {{site.data.common.texts.frontpageMarker}}
+        <div class="col-lg-6">
+          <div class="inner-text">
+            <h1>{{page.headerTitle}}</h1>
+            <p>{{page.headerSubtitle}}</p>
+            {% for release in site.data.scala-releases %}
+            {% if release.category == "current_version" %}
+            <a href="/download/{{ release.version }}.html" class="button">
+              Scala {{ release.version }}
+            </a>
+            {% endif %}
+            {% endfor %}
+            <a href="/download/all.html" class="button">
+              All Releases
+            </a>
           </div>
+        </div>
+        <div class="col-lg-6">
+          {% include code-carousel.html id='scala-main-carousel' collection=site.scala_carousel_items %}
         </div>
       </div>
     </div>

--- a/_sass/components/alt-details.scss
+++ b/_sass/components/alt-details.scss
@@ -30,7 +30,7 @@
         &:after {
             // show a right arrow at the end of the toggle element
             content: "\f138"; // <i class="fa-solid fa-circle-chevron-right"></i>
-            font-family: "FontAwesome";
+            font-family: "Font Awesome 6 Free";
             font-weight: 900;
             font-size: 15px;
             float: right;

--- a/_sass/components/code.scss
+++ b/_sass/components/code.scss
@@ -7,7 +7,7 @@
 }
 
 .code-background.dark {
-    background: #22272e;
+    background: $code-bg-color-dark;
 }
 
 .code-carousel {
@@ -71,12 +71,25 @@
 
         pre {
             margin: 0;
-            padding: 0 25px 10px 25px; // looks better with no JS
+            padding: 30px 25px 10px 25px;
 
             code {
                 padding: 0;
             }
         }
+
+        &.compact {
+            pre {
+                padding: 10px 25px; // no top padding, buttons appear inline
+            }
+            @include bp(small) {
+                // restore non compact padding on small screens
+                pre {
+                    padding: 30px 25px 10px 25px;
+                }
+            }
+        }
+
 
     }
 
@@ -146,6 +159,13 @@
 
 .code-element {
     margin-bottom: 20px;
+    position: relative;
+
+    .code-snippet-buttons {
+        position: absolute;
+        z-index: 60;
+        right: 0px;
+    }
 
     pre {
         margin-top: 0;
@@ -200,7 +220,7 @@
     color: $gray-darker;
     cursor: pointer;
     margin: 4px;
-    padding: 5px;
+    padding: 3px 5px;
 
     a {
         color: $gray-darker;
@@ -212,10 +232,15 @@
     }
 }
 
-.code-background.dark {
+.code-snippet-buttons.dark {
+
     .code-snippet-button {
-        background: #22272e;
+        background: $code-bg-color-dark;
         color: #fff;
+
+        &:hover {
+            background: $code-bg-color-dark-highlight;
+        }
 
         a {
             color: #fff;

--- a/_sass/components/code.scss
+++ b/_sass/components/code.scss
@@ -72,7 +72,6 @@
         pre {
             margin: 0;
             padding: 0 25px 10px 25px; // looks better with no JS
-            height: 270px; // consistent height for all code blocks
 
             code {
                 padding: 0;

--- a/_sass/components/code.scss
+++ b/_sass/components/code.scss
@@ -1,6 +1,150 @@
 // CODE
 //------------------------------------------------
 //------------------------------------------------
+
+.code-background {
+    background: #fdfdf7;
+}
+
+.code-background.dark {
+    background: #22272e;
+}
+
+.code-carousel {
+
+    .code-carousel_control {
+        display: none;
+    }
+
+    .progress-label {
+        position: absolute;
+        bottom: 5px;
+        right: 5px;
+        color: #222;
+
+        z-index: 40;
+
+        padding-left: 3px;
+
+        .progress-out-of {
+            color: #666;
+            font-size: $font-size-xsmall;
+        }
+
+        font-size: $font-size-small;
+    }
+
+    .progress-label.dark {
+        color: #fff;
+
+        .progress-out-of {
+            color: #aaa;
+        }
+    }
+
+    .content-area {
+        width: 100%;
+
+        section {
+            position: absolute;
+            top: -999em;
+            left: -999em;
+
+            pre {
+                opacity: 0;
+            }
+
+            transition: 400ms;
+        }
+
+        p {
+            text-align: center;
+            font-size: $font-size-small;
+            color: $base-font-color-inverse;
+        }
+    }
+
+
+    .code-element {
+        margin: 0 0 5px 0;
+        font-size: $font-size-medium;
+
+        pre {
+            margin: 0;
+            padding: 0 25px 10px 25px; // looks better with no JS
+            height: 270px; // consistent height for all code blocks
+
+            code {
+                padding: 0;
+            }
+        }
+
+    }
+
+    .arrow-switcher {
+        position: absolute; // so we can position the buttons
+        color: #444;
+        font-size: $font-size-carousel-arrow;
+        height: 100%;
+
+        z-index: 50;
+
+        label {
+            @include display(flex);
+            @include flex-direction(column);
+            @include justify-content(center);
+            height: 100%;
+            cursor: pointer;
+
+            &:hover {
+                background: rgba(#666, 0.3);
+            }
+        }
+    }
+
+    .arrow-switcher.dark {
+        color: #fff;
+
+        label {
+            &:hover {
+                background: rgba(#fff, 0.3);
+            }
+        }
+    }
+
+    .arrow-switcher_right {
+        right: 0px;
+
+        label {
+            padding: 5px 5px 5px 25px;
+        }
+    }
+
+    .arrow-switcher_left {
+        left: 0px;
+
+        label {
+            padding: 5px 25px 5px 5px;
+        }
+    }
+
+    input:checked:nth-child(1)~.content-area>section:nth-child(1),
+    input:checked:nth-child(2)~.content-area>section:nth-child(2),
+    input:checked:nth-child(3)~.content-area>section:nth-child(3),
+    input:checked:nth-child(4)~.content-area>section:nth-child(4),
+    input:checked:nth-child(5)~.content-area>section:nth-child(5),
+    input:checked:nth-child(6)~.content-area>section:nth-child(6),
+    input:checked:nth-child(7)~.content-area>section:nth-child(7),
+    input:checked:nth-child(8)~.content-area>section:nth-child(8),
+    input:checked:nth-child(9)~.content-area>section:nth-child(9) {
+        position: static;
+        pre {
+            opacity: 1;
+        }
+    }
+
+}
+
 .code-element {
     margin-bottom: 20px;
 
@@ -9,18 +153,79 @@
     }
 
     code {
-        padding: 20px;
+        // style that would be injected by hljs when JS is enabled
+        display: block;
+        font-family: 'Consolas';
+        border: none;
+        display: block;
+        overflow-x: auto;
+        padding: 0.5em;
     }
 
     .bar-code {
         background: #B4BBBD;
         text-align: center;
         padding: 2px 0;
-        font-size: $font-size-small;
+        font-size: $font-size-medium;
         font-weight: $font-bold;
         min-height: 26px;
         @include border-radius($border-radius-base $border-radius-base 0 0);
 
+    }
+}
+
+.code-element.dark {
+    code {
+        color: #adbac7;
+    }
+
+    .bar-code {
+        background: #404a4e;
+        color: #ccc;
+    }
+}
+
+.code-snippet-buttons {
+    @include display(flex);
+    @include flex-direction(row);
+    @include flex-wrap(wrap);
+    @include justify-content(flex-end);
+}
+
+.code-snippet-button {
+    // style shared by _includes/code-snippet.html and _includes/code-carousel.html
+    border: $base-border-gray;
+    background: #fff;
+    border-radius: 3px;
+    font-size: $font-size-small;
+    color: $gray-darker;
+    cursor: pointer;
+    margin: 4px;
+    padding: 5px;
+
+    a {
+        color: $gray-darker;
+
+        &:hover {
+            color: $gray-darker;
+            text-decoration: none;
+        }
+    }
+}
+
+.code-background.dark {
+    .code-snippet-button {
+        background: #22272e;
+        color: #fff;
+
+        a {
+            color: #fff;
+
+            &:hover {
+                color: #fff;
+                text-decoration: none;
+            }
+        }
     }
 }
 
@@ -45,13 +250,5 @@
         position: absolute; // so we can position the buttons
         right: 3px;
         top: 5px;
-
-        button {
-            border: none;
-            background: #fff;
-            font-size: $font-size-medium;
-            color: $gray-darker;
-            cursor: pointer;
-        }
     }
 }

--- a/_sass/layout/header.scss
+++ b/_sass/layout/header.scss
@@ -7,7 +7,7 @@
     background: $gray-darker;
 
     .new-on-the-blog {
-      background: rgba($gray-darker, 0.8);
+      background: rgba($banner-notice-bg, 0.8);
       text-align: center;
       padding: 8px 0;
       color: #fff;
@@ -44,7 +44,7 @@
     &.header-home {
         background: none;
         .header-background {
-            background: linear-gradient($brand-secondary, 40%, $gray-darker);
+            background: $header-bg;
             position: relative;
             padding-bottom: 120px;
         }

--- a/_sass/layout/header.scss
+++ b/_sass/layout/header.scss
@@ -44,20 +44,20 @@
     &.header-home {
         background: none;
         .header-background {
-            background: rgba($gray-darker, 0.45);
+            background: linear-gradient($brand-secondary, 40%, $gray-darker);
             position: relative;
-            padding-bottom: 150px;
+            padding-bottom: 120px;
 
-            &:before {
-                content: "";
-                position: absolute;
-                background: url("../img/frontpage/background-header-home.jpg") no-repeat center center;
-                @include image-size();
-                left: 0;
-                width: 100%;
-                height: 100%;
-                z-index: -1;
-            }
+            // &:before {
+            //     content: "";
+            //     position: absolute;
+            //     background: url("../img/frontpage/background-header-home.jpg") no-repeat center center;
+            //     @include image-size();
+            //     left: 0;
+            //     width: 100%;
+            //     height: 100%;
+            //     z-index: -1;
+            // }
         }
     }
 }

--- a/_sass/layout/header.scss
+++ b/_sass/layout/header.scss
@@ -47,17 +47,6 @@
             background: linear-gradient($brand-secondary, 40%, $gray-darker);
             position: relative;
             padding-bottom: 120px;
-
-            // &:before {
-            //     content: "";
-            //     position: absolute;
-            //     background: url("../img/frontpage/background-header-home.jpg") no-repeat center center;
-            //     @include image-size();
-            //     left: 0;
-            //     width: 100%;
-            //     height: 100%;
-            //     z-index: -1;
-            // }
         }
     }
 }

--- a/_sass/layout/inner-text.scss
+++ b/_sass/layout/inner-text.scss
@@ -1,15 +1,23 @@
 // INNER TEXT
 //------------------------------------------------
 //------------------------------------------------
-.inner-text {
-    position: relative;
 
+.col-lg-6 {
+    @include span-columns(6);
+
+    @include bp(large) {
+        @include span-columns(12);
+        padding-bottom: 8px;
+    }
+}
+
+.inner-text {
     h1 {
         font-family: $base-font-family;
-        font-size: 2.813rem;
+        font-size: min(2.85vw, 2.21rem);
         font-weight: $font-black;
         color: #fff;
-        margin: $padding-medium 0 ($padding-medium / 2) 0;
+        margin: $padding-small 20px $padding-small 0;
     }
 
     p {
@@ -18,17 +26,14 @@
         margin-bottom: $padding-medium;
     }
 
-    @include span-columns(8);
     @include bp(large) {
-        @include span-columns(12);
-
         .button {
             margin-bottom: 3px;
         }
 
         h1 {
-            font-size: 2.213rem;
-            margin: 0 0 ($padding-medium / 2) 0;
+            font-size: 2.5rem;
+            margin: ($padding-medium / 2) 0;
         }
     }
 }

--- a/_sass/layout/nutshell.scss
+++ b/_sass/layout/nutshell.scss
@@ -3,12 +3,12 @@
 //------------------------------------------------
 
 .nutshell {
-    background: $gray;
+    background: $gray-nutshell;
 
     .heading-line {
         h2 {
             span {
-                background: $gray;
+                background: $gray-nutshell;
             }
         }
         .call-to-action.action-medium {

--- a/_sass/layout/scala-main-resources.scss
+++ b/_sass/layout/scala-main-resources.scss
@@ -4,7 +4,7 @@
 
 .scala-main-resources {
     height: 105px;
-    background: $gray-darker;
+    background: $banner-bg;
     position: relative;
 
     .resources {
@@ -82,9 +82,11 @@
                     margin-right: 7px;
                     font-weight: $font-bold;
 
+                    color: rgba(#fff, 0.90);
+
                     a {
-                        color: rgba(#fff, 0.90);
                         font-size: $font-size-medium;
+                        color: rgba(#fff, 0.90);
 
                         &:active,
                         &:focus,
@@ -122,7 +124,7 @@
             @include justify-content(center);
 
             .circle-solid {
-                background: $gray-darker;
+                background: $gray-darkest;
                 width: 185px;
                 height: 185px;
                 border-radius: 100%;

--- a/_sass/layout/scala-main-resources.scss
+++ b/_sass/layout/scala-main-resources.scss
@@ -3,7 +3,7 @@
 //------------------------------------------------
 
 .scala-main-resources {
-    height: 100px;
+    height: 105px;
     background: $gray-darker;
     position: relative;
 
@@ -110,11 +110,11 @@
         }
 
         .scala-brand-circle {
-            width: 280px;
-            height: 280px;
+            width: 190px;
+            height: 190px;
             left: 50%;
-            top: -142px;
-            margin-left: -140px;
+            top: -97px;
+            margin-left: -96px;
             position: absolute;
             z-index: 60;
             @include display(flex);
@@ -123,15 +123,15 @@
 
             .circle-solid {
                 background: $gray-darker;
-                width: 205px;
-                height: 205px;
+                width: 185px;
+                height: 185px;
                 border-radius: 100%;
                 text-align: center;
 
                 > img {
-                    width: 152px;
+                    width: 120px;
                     height: auto;
-                    margin-top: -36px;
+                    margin-top: -15px;
                 }
 
                 .scala-version {

--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -164,7 +164,6 @@
             overflow-x: auto;
             display: block;
             font-size: $font-size-medium;
-            @include border-radius($border-radius-base);
             padding: 10px 7px;
         }
     }

--- a/_sass/utils/_variables.scss
+++ b/_sass/utils/_variables.scss
@@ -40,7 +40,8 @@ $heading-font-family: 'Roboto Slab', serif;
 $em-base: 16px !global;
 $base-font-size: $em-base;
 //------------------------------------------------
-$font-size-logo-btn: 1.4rem; // 17px
+$font-size-carousel-arrow: 1.8rem;
+$font-size-logo-btn: 1.4rem;
 $font-size-large: 1.063rem; // 17px
 $font-size-medium: 0.9375rem; // 15px
 $font-size-small: 0.875rem; // 14px

--- a/_sass/utils/_variables.scss
+++ b/_sass/utils/_variables.scss
@@ -10,15 +10,22 @@ $brand-tertiary: #5CC6E4;
 $brand-tertiary-dotty: #E45C77;
 
 //-------------------------------------------------
+$gray-darkest: #002B36;
 $gray-darker: #002B36;
 $gray-dark: #073642;
 $gray: #15414C;
+$gray-nutshell: $gray;
 $gray-li: #244E58;
 $gray-light: #E5EAEA;
 $gray-lighter: #F0F3F3;
 $apple-blue: #6dccf5;
 $std-link: #23aad1;
 $gray-heading: rgb(134, 161, 166);
+
+// $header-bg: #266270;
+$header-bg: #22525e;
+$banner-notice-bg: $gray-darkest;
+$banner-bg: #0c3540;
 
 //-------------------------------------------------
 $code-bg-color-dark: #22272e; // taken from github-dark-dimmed hljs theme

--- a/_sass/utils/_variables.scss
+++ b/_sass/utils/_variables.scss
@@ -21,6 +21,10 @@ $std-link: #23aad1;
 $gray-heading: rgb(134, 161, 166);
 
 //-------------------------------------------------
+$code-bg-color-dark: #22272e; // taken from github-dark-dimmed hljs theme
+$code-bg-color-dark-highlight: #464e5b;
+
+//-------------------------------------------------
 $headings-font-color: $gray-dark;
 $base-font-color: #4A5659;
 $base-font-color-light: #899295;

--- a/_scala_carousel_items/1-collections-ops.md
+++ b/_scala_carousel_items/1-collections-ops.md
@@ -1,0 +1,20 @@
+---
+optionId: collections-ops
+scastieLink: 'https://scastie.scala-lang.org/IRGiFXDhQPeOXYsW41FnCw'
+codeTitle: 'Functional programming with immutable collections'
+description: "High-level operations avoid the need for complex and error-prone loops."
+---
+
+```scala
+val fruits =
+  List("apple", "banana", "avocado", "papaya")
+
+val countsToFruits = // count how many 'a' in each fruit
+  fruits.groupBy(f => f.count(_ == 'a'))
+
+for (count, fruits) <- countsToFruits do
+  println(s"with 'a' × $count = $fruits")
+// prints: with 'a' × 1 = List(apple)
+// prints: with 'a' × 2 = List(avocado)
+// prints: with 'a' × 3 = List(banana, papaya)
+```

--- a/_scala_carousel_items/1-collections-ops.md
+++ b/_scala_carousel_items/1-collections-ops.md
@@ -1,6 +1,6 @@
 ---
 optionId: collections-ops
-scastieLink: 'https://scastie.scala-lang.org/IRGiFXDhQPeOXYsW41FnCw'
+scastieLink: 'https://scastie.scala-lang.org/UUmbjLZMRim4kogxDWncmw'
 codeTitle: 'Functional programming with immutable collections'
 description: "High-level operations avoid the need for complex and error-prone loops."
 ---
@@ -10,7 +10,7 @@ val fruits =
   List("apple", "banana", "avocado", "papaya")
 
 val countsToFruits = // count how many 'a' in each fruit
-  fruits.groupBy(f => f.count(_ == 'a'))
+  fruits.groupBy(fruit => fruit.count(_ == 'a'))
 
 for (count, fruits) <- countsToFruits do
   println(s"with 'a' × $count = $fruits")

--- a/_scala_carousel_items/2-json-codec.md
+++ b/_scala_carousel_items/2-json-codec.md
@@ -2,7 +2,7 @@
 optionId: json-codec
 scastieLink: 'https://scastie.scala-lang.org/WNnVCqZeR1ufyXxyqsiqag'
 codeTitle: "Encode and decode custom data types to JSON"
-description: "The pluggable derivation system quickly gives custom types new capabilities."
+description: "The pluggable derivation system gives custom types new capabilities."
 ---
 
 ```scala

--- a/_scala_carousel_items/2-json-codec.md
+++ b/_scala_carousel_items/2-json-codec.md
@@ -1,0 +1,20 @@
+---
+optionId: json-codec
+scastieLink: 'https://scastie.scala-lang.org/WNnVCqZeR1ufyXxyqsiqag'
+codeTitle: "Encode and decode custom data types to JSON"
+description: "The pluggable derivation system quickly gives custom types new capabilities."
+---
+
+```scala
+case class Pet(
+  name: String,
+  kind: String
+) derives Codec // enable coding Pet to and from text
+
+val coco = Pet(name = "Coco", kind = "Cat")
+
+val message = writeJson(coco)
+//  ^^^^^^^ contains the text: {"name":"Coco","kind":"Cat"}
+
+readJson[Pet](message) // convert message back to a Pet!
+```

--- a/_scala_carousel_items/3-js-dom.md
+++ b/_scala_carousel_items/3-js-dom.md
@@ -1,0 +1,20 @@
+---
+optionId: js-dom-api
+scastieLink: 'https://scastie.scala-lang.org/YpcEab3ySieF4BkW5jE4Gw'
+codeTitle: 'Target the Web with Scala.js on the frontend'
+description: "Share code full-stack, interact with the DOM or use any JS library."
+---
+
+```scala
+val counter = Var(0)
+
+// create a counter button that increments on-click
+def counterButton() = button(
+  tpe := "button",
+  "count is ",
+  child.text <-- counter,
+  onClick --> { event => counter.update(c => c + 1) },
+)
+val app = dom.document.getElementById("app")
+render(app, counterButton())
+```

--- a/_scala_carousel_items/4-data-definitions.md
+++ b/_scala_carousel_items/4-data-definitions.md
@@ -1,0 +1,20 @@
+---
+optionId: data-definitions
+scastieLink: 'https://scastie.scala-lang.org/2plItYkVS4enZCFwBIPnZA'
+codeTitle: 'Define data types and pattern match on them with ease'
+description: "Model domains precisely, and make choices based on the shape of data."
+---
+
+```scala
+enum Payment:
+  case Card(name: String, digits: Long, expires: Date)
+  case PayPal(email: String)
+
+def process(kind: Payment) = kind match
+  case Card(name, digits, expires) =>
+    s"Processing credit card $name, $digits, $expires"
+  case PayPal(email) =>
+    s"Processing PayPal account $email"
+
+process(Card(name, digits, expires))
+```

--- a/_scala_items/1-seamless-java-interop.md
+++ b/_scala_items/1-seamless-java-interop.md
@@ -1,11 +1,11 @@
 ---
 shortTitle: "Seamless Java Interop"
 shortDescription: "Scala runs on the JVM, so Java and Scala stacks can be freely mixed for totally seamless integration."
-scastieUrl: 
+scastieUrl:
 ---
 <div class="wrap">
   <div class="scala-code">
-    <div class="code-element">
+    <div class="code-element dark">
       <div class="bar-code"><span>Author.scala</span></div>
       <pre><code>class Author(val firstName: String,
     val lastName: String) extends Comparable[Author] {
@@ -21,7 +21,7 @@ object Author {
   def loadAuthorsFromFile(file: java.io.File): List[Author] = ???
 }</code></pre>
     </div>
-    <div class="code-element">
+    <div class="code-element dark">
       <div class="bar-code"><span>App.java</span></div>
       <pre><code>import static scala.collection.JavaConversions.asJavaCollection;
 

--- a/_scala_items/2-type-inference.md
+++ b/_scala_items/2-type-inference.md
@@ -1,11 +1,11 @@
 ---
 shortTitle: "Type Inference"
 shortDescription: "So the type system doesn’t feel so static. Don’t work for the type system. Let the type system work for you!"
-scastieUrl: 
+scastieUrl:
 ---
 <div class="wrap">
                                 <div class="scala-code">
-                                    <div class="code-element">
+                                    <div class="code-element dark">
                                         <div class="bar-code"><span>Type inference</span></div>
                                         <pre><code>scala> class Person(val name: String, val age: Int) {
      |   override def toString = s"$name ($age)"

--- a/_scala_items/3-concurrency-distribution.md
+++ b/_scala_items/3-concurrency-distribution.md
@@ -1,11 +1,11 @@
 ---
 shortTitle: "Concurrency & Distribution"
 shortDescription: "Use data-parallel operations on collections, use actors for concurrency and distribution, or futures for asynchronous programming."
-scastieUrl: 
+scastieUrl:
 ---
 <div class="wrap">
                                 <div class="scala-code">
-                                    <div class="code-element">
+                                    <div class="code-element dark">
                                         <div class="bar-code"><span>Concurrent/Distributed</span></div>
                                         <pre><code>val x = Future { someExpensiveComputation() }
 val y = Future { someOtherExpensiveComputation() }

--- a/_scala_items/4-traits.md
+++ b/_scala_items/4-traits.md
@@ -1,7 +1,7 @@
 ---
 shortTitle: "Traits"
 shortDescription: "Combine the flexibility of Java-style interfaces with the power of classes. Think principled multiple-inheritance."
-scastieUrl: 
+scastieUrl:
 ---
 {% comment %}
 Borrowed from
@@ -9,7 +9,7 @@ https://gleichmann.wordpress.com/2009/10/21/scala-in-practice-composing-traits-l
 {% endcomment %}
 <div class="wrap">
                                 <div class="scala-code">
-                                    <div class="code-element">
+                                    <div class="code-element dark">
                                         <div class="bar-code"><span>Traits</span></div>
                                         <pre><code>abstract class Spacecraft {
   def engage(): Unit

--- a/_scala_items/5-pattern-matching.md
+++ b/_scala_items/5-pattern-matching.md
@@ -20,7 +20,7 @@ deconstructs the arguments of a <code>Node</code>.
                                 </div>
 
                                 <div class="scala-code">
-                                    <div class="code-element">
+                                    <div class="code-element dark">
                                         <div class="bar-code"><span>Pattern matching</span></div>
                                         <pre><code>// Define a set of case classes for representing binary trees.
 sealed abstract class Tree

--- a/_scala_items/6-higher-order-functions.md
+++ b/_scala_items/6-higher-order-functions.md
@@ -1,7 +1,7 @@
 ---
 shortTitle: "Higher-order functions"
 shortDescription: "Functions are first-class objects. Compose them with guaranteed type safety. Use them anywhere, pass them to anything."
-scastieUrl: 
+scastieUrl:
 ---
 <div class="wrap">
               <div class="scala-text scala-text-large">
@@ -10,7 +10,7 @@ scastieUrl:
   with a concise syntax.</p>
               </div>
               <div class="scala-code">
-                <div class="code-element">
+                <div class="code-element dark">
                   <div class="bar-code"><span>Scala</span></div>
                   <pre><code>val people: Array[Person]
 
@@ -20,7 +20,7 @@ val (minors, adults) = people partition (_.age &lt; 18)</code></pre>
                 </div>
               </div>
               <div class="scala-code">
-                <div class="code-element">
+                <div class="code-element dark">
                   <div class="bar-code"><span>Java</span></div>
                   <pre><code>List&lt;Person&gt; people;
 

--- a/_scala_items/7-education.md
+++ b/_scala_items/7-education.md
@@ -28,12 +28,12 @@ shortDescription: "Scala is ideal for teaching programming to beginners as well 
 
   <div class="scala-code">
 
-    <div class="code-element">
+    <div class="code-element dark">
       <div class="bar-code"><span>HelloWorld.scala</span></div>
       <pre><code>@main def run() = println("Hello, World!")</code></pre>
     </div>
 
-    <div class="code-element">
+    <div class="code-element dark">
       <div class="bar-code"><span>Modules.scala</span></div>
       <pre><code>// A module that can access the data stored in a database
 class DatabaseAccess(connection: Connection):
@@ -51,7 +51,7 @@ class HttpServer(databaseAccess: DatabaseAccess):
 
   <div class="scala-code">
 
-    <div class="code-element">
+    <div class="code-element dark">
       <div class="bar-code"><span>Modeling.scala</span></div>
       <pre><code>/** A Player can either be a Bot, or a Human.
   * In case it is a Human, it has a name.
@@ -61,7 +61,7 @@ enum Player:
   case Human(name: String)</code></pre>
     </div>
 
-    <div class="code-element">
+    <div class="code-element dark">
       <div class="bar-code"><span>Algorithms.scala</span></div>
       <pre><code>// Average number of contacts a person has according to age
 def contactsByAge(people: Seq[Person]): Map[Int, Double] =

--- a/index.md
+++ b/index.md
@@ -1,6 +1,8 @@
 ---
 layout: frontpage
 
+darkmodeCode: true
+
 # Header texts
 headerTitle: "The Scala Programming Language"
 headerSubtitle: "Scala combines object-oriented and functional programming in one concise, high-level language. Scala's static types help avoid bugs in complex applications, and its JVM and JavaScript runtimes let you build high-performance systems with easy access to huge ecosystems of libraries."

--- a/resources/css/highlightjs-dark.css
+++ b/resources/css/highlightjs-dark.css
@@ -1,0 +1,148 @@
+/*!
+  Theme: GitHub Dark Dimmed
+  Description: Dark dimmed theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Colors taken from GitHub's CSS
+
+  BSD 3-Clause License
+
+  Copyright (c) 2006, Ivan Sagalaev.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms,
+  with or without modification,
+  are permitted provided that the following conditions are met: * Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES,
+  INCLUDING,
+  BUT NOT LIMITED TO,
+  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT,
+  INCIDENTAL,
+  SPECIAL,
+  EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT,
+  STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+.hljs {
+  color: #adbac7;
+  background: #22272e;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #f47067;
+}
+
+.hljs-title,
+.hljs-type,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #dcbdfb;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #6cb6ff;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #96d0ff;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #f69d50;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #768390;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #8ddb8c;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #adbac7;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #316dca;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #eac55f;
+}
+
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #adbac7;
+  font-style: italic;
+}
+
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #adbac7;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #b4f1b4;
+  background-color: #1b4721;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffd8d3;
+  background-color: #78191b;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -323,6 +323,40 @@ $(document).ready(function () {
   }
 });
 
+$(document).ready(function () {
+  // set up automatic switching of code carousel
+  $(".code-carousel").each(function () {
+    var carousel = this;
+    var inputs = [];
+    $(carousel).children("input.code-carousel_control").each(function () {
+      inputs.push(this);
+    });
+
+    // if there is more than one section, set up automatic switching
+    if (inputs.length > 1) {
+
+      var cancelled = false;
+
+      var index = inputs.findIndex(input => input.checked);
+
+      // switch every 8 seconds while the page is visible and not cancelled
+      const intervalHandle = setInterval(() => {
+        if (!document.hidden && !cancelled) {
+          const nextIndex = (index + 1) % inputs.length;
+          inputs[nextIndex].checked = true;
+          index = nextIndex;
+        }
+      }, 8000);
+
+      carousel.addEventListener("click", function cancelTicker() {
+        carousel.removeEventListener("click", cancelTicker);
+        cancelled = true;
+        clearInterval(intervalHandle);
+      });
+    }
+  });
+});
+
 var image = { width: 1680, height: 1100 };
 var target = { x: 1028, y: 290 };
 


### PR DESCRIPTION
The idea here is to add a carousel that is immediately visible. Each slide comes with a title, code snippet, Scastie link, and summary. it can be operated without JS on, but when JS is on then it changes slides every 8 seconds, until the user interacts with the carousel, which cancels the timer.

Also added a dark mode theme for code on the front page.

<img width="1491" alt="Screenshot 2023-01-31 at 14 00 29" src="https://user-images.githubusercontent.com/13436592/215766705-950b7122-e693-44ac-b41c-194997598702.png">

<img width="1491" alt="Screenshot 2023-01-31 at 13 59 54" src="https://user-images.githubusercontent.com/13436592/215766577-99b1441b-95dc-44d4-9cb8-c160c3ac8ab1.png">

Also tag @romanowski @Kordyjan for review