### PR TITLE
Install page - Remove Scastie references.

### DIFF
--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -33,13 +33,6 @@ For a summary of important changes, see the <a href="https://github.com/scala/sc
       <li>With <a href="https://www.macports.org/">MacPorts</a>, you can get Scala using
         <code>sudo port install scala2.x</code>command.<br /> For example to install Scala 2.12 simply
         use<code>sudo port install scala2.12</code></li>
-      <li>Use <a href="https://scastie.scala-lang.org">Scastie</a> to run single-file Scala programs in your browser using
-        multiple Scala compilers; the production Scala 2.x compilers, Scala.js, Dotty, and Typelevel Scala. Save and share
-        executable Scala code snippets.</li>
-      <li>Try Scala in the browser via <a href="https://scalafiddle.io/">ScalaFiddle</a>. This lets you run single-file
-        Scala programs in your browser using Scala.js, including graphical/interactive examples such as <a
-          href="https://scalafiddle.io/sf/KOsXSKv/0">Oscilloscope</a> or <a href="https://scalafiddle.io/sf/4beVrVc/1">Ray
-          Tracer</a></li>
       <li><a href="https://ammonite.io/">Get Ammonite</a>, a popular Scala REPL</li>
     </ul>
   </div>

--- a/_includes/downloads-scala3.html
+++ b/_includes/downloads-scala3.html
@@ -31,9 +31,6 @@ For a summary of important changes, see the <a
       <li>On macOS you can also use <a href="https://brew.sh/">Homebrew</a> and run the following commands:<br>
         <code>brew update</code><br /><code>brew install scala</code>
       </li>
-      <li>Use <a href="https://scastie.scala-lang.org/?target=scala3">Scastie</a> to run single-file Scala programs in
-        your browser using multiple Scala compilers; the production Scala 2.x compilers, Scala.js, Scala 3, and Typelevel
-        Scala. Save and share executable Scala code snippets.</li>
     </ul>
   </div>
   {% include download-resource-list.html %}


### PR DESCRIPTION
Scastie is not a way for _installing_ or downloading Scala into a local machine, as the title of the page says. There are links to Scastie directly from main page.

Regarding Scalafiddle, the link https://scalafiddle.io/  seem not to be working. If it is another playground like Scastie, should it be linked from the scala-lang page?