### PR TITLE
disable dead links to scalamacros.org

### DIFF
--- a/_posts/2013-02-28-release-notes-v2.10.1-RC2.md
+++ b/_posts/2013-02-28-release-notes-v2.10.1-RC2.md
@@ -116,7 +116,7 @@ As for 2.10.0, here's an overview of the most prominent new features and improve
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 #### A big thank you to all the contributors!

--- a/_posts/2013-03-06-release-notes-v2.10.1-RC3.md
+++ b/_posts/2013-03-06-release-notes-v2.10.1-RC3.md
@@ -117,7 +117,7 @@ As for 2.10.0, here's an overview of the most prominent new features and improve
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 #### A big thank you to all the contributors!

--- a/_posts/2013-03-13-release-notes-v2.10.1.md
+++ b/_posts/2013-03-13-release-notes-v2.10.1.md
@@ -113,7 +113,7 @@ Since 2.10.1 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 #### A big thank you to all the contributors!

--- a/_posts/2013-05-23-release-notes-v2.10.2-RC1.md
+++ b/_posts/2013-05-23-release-notes-v2.10.2-RC1.md
@@ -113,7 +113,7 @@ Since 2.10.2 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 #### A big thank you to all the contributors!

--- a/_posts/2013-05-31-release-notes-v2.10.2-RC2.md
+++ b/_posts/2013-05-31-release-notes-v2.10.2-RC2.md
@@ -113,7 +113,7 @@ Since 2.10.2 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 #### A big thank you to all the contributors!

--- a/_posts/2013-06-06-release-notes-v2.10.2.md
+++ b/_posts/2013-06-06-release-notes-v2.10.2.md
@@ -82,7 +82,7 @@ Since 2.10.2 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 #### A big thank you to all the contributors!

