### PR TITLE
Update links to use scala/scala3 in latest blog post

### DIFF
--- a/blog/_posts/2024-03-06-scala-3.3.2-post-mortem.md
+++ b/blog/_posts/2024-03-06-scala-3.3.2-post-mortem.md
@@ -51,7 +51,7 @@ However, for code readability and performance reasons, the compiler maintains a 
 When it reads the string `"evidence$"`, it reuses the instance of `NameKind` that it uses for that particular string.
 
 This leads us to the cause of our bug.
-Between 3.3.1 and 3.3.2, we merged [PR #18280](https://github.com/lampepfl/dotty/pull/18280).
+Between 3.3.1 and 3.3.2, we merged [PR #18280](https://github.com/scala/scala3/pull/18280).
 That PR starts with what appeared to be a *refactoring* commit that renamed some `NameKind`s and their associated strings.
 Unfortunately, that means the 3.3.2 compiler started emitting `UniqueName`s with the string `"contextual$"`.
 When the 3.3.1 compiler reads that structured name, it tries to find the cached instance of `NameKind` that it should use for `"contextual$"`, and does not find any, because it did not use to generate that string.
@@ -63,7 +63,7 @@ In order to fix this in 3.3.3, we reverted to generating `UniqueName("evidence$"
 The root cause is that the compiler assumed that only a fixed set of known strings would ever appear in TASTy `UniqueName`s, despite the fact that the TASTy format says that any string is valid in that position.
 From that root cause, an unfortunate combination of events happened.
 
-First, when we reviewed [PR #18280](https://github.com/lampepfl/dotty/pull/18280), taking the TASTy format into account, we assumed that using new strings would be a perfectly compatible change.
+First, when we reviewed [PR #18280](https://github.com/scala/scala3/pull/18280), taking the TASTy format into account, we assumed that using new strings would be a perfectly compatible change.
 We therefore did not mark the PR as "needs-minor-release" as we merged it into the `main` branch for release in 3.4.0.
 
 Second, the PR was backported to the 3.3.x LTS branch.


### PR DESCRIPTION
- Same as #1600
- #1603 was merged after repo migrated

/cc @sjrd