### PR TITLE
Reverse past events

### DIFF
--- a/_includes/events-training-list-top.html
+++ b/_includes/events-training-list-top.html
@@ -9,69 +9,136 @@
 			{% assign firstYearNum = firstYear | plus: 0 %}
 			{% capture lastYear %}{{include.collection.last.date | date: "%Y"}}{% endcapture %}
 			{% assign lastYearNum = lastYear | plus: 0 %}
+			{% if page.reversed == false %}
+				{% for y in (firstYear..lastYear) %}
+					{% for m in (1..12) %}
+						{% assign currentMonthEvents = '' | split: ','' %}
 
-			{% for y in (firstYear..lastYear) %}
-				{% for m in (1..12) %}
-					{% assign currentMonthEvents = '' | split: ','' %}
+						{% for event in include.collection %}
+							{% capture year %}{{event.date | date: "%Y"}}{% endcapture %}
+							{% assign yearNum = year | plus: 0 %}
+							{% capture month %}{{event.date | date: "%m"}}{% endcapture %}
+							{% assign monthNum = month | plus: 0 %}
+							{% if monthNum == m and yearNum == y %}
+								{% assign currentMonthEvents = currentMonthEvents | push: event %}
+							{% endif %}
+						{% endfor %}
 
-					{% for event in include.collection %}
-						{% capture year %}{{event.date | date: "%Y"}}{% endcapture %}
-						{% assign yearNum = year | plus: 0 %}
-						{% capture month %}{{event.date | date: "%m"}}{% endcapture %}
-						{% assign monthNum = month | plus: 0 %}
-						{% if monthNum == m and yearNum == y %}
-							{% assign currentMonthEvents = currentMonthEvents | push: event %}
-						{% endif %}
-					{% endfor %}
+						{% capture monthName %}
+							{% case m %}
+							  {% when 1 %}January
+							  {% when 2 %}February
+							  {% when 3 %}March
+							  {% when 4 %}April
+							  {% when 5 %}May
+							  {% when 6 %}June
+							  {% when 7 %}July
+							  {% when 8 %}August
+							  {% when 9 %}September
+							  {% when 10 %}October
+							  {% when 11 %}November
+							  {% when 12 %}December
+							{% endcase %}
+						{% endcapture %}
 
-					{% capture monthName %}
-						{% case m %}
-						  {% when 1 %}January
-						  {% when 2 %}February
-						  {% when 3 %}March
-						  {% when 4 %}April
-						  {% when 5 %}May
-						  {% when 6 %}June
-						  {% when 7 %}July
-						  {% when 8 %}August
-						  {% when 9 %}September
-						  {% when 10 %}October
-						  {% when 11 %}November
-						  {% when 12 %}December
-						{% endcase %}
-					{% endcapture %}
+						{% for event in currentMonthEvents %}
+							{% capture year %}{{event.date | date: "%Y"}}{% endcapture %}
+							{% capture day %}{{event.date | date: "%d"}}{% endcapture %}
+							{% if forloop.first %}
+								<h3>{{monthName}} {{year}}</h3>
+								<div class="training-list">
+							{% endif %}
 
-					{% for event in currentMonthEvents %}
-						{% capture year %}{{event.date | date: "%Y"}}{% endcapture %}
-						{% capture day %}{{event.date | date: "%d"}}{% endcapture %}
-						{% if forloop.first %}
-							<h3>{{monthName}} {{year}}</h3>
-							<div class="training-list">
-						{% endif %}
+							<a href="{{event.link-out}}" class="training-item">
+								{% if event.logo %}
+									<img src="{{event.logo}}" alt="{{event.title}}">
+								{% else %}
+									<div class="calendar">
+										<span>{{monthName | truncate: 9, "" | upcase}}</span>
+										<span>{{day}}</span>
+									</div>
+								{% endif %}
+								<div class="training-text">
+									<h4>{{event.title | upcase}}</h4>
+									<p>{{event.location}}</p>
+									{% if event.organizer %}
+										<p>{{event.organizer}}</p>
+									{% else %}
+										<p>{{event.start}}{% if event.start != event.end %} - {{event.end}}{% endif %}</p>
+									{% endif %}
+								</div>
+							</a>
 
-						<a href="{{event.link-out}}" class="training-item">
-							{% if event.logo %}
-								<img src="{{event.logo}}" alt="{{event.title}}">
-							{% else %}
-								<div class="calendar">
-									<span>{{monthName | truncate: 9, "" | upcase}}</span>
-									<span>{{day}}</span>
+							{% if forloop.last %}
 								</div>
 							{% endif %}
-							<div class="training-text">
-								<h4>{{event.title | upcase}}</h4>
-								<p>{{event.location}}</p>
-								{% if event.organizer %}
-									<p>{{event.organizer}}</p>
-								{% else %}
-									<p>{{event.start}}{% if event.start != event.end %} - {{event.end}}{% endif %}</p>
-								{% endif %}
-							</div>
-						</a>
-
-						{% if forloop.last %}
-							</div>
-						{% endif %}
+						{% endfor %}
 					{% endfor %}
 				{% endfor %}
-			{% endfor %}
+            {% else %}
+            	{% for y in (firstYear..lastYear) reversed %}
+            		{% for m in (1..12) reversed %}
+            			{% assign currentMonthEvents = '' | split: ','' %}
+
+            			{% for event in include.collection %}
+            				{% capture year %}{{event.date | date: "%Y"}}{% endcapture %}
+            				{% assign yearNum = year | plus: 0 %}
+            				{% capture month %}{{event.date | date: "%m"}}{% endcapture %}
+            				{% assign monthNum = month | plus: 0 %}
+            				{% if monthNum == m and yearNum == y %}
+            					{% assign currentMonthEvents = currentMonthEvents | push: event %}
+            				{% endif %}
+            			{% endfor %}
+
+            			{% capture monthName %}
+            				{% case m %}
+            					{% when 1 %}January
+								{% when 2 %}February
+								{% when 3 %}March
+								{% when 4 %}April
+								{% when 5 %}May
+								{% when 6 %}June
+								{% when 7 %}July
+								{% when 8 %}August
+								{% when 9 %}September
+								{% when 10 %}October
+								{% when 11 %}November
+								{% when 12 %}December
+            				{% endcase %}
+            			{% endcapture %}
+
+            			{% for event in currentMonthEvents %}
+            				{% capture year %}{{event.date | date: "%Y"}}{% endcapture %}
+            				{% capture day %}{{event.date | date: "%d"}}{% endcapture %}
+            				{% if forloop.first %}
+								<h3>{{monthName}} {{year}}</h3>
+								<div class="training-list">
+                			{% endif %}
+
+							<a href="{{event.link-out}}" class="training-item">
+								{% if event.logo %}
+									<img src="{{event.logo}}" alt="{{event.title}}">
+								{% else %}
+									<div class="calendar">
+										<span>{{monthName | truncate: 9, "" | upcase}}</span>
+										<span>{{day}}</span>
+									</div>
+								{% endif %}
+								<div class="training-text">
+									<h4>{{event.title | upcase}}</h4>
+									<p>{{event.location}}</p>
+									{% if event.organizer %}
+										<p>{{event.organizer}}</p>
+									{% else %}
+										<p>{{event.start}}{% if event.start != event.end %} - {{event.end}}{% endif %}</p>
+									{% endif %}
+								</div>
+							</a>
+
+							{% if forloop.last %}
+								</div>
+							{% endif %}
+						{% endfor %}
+            		{% endfor %}
+            	{% endfor %}
+			{% endif %}

--- a/events/index.md
+++ b/events/index.md
@@ -2,6 +2,7 @@
 layout: events
 title: Upcoming events
 permalink: /events/
+reversed: false
 
 # Pagination
 paginate:

--- a/pastevents/index.md
+++ b/pastevents/index.md
@@ -2,6 +2,7 @@
 layout: pastevents
 title: Past events
 permalink: /pastevents/
+reversed: true
 
 # Pagination
 paginate:


### PR DESCRIPTION
Applying this PR reverses the events on the past events page. Fixes https://github.com/scala/scala-lang/issues/1738. I couldn't find a way to programmatically apply the "reversed" tag , that would be neater.