### PR TITLE
Main Page - Remove "community-frontpage" section.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -192,18 +192,6 @@
   </div>
 </section>
 
-<!-- Community Redirect -->
-<section class="community-frontpage">
-  <div class="wrap">
-    <div class="heading-line">
-      <h2><span>Looking for upcoming events?</span></h2>
-      <div class="call-to-action action-medium">
-        <p>Or want to chat with like-minded users? Visit the <a href="/community/">Community page</a> to learn more.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
 <!-- Supporters -->
 <section class="maintenance">
   <div class="wrap">


### PR DESCRIPTION
This section of the webpage seems redundant, as the link also appears at the top.
Fixes https://github.com/scala/scala-lang/issues/1495
