### PR TITLE
Update Scala JP community from Gitter to Discord

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -90,7 +90,7 @@ International chat rooms are available as well:
 * **[scala/cn](https://gitter.im/scala/cn)** (Gitter)
 * **[Scala Fr](https://discord.gg/w6VUKrrZK3)** (Discord)
 * **[scala/it](https://discord.gg/8wadTgcZVt)** (Discord)
-* **[scalajp/public](https://gitter.im/scalajp/public)** (Gitter)
+* **[Scala Jp](https://discord.gg/SaXM8s4Cyr)** (Discord)
 * **[scala_ru](https://t.me/scala_ru)** (Telegram)
 * **[Scala Ukraine](https://t.me/scala_ukraine)** (Telegram)
 


### PR DESCRIPTION
The Scala JP Gitter is no longer actively used with no conversations in the past at least 6 months.
This commit updates the Japanese Scala community to the "Scala わいわいランド" ("Scala Chatterland") Discord server, which is the most active Scala community in Japan (with over 100 members and conversations almost every day).

FYI @xuwei-k noticed that the Scala community page on the scala-lang website lists Gitter as a Scala community, even though Gitter is no longer used and suggested that the page be updated :+1:
@tototoshi @windymelt