### PR TITLE
move scala-js 10 year blog post to blogs.

### DIFF
--- a/blog/_posts/2023-02-05-ten-years-of-scala-js.md
+++ b/blog/_posts/2023-02-05-ten-years-of-scala-js.md
@@ -1,8 +1,9 @@
 ---
-category: blog-detail
+layout: blog-detail
 post-type: blog
 by: Sébastien Doeraene
 title: "10 years of Scala.js"
+description: An overview and celebration of the past 10 years of Scala.js
 ---
 
 10 years ago, on February 5, 2013, we made the [first commit to Scala.js](https://github.com/scala-js/scala-js/commit/9ad7627c2418e5d345375705ca087a60e3aa2c22).


### PR DESCRIPTION
This will ensure that people using rss readers to follow our blog rss feed will see this.

### An aside

I don't fully get why we have `_posts` and `blog`. Is there some rules we have about when we should put something in one place or the other? This came about because of [this comment on reddit](https://www.reddit.com/r/scala/comments/10u89zh/comment/j7al9nz/?utm_source=share&utm_medium=web2x&context=3), and it's a good point. I feel like all the stuff in `_posts` should potentially be going in the other rss feed, [here](https://www.scala-lang.org/feed/index.xml), but isn't. I'll look into that.