### PR TITLE
Update links to Scastie in carousel view

### DIFF
--- a/_scala_carousel_items/1-collections-ops.md
+++ b/_scala_carousel_items/1-collections-ops.md
@@ -1,6 +1,6 @@
 ---
 optionId: collections-ops
-scastieLink: 'https://scastie.scala-lang.org/UUmbjLZMRim4kogxDWncmw'
+scastieLink: 'https://scastie.scala-lang.org/S0bkCiXkQiuOMXnlhWn46g'
 codeTitle: 'Functional programming with immutable collections'
 description: "High-level operations avoid the need for complex and error-prone loops."
 ---

--- a/_scala_carousel_items/2-json-codec.md
+++ b/_scala_carousel_items/2-json-codec.md
@@ -1,6 +1,6 @@
 ---
 optionId: json-codec
-scastieLink: 'https://scastie.scala-lang.org/WNnVCqZeR1ufyXxyqsiqag'
+scastieLink: 'https://scastie.scala-lang.org/jzYU3JWJTZW6731MigOqlA'
 codeTitle: "Encode and decode custom data types to JSON"
 description: "The pluggable derivation system gives custom types new capabilities."
 ---

--- a/_scala_carousel_items/3-js-dom.md
+++ b/_scala_carousel_items/3-js-dom.md
@@ -1,6 +1,6 @@
 ---
 optionId: js-dom-api
-scastieLink: 'https://scastie.scala-lang.org/YpcEab3ySieF4BkW5jE4Gw'
+scastieLink: 'https://scastie.scala-lang.org/gyNudjdITL2irc9ni0kRxA'
 codeTitle: 'Target the Web with Scala.js on the frontend'
 description: "Share code full-stack, interact with the DOM or use any JS library."
 ---

--- a/_scala_carousel_items/4-data-definitions.md
+++ b/_scala_carousel_items/4-data-definitions.md
@@ -1,6 +1,6 @@
 ---
 optionId: data-definitions
-scastieLink: 'https://scastie.scala-lang.org/2plItYkVS4enZCFwBIPnZA'
+scastieLink: 'https://scastie.scala-lang.org/VcczUlAVT8mHTl7tpGmiJg'
 codeTitle: 'Define data types and pattern match on them with ease'
 description: "Model domains precisely, and make choices based on the shape of data."
 ---


### PR DESCRIPTION
Temporary solution for:
https://github.com/scalacenter/scastie/issues/873

In the future, it would be better to replace the anonymous snippet links with ones assigned to the user, as we won't need to update links, but only the snippets (it would be the best to assign it to Scala org or something similar, but it will require few changes).