### PR TITLE
CI: bump action/checkout to v4 (from v3)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   build-and-validate-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0.5'


### PR DESCRIPTION
this should make a "Node.js 16 actions are deprecated" warning from GitHub go away
