### PR TITLE
feat: add in Mastodon link

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -50,6 +50,8 @@
   links:
     - title: GitHub
       url: "https://github.com/scala"
+    - title: Mastodon
+      url: https://fosstodon.org/@scala_lang
     - title: Twitter
       url: "https://twitter.com/scala_lang"
     - title: Discord

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,12 @@
           <ul class="{{item.class}}">
             <li><h3>{{item.title}}</h3></li>
             {% for link in item.links %}
-              <li><a href="{{link.url}}">{{link.title}}</a></li>
+              {% if link.title == "Mastodon" %}
+                 <!-- special case Manstodon to validate with rel="me" -->
+                <li><a rel="me" href="{{link.url}}">{{link.title}}</a></li>
+              {% else %}
+                <li><a href="{{link.url}}">{{link.title}}</a></li>
+              {% endif %}
             {% endfor %}
           </ul>
         {% endfor %}


### PR DESCRIPTION
This PR adds in a link to our Mastodon account in the footer and also
includes a `rel="me"` to _verify_ us showing that we own the domain.
This should give us a green check mark on our account.

### What the footer now looks like
<img width="205" alt="Screenshot 2023-03-14 at 10 44 53" src="https://user-images.githubusercontent.com/13974112/224961721-5c54d0c3-97b0-4b27-813e-895083aaf617.png">

### Showing the `rel="me"` is only applied to the Mastodon link
<img width="377" alt="Screenshot 2023-03-14 at 10 45 08" src="https://user-images.githubusercontent.com/13974112/224961878-5ca76d8d-40ef-4c15-8456-36ac15e247da.png">

Closes #1480 
