### PR TITLE
blog post on Scala 2 maintenance

### DIFF
--- a/blog/_posts/2024-12-16-scala-2-maintenance.md
+++ b/blog/_posts/2024-12-16-scala-2-maintenance.md
@@ -1,0 +1,18 @@
+---
+layout: blog-detail
+post-type: blog
+by: Seth Tisue, Akka
+title: "Scala 2 maintenance plans"
+---
+
+In October 2024, we published a [Scala Development Guarantees](https://www.scala-lang.org/development/) page that lays out our policies for the Scala 3 LTS (Long Term Support) and Scala Next version lines.
+
+We have now expanded this page to also cover **Scala 2**.
+
+In summary,
+
+> Maintenance of **Scala 2.13** will continue indefinitely.
+
+> Minimal maintenance of **Scala 2.12** will continue as long as sbt 1 remains in wide use.
+
+For more details, please visit [the page](https://www.scala-lang.org/development/).


### PR DESCRIPTION
for merge on Monday, December 16

once published, we should link to it from:
* https://contributors.scala-lang.org/t/2-13-eol-and-lts-planning/6664
* https://users.scala-lang.org/t/scala-2-12-end-of-life-date/8261
