### PR TITLE
Scala 2.13.11

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: The Scala Programming Language
 
-scalaversion: "2.13.10"
+scalaversion: "2.13.11"
 
 url: https://www.scala-lang.org
 baseurl: ""

--- a/_data/scala-releases.yml
+++ b/_data/scala-releases.yml
@@ -4,8 +4,8 @@
   release_date: May 30, 2023
 - category: current_version
   title: Current 2.13.x release
-  version: 2.13.10
-  release_date: October 13, 2022
+  version: 2.13.11
+  release_date: June 7, 2023
 - category: maintenance_version
   title: Latest 2.12.x maintenance release
   version: 2.12.17

--- a/_downloads/2023-06-07-2.13.11.md
+++ b/_downloads/2023-06-07-2.13.11.md
@@ -1,0 +1,21 @@
+---
+title: Scala 2.13.11
+start: 07 June 2023
+layout: downloadpage
+release_version: 2.13.11
+release_date: "June 7, 2023"
+show_resources: "true"
+permalink: /download/2.13.11.html
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
+api_docs: https://www.scala-lang.org/api/2.13.11/
+resources: [
+  ["-main-unixsys", "scala-2.13.11.tgz", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.tgz", "Mac OS X, Unix, Cygwin", ""],
+  ["-main-windows", "scala-2.13.11.msi", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.msi", "Windows (msi installer)", ""],
+  ["-non-main-sys", "scala-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.zip", "Windows", ""],
+  ["-non-main-sys", "scala-2.13.11.deb", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.deb", "Debian", ""],
+  ["-non-main-sys", "scala-2.13.11.rpm", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.rpm", "RPM package", ""],
+  ["-non-main-sys", "scala-docs-2.13.11.txz", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.txz", "API docs", ""],
+  ["-non-main-sys", "scala-docs-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.zip", "API docs", ""],
+  ["-non-main-sys", "scala-sources-2.13.11.tar.gz", "https://github.com/scala/scala/archive/v2.13.11.tar.gz", "Sources", ""]
+]
+---

--- a/_downloads/2023-06-07-2.13.11.md
+++ b/_downloads/2023-06-07-2.13.11.md
@@ -17,4 +17,5 @@ resources: [
   ["-non-main-sys", "scala-docs-2.13.11.txz", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.txz", "API docs", "60.37M"],
   ["-non-main-sys", "scala-docs-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.zip", "API docs", "115.51M"],
   ["-non-main-sys", "scala-sources-2.13.11.tar.gz", "https://github.com/scala/scala/archive/v2.13.11.tar.gz", "Sources", "8.3M"]
+]
 ---

--- a/_downloads/2023-06-07-2.13.11.md
+++ b/_downloads/2023-06-07-2.13.11.md
@@ -9,13 +9,12 @@ permalink: /download/2.13.11.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.11/
 resources: [
-  ["-main-unixsys", "scala-2.13.11.tgz", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.tgz", "Mac OS X, Unix, Cygwin", ""],
-  ["-main-windows", "scala-2.13.11.msi", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.msi", "Windows (msi installer)", ""],
-  ["-non-main-sys", "scala-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.zip", "Windows", ""],
-  ["-non-main-sys", "scala-2.13.11.deb", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.deb", "Debian", ""],
-  ["-non-main-sys", "scala-2.13.11.rpm", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.rpm", "RPM package", ""],
-  ["-non-main-sys", "scala-docs-2.13.11.txz", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.txz", "API docs", ""],
-  ["-non-main-sys", "scala-docs-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.zip", "API docs", ""],
-  ["-non-main-sys", "scala-sources-2.13.11.tar.gz", "https://github.com/scala/scala/archive/v2.13.11.tar.gz", "Sources", ""]
-]
+  ["-main-unixsys", "scala-2.13.11.tgz", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.tgz", "Mac OS X, Unix, Cygwin", "22.88M"],
+  ["-main-windows", "scala-2.13.11.msi", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.msi", "Windows (msi installer)", "134.98M"],
+  ["-non-main-sys", "scala-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.zip", "Windows", "22.92M"],
+  ["-non-main-sys", "scala-2.13.11.deb", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.deb", "Debian", "657.15M"],
+  ["-non-main-sys", "scala-2.13.11.rpm", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.rpm", "RPM package", "135.21M"],
+  ["-non-main-sys", "scala-docs-2.13.11.txz", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.txz", "API docs", "60.37M"],
+  ["-non-main-sys", "scala-docs-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.zip", "API docs", "115.51M"],
+  ["-non-main-sys", "scala-sources-2.13.11.tar.gz", "https://github.com/scala/scala/archive/v2.13.11.tar.gz", "Sources", "8.3M"]
 ---

--- a/_posts/2023-06-07-release-notes-2.13.11.md
+++ b/_posts/2023-06-07-release-notes-2.13.11.md
@@ -1,0 +1,15 @@
+---
+category: announcement
+permalink: /news/2.13.11
+title: "Scala 2.13.11 is now available!"
+---
+[Scala 2.13.11](https://github.com/scala/scala/releases/tag/v2.13.11) is now available!
+
+This release
+improves collections,
+adds support for JDK 20 and 21,
+adds support for JDK 17 `sealed`,
+aids migration to Scala 3,
+and more.
+
+For details, refer to the [release notes](https://github.com/scala/scala/releases/tag/v2.13.11) on GitHub.


### PR DESCRIPTION
> This release improves collections, adds support for JDK 20 and 21, adds support for JDK 17 `sealed`, aids migration to Scala 3, and more.

reference: https://contributors.scala-lang.org/t/scala-2-13-11-release-planning/6088