### PR TITLE
Add credits in Highlights blog post

### DIFF
--- a/_posts/2025-02-06-highlights-2024.md
+++ b/_posts/2025-02-06-highlights-2024.md
@@ -26,6 +26,8 @@ A few of the highlights covered in this issue:
 
 ### Named tuples and other Scala 3 improvements
 
+*Powered by LAMP, the Scala open source team at VirtusLab, the Scala team at Akka and the Scala Center*
+
 In 2024 we released two new Scala Next versions: 3.5 and 3.6. Scala Next is the version we recommend for most Scala 3 users.
 
 Scala 3.5 introduces support for `var` in refinements, binary integer literals, and experimental named tuples.
@@ -46,6 +48,8 @@ Further reading:
 
 ### Scala 2 maintenance
 
+*Powered by the Scala team at Akka*
+
 We remain committed to maintaining Scala 2 and publishing new versions as needed.
 
 Scala 2.13 improvements are mostly in the areas of JDK compatibility, warnings and lints, and aligning with Scala 3, especially under the `-Xsource:3` flag.
@@ -63,6 +67,8 @@ Further reading:
 - Release notes: [2.13.16](https://github.com/scala/scala/releases/tag/v2.13.16), [2.13.15](https://github.com/scala/scala/releases/tag/v2.13.15), [2.13.14](https://github.com/scala/scala/releases/tag/v2.13.14), [2.13.13](https://github.com/scala/scala/releases/tag/v2.13.13)
 
 ### Experimental WebAssembly backend in Scala.js
+
+*Powered by the Scala Center and the Scala open source team at VirtusLab*
 
 Starting with 1.17.0, Scala.js introduces an experimental WebAssembly (Wasm) backend.
 It is designed to be a drop-in replacement for the usual JavaScript backend, albeit with a few [current limitations](https://www.scala-js.org/doc/project/webassembly.html#language-semantics).
@@ -84,6 +90,8 @@ Further reading:
 
 ### Multi-threading support in Scala Native
 
+*Powered by the Scala open source team at VirtusLab*
+
 Scala Native 0.5 introduces an implementation of `java.lang.Thread` based on system threads, along with Scala and Java concurrency primitives.
 It provides support for synchronized blocks, `@volatile` annotations, final fields, and includes thread-safe implementations of most classes in `java.util.concurrent`, `scala.concurrent` and `scala.collection.concurrent`.
 
@@ -95,6 +103,8 @@ It also contains initial support for 32-bit architectures, and more.
 ## Developer experience
 
 ### Scala CLI as the new default runner for Scala
+
+*Scala CLI is powered by the Scala open source team at VirtusLab, with the new default runner contributed by LAMP and the Scala Center.*
 
 [Scala CLI](https://scala-cli.virtuslab.org/) is a popular tool for developing Scala scripts and single-module projects.
 It allows lightning-fast running and testing of Scala code. It can even publish single-module projects to Maven Central without involving a separate build tool.
@@ -110,6 +120,8 @@ And it fully supports both Scala 3 and Scala 2.
 Check out the [Scala CLI documentation](https://scala-cli.virtuslab.org/) to discover its full power.
 
 ### Scala 3 build definitions in sbt 2.x (beta)
+
+*sbt 2.x is developed and overseen by Eugene Yokota, with contributions from the Scala Center.*
 
 Eugene Yokota, in collaboration with the Scala Center and community contributors, released sbt 2.0.0-M3, a new beta version of sbt 2.x, powered by Scala 3.
 This release enables `build.sbt` files to be written in Scala 3.
@@ -138,7 +150,7 @@ To learn about these new features and more, check out the [sbt 2.0.0-M3 announce
 
 ### Improvements in IntelliJ Scala Plugin
 
-*By the IntelliJ Scala plugin team at JetBrains*
+*Powered by the IntelliJ Scala plugin team at JetBrains*
 
 In 2024, the IntelliJ Scala Plugin introduced a new sbt layout which creates separate `main` and `test` modules for each sbt project.
 This change allows for different compiler options in each scope and improves the representation of dependencies.
@@ -161,6 +173,8 @@ Other major updates from 2024 include:
 As a further read, check out the [The IntelliJ Scala Plugin in 2024](https://blog.jetbrains.com/scala/2024/12/20/the-intellij-scala-plugin-in-2024/) post on JetBrains' blog.
 
 ### Best-effort compilation in Metals
+
+*Powered by the Scala open source team at VirtusLab*
 
 Our main focus with Metals has been stability, to provide a smoother experience for Scala developers.
 One of those efforts has been implementing best-effort compilation for Scala 3.
@@ -233,7 +247,7 @@ The community page also has many useful links to newsletters, learning materials
 
 ## How you can support Scala
 
-The Scala Center is the Scala language foundation coordinating Scala governance, community, education, and open-source development.
+The Scala Center is the Scala language foundation coordinating Scala governance, community, education, and open source development.
 
 The Center contributes to the core language and to open source Scala tooling and libraries, and it delivers high-quality education materials.
 It fosters conversations in the community and coordinates with various parties to unblock and improve the Scala ecosystem.

--- a/_posts/2025-02-06-highlights-2024.md
+++ b/_posts/2025-02-06-highlights-2024.md
@@ -26,7 +26,7 @@ A few of the highlights covered in this issue:
 
 ### Named tuples and other Scala 3 improvements
 
-*Powered by LAMP, the Scala open source team at VirtusLab, the Scala team at Akka and the Scala Center*
+*Led by LAMP, the Scala open source team at VirtusLab, the Scala team at Akka and the Scala Center*
 
 In 2024 we released two new Scala Next versions: 3.5 and 3.6. Scala Next is the version we recommend for most Scala 3 users.
 
@@ -48,7 +48,7 @@ Further reading:
 
 ### Scala 2 maintenance
 
-*Powered by the Scala team at Akka*
+*Led by the Scala team at Akka*
 
 We remain committed to maintaining Scala 2 and publishing new versions as needed.
 
@@ -68,7 +68,7 @@ Further reading:
 
 ### Experimental WebAssembly backend in Scala.js
 
-*Powered by the Scala Center and the Scala open source team at VirtusLab*
+*Led by the Scala Center and the Scala open source team at VirtusLab*
 
 Starting with 1.17.0, Scala.js introduces an experimental WebAssembly (Wasm) backend.
 It is designed to be a drop-in replacement for the usual JavaScript backend, albeit with a few [current limitations](https://www.scala-js.org/doc/project/webassembly.html#language-semantics).
@@ -90,7 +90,7 @@ Further reading:
 
 ### Multi-threading support in Scala Native
 
-*Powered by the Scala open source team at VirtusLab*
+*Led by the Scala open source team at VirtusLab*
 
 Scala Native 0.5 introduces an implementation of `java.lang.Thread` based on system threads, along with Scala and Java concurrency primitives.
 It provides support for synchronized blocks, `@volatile` annotations, final fields, and includes thread-safe implementations of most classes in `java.util.concurrent`, `scala.concurrent` and `scala.collection.concurrent`.
@@ -150,7 +150,7 @@ To learn about these new features and more, check out the [sbt 2.0.0-M3 announce
 
 ### Improvements in IntelliJ Scala Plugin
 
-*Powered by the IntelliJ Scala plugin team at JetBrains*
+*Led by the IntelliJ Scala plugin team at JetBrains*
 
 In 2024, the IntelliJ Scala Plugin introduced a new sbt layout which creates separate `main` and `test` modules for each sbt project.
 This change allows for different compiler options in each scope and improves the representation of dependencies.
@@ -174,7 +174,7 @@ As a further read, check out the [The IntelliJ Scala Plugin in 2024](https://blo
 
 ### Best-effort compilation in Metals
 
-*Powered by the Scala open source team at VirtusLab*
+*Led by the Scala open source team at VirtusLab*
 
 Our main focus with Metals has been stability, to provide a smoother experience for Scala developers.
 One of those efforts has been implementing best-effort compilation for Scala 3.


### PR DESCRIPTION
This PR updates the Scala Highlights blog post to acknowledge which organizations is investing in the open source development of Scala.

It should supersede #1745