### PR TITLE
add release date to download page

### DIFF
--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -1,4 +1,4 @@
-<p>Are you looking for <a href="{{ site.baseurl }}/download/all.html">another release</a> of Scala?</p>
+<p>Released <b>{{page.release_date}}</b>. See <a href="{{ site.baseurl }}/download/all.html">all releases</a>.</p>
 <h3>Release Notes</h3>
 For a summary of important changes, see the <a href="https://github.com/scala/scala/releases">GitHub release notes</a>.
 <br/><small>(Or consult our archive of <a href="{{ site.baseurl }}/blog/announcements/">older release

--- a/_includes/downloads-scala3.html
+++ b/_includes/downloads-scala3.html
@@ -1,4 +1,4 @@
-<p>Are you looking for <a href="{{ site.baseurl }}/download/all.html">another release</a> of Scala?</p>
+<p>Released <b>{{page.release_date}}</b>. See <a href="{{ site.baseurl }}/download/all.html">all releases</a>.</p>
 <br/>
 <p>Scala binaries for <strong>{{page.release_version}}</strong> are available at <a href="https://github.com/scala/scala3/releases/tag/{{page.release_version}}">github</a>.</p>
 


### PR DESCRIPTION
Surprising this wasn't done before

![Screenshot 2024-06-25 at 13 05 34](https://github.com/scala/scala-lang/assets/13436592/8a5bd757-304b-4dfb-be1e-222dc84c3e15)
![Screenshot 2024-06-25 at 13 05 45](https://github.com/scala/scala-lang/assets/13436592/48c3cf55-6d46-4f72-8944-4639ecb16a97)
