### PR TITLE
blog post: Scala 3 roadmap for 2024

### DIFF
--- a/blog/_posts/2024-03-15-scala-3-roadmap-2024.md
+++ b/blog/_posts/2024-03-15-scala-3-roadmap-2024.md
@@ -1,0 +1,18 @@
+---
+layout: blog-detail
+post-type: blog
+by: The Scala Center
+title: Scala 3 Roadmap for 2024 Published
+description: links to VirtusLab blog post
+---
+
+We call your attention to the following blog post from VirtusLab:
+
+* https://virtuslab.com/blog/technology/scala-3-roadmap-for-2024/
+
+It lays out the Scala 3 team's plans for Scala 3 this year.
+
+Topics covered include the timing, contents, and compatibility stories of future Scala 3 versions. There's also specifics about plans to make improvements in build times, IDE support, and elsewhere.
+
+**Reminder** The Scala Center also regular publishes roadmaps.
+A [previous blog post](https://scala-lang.org/blog/2024/02/06/scala-center-2024-roadmap.html) outlines the Center's 2024 plans.

--- a/blog/_posts/2024-03-15-scala-3-roadmap-2024.md
+++ b/blog/_posts/2024-03-15-scala-3-roadmap-2024.md
@@ -14,5 +14,5 @@ It lays out the Scala 3 team's plans for Scala 3 this year.
 
 Topics covered include the timing, contents, and compatibility stories of future Scala 3 versions. There's also specifics about plans to make improvements in build times, IDE support, and elsewhere.
 
-**Reminder** The Scala Center also regular publishes roadmaps.
+**Reminder** The Scala Center also regularly publishes roadmaps.
 A [previous blog post](https://scala-lang.org/blog/2024/02/06/scala-center-2024-roadmap.html) outlines the Center's 2024 plans.


### PR DESCRIPTION
pretty much just links to https://virtuslab.com/blog/technology/scala-3-roadmap-for-2024/ — very little fresh wording