### PR TITLE
chore: add *The Scala Workshop* 2025 to events

### DIFF
--- a/_events/2025-10-13-scala-workshop.md
+++ b/_events/2025-10-13-scala-workshop.md
@@ -1,0 +1,10 @@
+---
+category: event
+title: The Scala Workshop
+logo: https://workshop.scala-lang.org/brand-assets/logo/dark/no-text/logo.svg
+location: Singapore
+description: "The Scala Workshop, First Edition"
+start: 13 October 2025
+end: 13 October 2025
+link-out: https://2025.workshop.scala-lang.org
+---


### PR DESCRIPTION
Add the first edition of *The Scala Workshop* to the list of events

Rendering:

<img width="1200" alt="Screenshot 2025-04-13 at 01 08 23" src="https://github.com/user-attachments/assets/49db8b90-2aba-4f88-a9ac-6d6ef24fbf9d" />
