### PR TITLE
fix: ensure image displays correctly on summit blog

### DIFF
--- a/blog/_posts/2023-04-11-march-2023-scala-tooling-summit.md
+++ b/blog/_posts/2023-04-11-march-2023-scala-tooling-summit.md
@@ -6,7 +6,7 @@ title: March 2023 - Scala Tooling Summit
 description: A recap of the recent Scala Tooling Summit in Lausanne, Switzerland.
 ---
 
-<img style="max-height: 350px; display: block; margin: auto;" src="{{ site.baseurl }}/resources/img/march-2023-tooling-summit-stairs.jpg" alt="Scala stairs with people standing on the stairs">
+<img style="max-height: 350px; display: block; margin: auto; width: auto;" src="{{ site.baseurl }}/resources/img/march-2023-tooling-summit-stairs.jpg" alt="Scala stairs with people standing on the stairs">
 
 Tooling is a pivotal part of the developer experience. Often when someone asks
 about a new language or how another developer enjoys working in a certain


### PR DESCRIPTION
_Current_

<img width="861" alt="Screenshot 2023-04-11 at 15 01 53" src="https://user-images.githubusercontent.com/13974112/231170475-558964a9-64e1-4b85-916e-20311c8d1bb2.png">

_With Fix_
<img width="861" alt="Screenshot 2023-04-11 at 15 02 30" src="https://user-images.githubusercontent.com/13974112/231170567-ae937436-e4c8-478f-acc6-79a161334b46.png">

