### PR TITLE
Align Scala 3.3.4 download page title with remaining LTS releases.

### DIFF
--- a/_downloads/2024-09-27-3.3.4.md
+++ b/_downloads/2024-09-27-3.3.4.md
@@ -1,5 +1,5 @@
 ---
-title: Scala 3.3.4
+title: Scala 3.3.4 LTS
 start: 27 September 2024
 layout: downloadpage
 release_version: 3.3.4


### PR DESCRIPTION
Fixes issue raised on Reddit https://www.reddit.com/r/scala/comments/1ga7e40/is_scala_334_not_lts_or_is_this_just_an_oversight/