### PR TITLE
Update 'Testing your setup' in download.html

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -52,7 +52,7 @@ Scala code runner version {{currentScalaRelease}} -- Copyright 2002-2022, LAMP/E
               <div class="wrap">
                 <p>Check your setup with the command <code>scala -version</code>, which should output:</p>
                 {% include code-snippet.html nocopy=true language='bash' codeSnippet=scalaDemo %}
-                <p>If that does not work, you may need to log out and log back in (or reboot) in order for the changes to take
+                <p>If that does not work, close and reopen your terminal; otherwise, you may need to log out and log back in (or reboot) in order for the changes to take
                   effect.
                 </p>
               </div>


### PR DESCRIPTION
Quitting/Closing and reopening the terminal *(iTerm2 in my case)* should also work to show succesful install on MacOS (Ventura).
I have revised the instructions to suggest closing and reopening the terminal for changes to take effect.