### PR TITLE
fix 404 reactconf link in past events page

### DIFF
--- a/_events/2014-04-07-react.md
+++ b/_events/2014-04-07-react.md
@@ -6,5 +6,5 @@ location: London
 description: "Reactive Conference"
 start: 7 April 2014
 end: 9 April 2014
-link-out: https://twitter.com/reactconf
+link-out: https://www.youtube.com/@instilco/videos
 ---

--- a/_events/2014-04-07-react.md
+++ b/_events/2014-04-07-react.md
@@ -6,5 +6,5 @@ location: London
 description: "Reactive Conference"
 start: 7 April 2014
 end: 9 April 2014
-link-out: https://reactconf.com
+link-out: https://twitter.com/reactconf
 ---


### PR DESCRIPTION
the old URL has been 404ing for a while now in our CI runs, e.g. https://github.com/scala/scala-lang/actions/runs/6700196688/job/18205723071#step:6:22

note that the old React conference is not to be confused with React.js