### PR TITLE
Remove extra "n" in "versioning"

### DIFF
--- a/blog/_posts/2023-06-20-toolkit.md
+++ b/blog/_posts/2023-06-20-toolkit.md
@@ -225,7 +225,7 @@ This is in part due to the fact it depends on milestone versions of sttp, and MU
 Once the Toolkit reaches its first stable version, it will be labeled as 1.0.0.
 Only stable versions of libraries will be included.
 
-### What is the versionning scheme of the Toolkit?
+### What is the versioning scheme of the Toolkit?
 
 The Scala Toolkit follows the [semantic versioning scheme](https://semver.org), provided that the underlying libraries also adhere to the semantic versioning scheme.
 


### PR DESCRIPTION
Noticed there was an extra `n` in one of the headers, tiny PR to fix that!