### PR TITLE
Remove redundant `.` from Scala coursier download instructions

### DIFF
--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -12,7 +12,7 @@ For a summary of important changes, see the <a href="https://github.com/scala/sc
         Using <a
           href="https://docs.scala-lang.org/getting-started/index.html#using-the-scala-installer-recommended-way">Coursier
           CLI</a>, run:<br>
-        <code>cs install scala:{{ page.release_version }} && cs install scalac:{{ page.release_version }}</code>.
+        <code>cs install scala:{{ page.release_version }} && cs install scalac:{{ page.release_version }}</code>
       </li>
       <li>
 	      <div id="download-binaries"></div>Download the Scala binaries for <span id="users-os"></span>

--- a/_includes/downloads-scala3.html
+++ b/_includes/downloads-scala3.html
@@ -16,7 +16,7 @@ For a summary of important changes, see the <a
         Using <a
           href="https://docs.scala-lang.org/getting-started/index.html#using-the-scala-installer-recommended-way">Coursier
           CLI</a>, run:<br>
-        <code>cs install scala:{{page.release_version}} && cs install scalac:{{page.release_version}}</code>.
+        <code>cs install scala:{{page.release_version}} && cs install scalac:{{page.release_version}}</code>
       </li>
       <li>
         Download the Scala binaries for <strong>{{page.release_version}}</strong> at <a


### PR DESCRIPTION
With the redundant `.` double-clicking the code box includes the `.`, leading to potential bad copy of code.

![image](https://github.com/user-attachments/assets/8bdb4cad-5591-4380-aa8c-c0f80819ba96)

![persistant](https://github.com/user-attachments/assets/65211704-9657-4f65-8dd3-57b2eb4d7d05)
