### PR TITLE
Scala 2 download pages: link to version-specific notes

### DIFF
--- a/_includes/downloads-scala2.html
+++ b/_includes/downloads-scala2.html
@@ -1,8 +1,7 @@
 <p>Released <b>{{page.release_date}}</b>. See <a href="{{ site.baseurl }}/download/all.html">all releases</a>.</p>
 <h3>Release Notes</h3>
-For a summary of important changes, see the <a href="https://github.com/scala/scala/releases">GitHub release notes</a>.
-<br/><small>(Or consult our archive of <a href="{{ site.baseurl }}/blog/releases/">older release
-    notes</a>.)</small>
+For a summary of important changes, see the <a
+  href="https://github.com/scala/scala/releases/tag/v{{page.release_version}}">GitHub release notes</a>.
 
 <div class="install-steps">
   <div class="text-step">

--- a/_includes/downloads-scala3.html
+++ b/_includes/downloads-scala3.html
@@ -5,8 +5,6 @@
 <h3>Release Notes</h3>
 For a summary of important changes, see the <a
   href="https://github.com/scala/scala3/releases/tag/{{page.release_version}}">GitHub release notes</a>.
-<br /><small>(Or consult our archive of <a href="{{ site.baseurl }}/blog/releases/">older release
-    notes</a>.)</small>
 
 <div class="install-steps">
   <div class="text-step">


### PR DESCRIPTION
we've had this problem for yearrrrrrrrrs and I've always meant to fix it, and, well, today's the day

also remove the unneeded links to the archive of old release blog posts. it's distracting noise. the release notes have been on GitHub at least since 2.12.0 and we just don't care whether older versions are now a bit harder to find