### PR TITLE
Update SDKMAN example

### DIFF
--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -26,7 +26,7 @@ For a summary of important changes, see the <a href="https://github.com/scala/sc
           href="/documentation/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.html">test it.</a>
       </li>
       <li>Using <a href="https://sdkman.io/">SDKMAN!</a>, you can easily <a href="https://sdkman.io/sdks#scala">install
-          specific versions of Scala</a> on any platform with <code>sdk install scala {{ site.scalaversion }}</code></li>
+          specific versions of Scala</a> on any platform with <code>sdk install scala {{ page.release_version }}</code></li>
       <li>On macOS you can also use <a href="https://brew.sh/">Homebrew</a> and existing <a
           href="https://formulae.brew.sh/formula/scala">Scala
           Formulae</a><br /><code>brew update</code><br /><code>brew install scala</code></li>


### PR DESCRIPTION
This makes the SDKMAN! examples consistent with the other examples.

It could be a bit surprising to have one of the snippets installing a different version.

![imagem](https://github.com/scala/scala-lang/assets/1187242/743de00a-451f-4e2c-9fd8-9cbbf148c45e)
