### PR TITLE
build: fix docker compose  permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ COPY Gemfile .
 COPY Gemfile.lock .
 
 RUN echo -n "bundle version: " && bundle --version
-RUN chmod u+s /bin/chown
 RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 services:
   jekyll:
-    user: "${UID}:${GID}"
     build: .
-    command: sh -c "chown $UID / && bundle exec jekyll serve --incremental --host=0.0.0.0 "
+    command: "bundle exec jekyll serve --incremental --host=0.0.0.0"
     ports:
-      - '4000:4000'
+      - "4000:4000"
     volumes:
       - .:/srv/jekyll


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/cef6935a-a2b5-4d08-beb6-37a1d14c9d00)

fixes #1678.

## Solution Used

referenced [jekyll/jekyll](https://github.com/envygeeks/jekyll-docker/blob/master/README.md). completely removing all references to UID and GID fixed it. it works in both [rootless mode](https://docs.docker.com/engine/security/rootless/) and regular docker. both generated output aren't created as root but as host user.

| rootless | root |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/50e2c5d3-d5ff-4723-a9dd-e63d7645a876) | ![image](https://github.com/user-attachments/assets/57377bdb-1880-4033-9390-29ccdcf98c83) | 

_Originally posted in https://github.com/scala/scala-lang/issues/1678#issuecomment-2304458997_
            
