### PR TITLE
fallback to 'monospace' for code font-family

### DIFF
--- a/_sass/components/code.scss
+++ b/_sass/components/code.scss
@@ -174,7 +174,7 @@
     code {
         // style that would be injected by hljs when JS is enabled
         display: block;
-        font-family: 'Consolas';
+        font-family: 'Consolas', monospace;
         border: none;
         display: block;
         overflow-x: auto;

--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -151,7 +151,7 @@
     li,
     p {
         code {
-            font-family: 'Consolas';
+            font-family: 'Consolas', monospace;
             background-color: #fff;
             color: #859900;
             @include border-radius($border-radius-medium);


### PR DESCRIPTION
Some people like myself disable custom fonts on the web. The reasons are often related to accesibility. In my case it is dyslexia, but there are probably other vision related reasons too.