### PR TITLE
Added Scala Enthusiasts LinkedIn group

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -80,6 +80,11 @@ Scala-oriented Discord servers operated by the community include:
 * **[Scalameta](https://discord.gg/RFpSVth)**: Scalameta-based tooling: Metals, Scalameta, Scalafix, Scalafmt, and Mdoc
 * **[Play Framework](https://discord.gg/g5s2vtZ4Fa)**: the Play web framework for Scala and Java
 * **[Typelevel](https://discord.gg/XF3CXcMzqD)**: the Typelevel ecosystem for pure-functional programming in Scala
+* **[ZIO](https://discord.gg/2ccFBr4)**: the ZIO ecosystem for Type-safe, composable asynchronous and concurrent programming in Scala
+* **[Laminar](https://discord.gg/JTrUxhq7sj)**: the Laminar, Native Scala.js library for building user interfaces
+* **[Smithy4s](https://discord.gg/wvVga94s8r)**: the smithy4s for generating Scala code from Smithy files.
+* **[indigo](https://discord.gg/b5CD47g)**: the Indigo, Scala 2D game engine based on functional programming
+
 
 English-language Scala rooms on other chat platforms besides Discord include:
 

--- a/community/index.md
+++ b/community/index.md
@@ -59,7 +59,7 @@ The [Scala Reddit](https://www.reddit.com/r/scala/) has a monthly "who is hiring
 
 ## Scala LinkedIn Group
 
-The [Scala Enthusiasts Group](https://www.linkedin.com/groups/746917/) is a place for Scala professionals to connect and share information. Via this group you can come into contact with people and companies using scala.
+The [Scala Enthusiasts Group](https://www.linkedin.com/groups/746917/) is a place for Scala professionals to share information and come into contact with people and companies using Scala.
 
 ## Chat Rooms
 

--- a/community/index.md
+++ b/community/index.md
@@ -57,6 +57,10 @@ Job postings are not allowed in our other forums and chat rooms.
 
 The [Scala Reddit](https://www.reddit.com/r/scala/) has a monthly "who is hiring?" thread.
 
+## Scala LinkedIn Group
+
+The [Scala Enthusiasts Group](https://www.linkedin.com/groups/746917/) is a place for Scala professionals to connect and share information. Via this group you can come into contact with people and companies using scala.
+
 ## Chat Rooms
 
 Our main chat platform is Discord, and the main Scala server is:


### PR DESCRIPTION
On Scala Lang community page, Scala Enthusiasts LinkedIn group is missing. It's a very active group with 35K members and I feel it should be part of the page. 