### PR TITLE
Scala 2.12.19

### DIFF
--- a/_data/scala-releases.yml
+++ b/_data/scala-releases.yml
@@ -8,8 +8,8 @@
   release_date: September 11, 2023
 - category: maintenance_version
   title: Latest 2.12.x maintenance release
-  version: 2.12.18
-  release_date: June 7, 2023
+  version: 2.12.19
+  release_date: February 20, 2024
 - category: maintenance_version
   title: Last 2.11.x maintenance release
   version: 2.11.12

--- a/_downloads/2024-02-20-2.12.19.md
+++ b/_downloads/2024-02-20-2.12.19.md
@@ -1,0 +1,21 @@
+---
+title: Scala 2.12.19
+start: 20 February 2024
+layout: downloadpage
+release_version: 2.12.19
+release_date: "February 20, 2024"
+show_resources: "true"
+permalink: /download/2.12.19.html
+requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
+api_docs: https://www.scala-lang.org/api/2.12.19/
+resources: [
+  ["-main-unixsys", "scala-2.12.19.tgz", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.tgz", "Mac OS X, Unix, Cygwin", "20.08M"],
+  ["-main-windows", "scala-2.12.19.msi", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.msi", "Windows (msi installer)", "126.70M"],
+  ["-non-main-sys", "scala-2.12.19.zip", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.zip", "Windows", "20.12M"],
+  ["-non-main-sys", "scala-2.12.19.deb", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.deb", "Debian", "147.69M"],
+  ["-non-main-sys", "scala-2.12.19.rpm", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.rpm", "RPM package", "126.95M"],
+  ["-non-main-sys", "scala-docs-2.12.19.txz", "https://downloads.lightbend.com/scala/2.12.19/scala-docs-2.12.19.txz", "API docs", "54.88M"],
+  ["-non-main-sys", "scala-docs-2.12.19.zip", "https://downloads.lightbend.com/scala/2.12.19/scala-docs-2.12.19.zip", "API docs", "109.81M"],
+  ["-non-main-sys", "scala-sources-2.12.19.tar.gz", "https://github.com/scala/scala/archive/v2.12.19.tar.gz", "Sources", "6.7M"]
+]
+---

--- a/_posts/2024-02-20-release-notes-2.12.19.md
+++ b/_posts/2024-02-20-release-notes-2.12.19.md
@@ -1,0 +1,12 @@
+---
+category: announcement
+permalink: /news/2.12.19
+title: "Scala 2.12.19 is now available!"
+---
+[Scala 2.12.19](https://github.com/scala/scala/releases/tag/v2.12.19) is now available!
+
+This release
+improves compatibility with recent JDKs
+and fixes bugs.
+
+For all the details, refer to the [release notes](https://github.com/scala/scala/releases/tag/v2.12.19) on GitHub.


### PR DESCRIPTION
for merge later this week; see https://github.com/scala/scala-dev/issues/858 and https://contributors.scala-lang.org/t/scala-2-12-19-release-planning/6216/