### PR TITLE
Don't call out Apple Silicon as needing manual installation

### DIFF
--- a/_install_tabs/1-macos.html
+++ b/_install_tabs/1-macos.html
@@ -6,7 +6,7 @@ tabLabel: macOS
   <div class="wrap">
     <p>Run the following command in your terminal, following the on-screen instructions:</p>
     {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
-    {% assign homebrewAlt = "Alternatively for Apple Silicon, or if you don't use Homebrew:" %}
+    {% assign homebrewAlt = "Alternatively, if you don't use Homebrew:" %}
     {% capture homebrewDetail %}
     <div class="wrap-narrow">
       <p>On the Apple Silicon (M1, M2, …) architecture:</p>


### PR DESCRIPTION
I have Apple Silicon and installed Scala fine for the first time via Homebrew.

See also https://github.com/scala/docs.scala-lang/pull/2889