### PR TITLE
community page: new location for This Week in Scala

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -156,7 +156,7 @@ Official:
 Community:
 
 * [Scala Times](https://scalatimes.com) weekly Scala newspaper
-* [#ThisWeekInScala](https://medium.com/disney-streaming/tagged/thisweekinscala) weekly Scala newspaper
+* [This Week in Scala](https://petr-zapletal.medium.com) weekly Scala newspaper
 * [Scala News](https://www.scalanews.net) source for Scala news and blog feeds
 * [Tooling Talks](https://www.tooling-talks.com) A series of talks about Scala and tooling.
 * [The Scala Logs](https://twitter.com/thescalalogs) Podcast with interviews with developers, open source contributors, subject matter experts, and the like


### PR DESCRIPTION
review by @pzapletal ? I couldn't figure out a URL that is restricted to just the posts tagged thisweekinscala, but maybe it doesn't matter