### PR TITLE
better organize versions on homepage

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -47,17 +47,31 @@
             <div class="button-row__container">
               <div class="button-row">
                 {% for release in site.data.scala-releases %}
-                {% if release.category == "current_version" %}
-                <a href="/download/{{ release.version }}.html" class="button">
-                  Scala {{ release.version }}
-                </a>
+                {% assign version_slice = release.version | slice: 0, 2 %}
+                {% if release.category == 'current_version' %}
+                  {% if version_slice == '3.' %}
+                    {% unless release.title contains "LTS" %}
+                    <a href="/download/{{ release.version }}.html" class="button">
+                      Latest Release: {{ release.version }}
+                    </a>
+                    {% endunless %}
+                    {% if release.title contains "LTS" %}
+                    <a href="/download/{{ release.version }}.html" class="button">
+                      LTS Release: {{ release.version }}
+                    </a>
+                    {% endif %}
+                  {% else %}
+                    {% assign scala_2_version = release.version %}
+                  {% endif %}
                 {% endif %}
                 {% endfor %}
-                <a href="/download/all.html" class="button">
-                  All Releases
-                </a>
               </div>
             </div>
+            <p>
+              <a href="/download/all.html">
+                Scala {{scala_2_version}} and older releases
+              </a>
+            </p>
           </div>
         </div>
         <div class="col-lg-6">

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -44,27 +44,31 @@
           <div class="inner-text">
             <div class="hero-logo hide-lg"></div>
             <h2>{{page.headerSubtitle}}</h2>
+
+            {% for release in site.data.scala-releases %}
+              {% assign version_slice = release.version | slice: 0, 2 %}
+              {% if release.category == 'current_version' %}
+                {% if version_slice == '3.' %}
+                  {% unless release.title contains "LTS" %}
+                    {% assign scala_next_release = release %}
+                  {% endunless %}
+                  {% if release.title contains "LTS" %}
+                    {% assign scala_lts_release = release %}
+                  {% endif %}
+                {% else %}
+                  {% assign scala_2_version = release.version %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+
             <div class="button-row__container">
               <div class="button-row">
-                {% for release in site.data.scala-releases %}
-                {% assign version_slice = release.version | slice: 0, 2 %}
-                {% if release.category == 'current_version' %}
-                  {% if version_slice == '3.' %}
-                    {% unless release.title contains "LTS" %}
-                    <a href="/download/{{ release.version }}.html" class="button">
-                      Latest Release: {{ release.version }}
-                    </a>
-                    {% endunless %}
-                    {% if release.title contains "LTS" %}
-                    <a href="/download/{{ release.version }}.html" class="button">
-                      LTS Release: {{ release.version }}
-                    </a>
-                    {% endif %}
-                  {% else %}
-                    {% assign scala_2_version = release.version %}
-                  {% endif %}
-                {% endif %}
-                {% endfor %}
+                <a href="/download/{{ scala_next_release.version }}.html" class="button">
+                  Latest Release: {{ scala_next_release.version }}
+                </a>
+                <a href="/download/{{ scala_lts_release.version }}.html" class="button">
+                  LTS Release: {{ scala_lts_release.version }}
+                </a>
               </div>
             </div>
             <p>

--- a/_sass/layout/inner-text.scss
+++ b/_sass/layout/inner-text.scss
@@ -37,6 +37,10 @@
             margin-bottom: $padding-medium;
         }
 
+        p {
+            margin-top: 10px;
+        }
+
         @include bp(large) {
             .button {
                 margin-bottom: 3px;
@@ -44,6 +48,11 @@
 
             h2 {
                 font-size: 1.4rem;
+                text-align: center;
+            }
+
+            p {
+                font-size: 1.2rem;
                 text-align: center;
             }
         }


### PR DESCRIPTION
Better present the version buttons on the homepage - you still see latest Next, LTS, and 2.13 releases, but now we mention explicitly "LTS", and combine 2.13 with the link for all releases.

wide:
<img width="1243" alt="Screenshot 2024-06-24 at 17 44 32" src="https://github.com/scala/scala-lang/assets/13436592/db59d3c8-9a0d-4d3b-96c9-8796e938307b">

mobile:
<img width="573" alt="Screenshot 2024-06-24 at 17 44 52" src="https://github.com/scala/scala-lang/assets/13436592/18d734fa-798c-49fd-8c42-884912947b67">
