### PR TITLE
Variable name mismatch in 2023-05-30-scala-3.3.0-released.md

### DIFF
--- a/blog/_posts/2023-05-30-scala-3.3.0-released.md
+++ b/blog/_posts/2023-05-30-scala-3.3.0-released.md
@@ -81,7 +81,7 @@ Two new methods were added to the standard library: `boundary` and `break`. They
 ```Scala
 import util.boundary, boundary.break
 
-def sumOfRoots(number: List[Double]): Option[Double] = boundary:
+def sumOfRoots(numbers: List[Double]): Option[Double] = boundary:
   val roots = numbers.map: n =>
     println(s" * calculating square root for $n*")
     if n >= 0 then Math.sqrt(n) else break(None)


### PR DESCRIPTION
Fixed variable mismatch in example.

See https://scastie.scala-lang.org/PQCOjE0xTp6o1a3t2fm0cg