### PR TITLE
feat: use `<time>` tag

### DIFF
--- a/_includes/blog-list.html
+++ b/_includes/blog-list.html
@@ -22,7 +22,7 @@
 								<ul class="tag-list">
 									{% for tag in post.tags %}
 										<li class="tag-item">{{tag}}</li>
-									{% endfor %}									
+									{% endfor %}
 								</ul>
 							{% endif %}
 						</div>
@@ -37,7 +37,7 @@
 
 			{% capture urlPath %}{% if include.category == "all" %}blog{% else %}{{currentCategoryPath}}{% endif %}{% endcapture %}
 			{% assign urlPath = urlPath | split: '/' | join: '/' | remove_first: '/' %}
-			{% include paginator.html urlPath=urlPath %}	
+			{% include paginator.html urlPath=urlPath %}
 		</div>
 		{% assign highlights = "" | split: "," %}
 		{% for post in site.posts %}
@@ -51,7 +51,7 @@
 				<div class="content-nav-blog">
 					<div class="inner-box">
 						<h5>Highlights</h5>
-						<div class="blog-list-nav">	
+						<div class="blog-list-nav">
 			{% endif %}
 			<div class="blog-list-nav-item">
 				<h4><a href="{{post.url}}">{{post.title}}</a></h4>
@@ -70,6 +70,6 @@
 				</div>
 			{% endif %}
 		{% endfor %}
-		
+
 	</div>
 </section>

--- a/_includes/blog-list.html
+++ b/_includes/blog-list.html
@@ -16,7 +16,7 @@
 					{% for post in paginator.posts %}
 						<div class="blog-item">
 							<h2><a href="{{post.url}}">{{post.title}}</a></h2>
-							<p class="blog-date">{{post.date | date: "%A %-d %B %Y"}}</p>
+							<time datetime="{{post.date}}" class="blog-date">{{post.date | date: "%A %-d %B %Y"}}</time>
 							{% if post.by %}<p class="blog-author">{{post.by}}</p>{% endif %}
 							{% if post.tags %}
 								<ul class="tag-list">

--- a/_includes/inner-page-blog-detail-main-content.html
+++ b/_includes/inner-page-blog-detail-main-content.html
@@ -4,7 +4,7 @@
 			<div class="inner-box">
 				<div class="blog-detail-head">
 					<div>
-						<p>{{page.date | date: "%A %-d %B %Y"}}</p>
+						<time datetime="{{page.date}}">{{page.date | date: "%A %-d %B %Y"}}</time>
 						<p>{{page.by}}</p>
 					</div>
 					{% if page.tags %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="main-page-column">
-  <div class="article-date">{{ page.date | date: "%B %-d, %Y" }}</div>
+  <time datetime="{{page.date}}" class="article-date">{{ page.date | date: "%B %-d, %Y" }}</time>
   {% if page.by %}
     <div class="written">Written By: <span class="by">{{ page.by }}</span></div>
   {% endif %}


### PR DESCRIPTION
## Summary

applied [`<time>` tag](https://developer.mozilla.org/ko/docs/Web/HTML/Element/time) to following places:

| Blog | Blog posts |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/d61a267f-6f7c-4498-b0f4-4c9cc9f9590c) | ![image](https://github.com/user-attachments/assets/1357332f-c255-4ea2-aa76-beaa064522aa) |

- using [`<time>` tag](https://developer.mozilla.org/ko/docs/Web/HTML/Element/time) gives semantic meaning to time and helps accessibility for screen readers.
- the usage of tag doesn't affect styling.
- `blog.html` doesn't seem to be used anywhere else but included for completeness' sake.