--- a/_posts/2013-09-18-release-notes-v2.10.3-RC2.md
+++ b/_posts/2013-09-18-release-notes-v2.10.3-RC2.md
@@ -112,7 +112,7 @@ Since 2.10.3 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2013-09-24-release-notes-v2.10.3-RC3.md
+++ b/_posts/2013-09-24-release-notes-v2.10.3-RC3.md
@@ -118,7 +118,7 @@ Since 2.10.3 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2013-10-01-release-notes-v2.10.3.md
+++ b/_posts/2013-10-01-release-notes-v2.10.3.md
@@ -118,7 +118,7 @@ Since 2.10.3 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2013-12-20-release-notes-v2.10.4-RC1.md
+++ b/_posts/2013-12-20-release-notes-v2.10.4-RC1.md
@@ -118,7 +118,7 @@ Since 2.10.4 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2014-02-04-release-notes-2.10.4-RC2.md
+++ b/_posts/2014-02-04-release-notes-2.10.4-RC2.md
@@ -117,7 +117,7 @@ Since 2.10.4 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2014-02-25-release-notes-2.10.4-RC3.md
+++ b/_posts/2014-02-25-release-notes-2.10.4-RC3.md
@@ -117,7 +117,7 @@ Since 2.10.4 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2014-03-06-release-notes-2.11.0-RC1.md
+++ b/_posts/2014-03-06-release-notes-2.11.0-RC1.md
@@ -160,7 +160,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](https://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
-  * See also this [summary](http://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
+  * See also this [summary](hxxp://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
   * [#3321](https://github.com/scala/scala/pull/3321) introduced [Sprinter](https://vladimirnik.github.io/sprinter/), a new AST pretty-printing library! Very useful for tools that deal with source code.
 * Back-end
   * The [GenBCode back-end](https://github.com/scala/scala/pull/2620) (experimental in 2.11). See [@magarciaepfl's extensive documentation](https://magarciaepfl.github.io/scala/).

--- a/_posts/2014-03-20-release-notes-2.11.0-RC3.md
+++ b/_posts/2014-03-20-release-notes-2.11.0-RC3.md
@@ -169,7 +169,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](https://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
-  * See also this [summary](http://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
+  * See also this [summary](hxxp://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
   * [#3321](https://github.com/scala/scala/pull/3321) introduced [Sprinter](https://vladimirnik.github.io/sprinter/), a new AST pretty-printing library! Very useful for tools that deal with source code.
 * Back-end
   * The [GenBCode back-end](https://github.com/scala/scala/pull/2620) (experimental in 2.11). See [@magarciaepfl's extensive documentation](https://magarciaepfl.github.io/scala/).

--- a/_posts/2014-03-24-release-notes-2.10.4.md
+++ b/_posts/2014-03-24-release-notes-2.10.4.md
@@ -115,7 +115,7 @@ Since 2.10.4 is strictly a bug-fix release, here's an overview of the most promi
 
 The API is subject to (possibly major) changes in the 2.11.x series, but don't let that stop you from experimenting with them!
 A lot of developers have already come up with very cool applications for them.
-Some examples can be seen at [http://scalamacros.org/news/2012/11/05/status-update.html](http://scalamacros.org/news/2012/11/05/status-update.html).
+Some examples can be seen at [hxxp://scalamacros.org/news/2012/11/05/status-update.html](hxxp://scalamacros.org/news/2012/11/05/status-update.html).
 
 
 

--- a/_posts/2014-04-08-release-notes-2.11.0-RC4.md
+++ b/_posts/2014-04-08-release-notes-2.11.0-RC4.md
@@ -180,7 +180,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](https://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
-  * See also this [summary](http://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
+  * See also this [summary](hxxp://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
   * [#3321](https://github.com/scala/scala/pull/3321) introduced [Sprinter](https://vladimirnik.github.io/sprinter/), a new AST pretty-printing library! Very useful for tools that deal with source code.
 * Back-end
   * The [GenBCode back-end](https://github.com/scala/scala/pull/2620) (experimental in 2.11). See [@magarciaepfl's extensive documentation](https://magarciaepfl.github.io/scala/).

--- a/_posts/2014-04-21-release-notes-2.11.0.md
+++ b/_posts/2014-04-21-release-notes-2.11.0.md
@@ -34,7 +34,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](https://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
-  * See also this [summary](http://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
+  * See also this [summary](hxxp://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
   * [#3321](https://github.com/scala/scala/pull/3321) introduced [Sprinter](https://vladimirnik.github.io/sprinter/), a new AST pretty-printing library! Very useful for tools that deal with source code.
 * Back-end
   * The [GenBCode back-end](https://github.com/scala/scala/pull/2620) (experimental in 2.11). See [@magarciaepfl's extensive documentation](https://magarciaepfl.github.io/scala/).

--- a/_posts/2014-05-21-release-notes-2.11.1.md
+++ b/_posts/2014-05-21-release-notes-2.11.1.md
@@ -46,7 +46,7 @@ This release contains all of the bug fixes and improvements made in the 2.10 ser
   * The compiler has been modularized internally, to separate the presentation compiler, scaladoc and the REPL. We hope this will make it easier to contribute. In this release, all of these modules are still packaged in scala-compiler.jar. We plan to ship them in separate JARs in 2.12.x.
 * Reflection, macros and quasiquotes
   * Please see [this detailed changelog](https://docs.scala-lang.org/overviews/macros/changelog211.html) that lists all significant changes and provides advice on forward and backward compatibility.
-  * See also this [summary](http://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
+  * See also this [summary](hxxp://scalamacros.org/news/index.html) of the experimental side of the 2.11 development cycle.
   * [#3321](https://github.com/scala/scala/pull/3321) introduced [Sprinter](https://vladimirnik.github.io/sprinter/), a new AST pretty-printing library! Very useful for tools that deal with source code.
 * Back-end
   * The [GenBCode back-end](https://github.com/scala/scala/pull/2620) (experimental in 2.11). See [@magarciaepfl's extensive documentation](https://magarciaepfl.github.io/scala/).

--- a/_posts/2014-07-28-roadmap-next.md
+++ b/_posts/2014-07-28-roadmap-next.md
@@ -26,7 +26,7 @@ This release focuses on improving the standard library.
    1. Lazy collections through improved views, including Java 8 streams interop.
    2. Parallel collections with performance improvements obtained from operation fusion and more efficient parallel scheduling.
    3. An integrated abstraction to handle validation.
-3. The (independent) [scala.meta](http://scalamacros.org/news/2014/07/16/roadmap-for-scala-macros.html) project aims to establish a new standard for reflection and macro programming. It will be considered for integration in the standard library once it is mature and stable.
+3. The (independent) [scala.meta](hxxp://scalamacros.org/news/2014/07/16/roadmap-for-scala-macros.html) project aims to establish a new standard for reflection and macro programming. It will be considered for integration in the standard library once it is mature and stable.
 4. As in every Scala release, we’ll also work on improving compiler performance. Since this release focuses on the library, compiler changes will be strictly internal.
 
 Backwards compatibility and migration strategy: The changes to collections might require source code to be rewritten, even though this should be rare. However, we aim to maintain source code compatibility modulo an automatic migration tool (analogous to `go fix` for Go) that can do the rewriting automatically. Ideally, that tool should be robust and expressive enough to support cross-building.


### PR DESCRIPTION
it appears someone bought the scalamacros.org domain and replaced it with some AI-generated junk... looks like a SEO scheme

doing the http->hxxp thing is kinda gross but the links are all in really ancient posts so I don't feel like putting more effort into e.g. finding archive.org links

as noticed by the link checker at e.g. https://github.com/scala/scala-lang/actions/runs/10674385404/job/29584796119