### PR TITLE
fix some 404s in old release announcements

### DIFF
--- a/_posts/2015-05-05-release-notes-2.12.0-M1.md
+++ b/_posts/2015-05-05-release-notes-2.12.0-M1.md
@@ -85,7 +85,7 @@ The following modules have been removed from the Scala 2.12 distribution:
 * The Scala actors library is no longer released with Scala 2.12.
   We recommend that you use the [Akka actors library](https://akka.io/) instead.
 * The Scala distribution archives and the `scala-library-all` maven dependency no longer inlcude Akka actors.
-  To use the Akka actors library, add it to your project [as a dependency](https://doc.akka.io/docs/akka/2.3.10/intro/getting-started.html).
+  To use the Akka actors library, add it to your project as a dependency.
 * The continuations plugin is no longer shipped with the Scala 2.12 distribution.
 
 

--- a/_posts/2015-07-14-release-notes-2.12.0-M2.md
+++ b/_posts/2015-07-14-release-notes-2.12.0-M2.md
@@ -84,7 +84,7 @@ The following modules have been removed from the Scala 2.12 distribution:
   We recommend [Akka actors](https://akka.io/) instead.
 * Akka actors.
   The Scala distribution and the `scala-library-all` dependency no longer include Akka actors.
-  To use Akka, [add it as a dependency](https://doc.akka.io/docs/akka/2.3.11/intro/getting-started.html).
+  To use Akka, add it as a dependency.
 * Continuations plugin.
   ([Community maintainers sought](https://github.com/scala/scala-continuations).)
 

--- a/_posts/2015-10-06-release-notes-2.12.0-M3.md
+++ b/_posts/2015-10-06-release-notes-2.12.0-M3.md
@@ -108,7 +108,7 @@ The following modules have been removed from the Scala 2.12 distribution:
   We recommend [Akka actors](https://akka.io/) instead.
 * Akka actors.
   The Scala distribution and the `scala-library-all` dependency no longer include Akka actors.
-  To use Akka, [add it as a dependency](https://doc.akka.io/docs/akka/2.4.0/intro/getting-started.html).
+  To use Akka, add it as a dependency.
 * Continuations plugin.
   ([Community maintainers sought](https://github.com/scala/scala-continuations).)
 


### PR DESCRIPTION
htmlproofer has been complaining in recent runs, e.g. https://github.com/scala/scala-lang/actions/runs/11674970706/job/32508662429