### PR TITLE
Update 2022-08-17-long-term-compatibility-plans for LTS vs Next guide

### DIFF
--- a/blog/_posts/2022-08-17-long-term-compatibility-plans.md
+++ b/blog/_posts/2022-08-17-long-term-compatibility-plans.md
@@ -30,7 +30,11 @@ Scala 3 guarantees backward compatibility between all releases and forward compa
 
 ## What version of Scala should I use?
 
-So, we know what output compatibility is and what Scala 3 guarantees. What does it mean in practice? What version of the compiler should I choose for my project? The compiler team believes that the good answer for this question is always *the newest one*.
+So, we know what output compatibility is and what Scala 3 guarantees. What does it mean in practice? What version of the compiler should I choose for my project?
+
+The simple answer is:
+* The **Scala Next** line should be used be used by most users, as it contains the latest features, bug fixes and improvements.
+* The **Scala LTS** line is advised to be used for publishing libraries. (Some especially conservative users might also choose it over Scala Next.)
 
 We believe that you should treat the compiler as one of your dependencies. If you are fine with updating the versions of your library dependencies, there should be no reason not to update the compiler version. In most cases, you wouldn't even notice that the Scala version has changed. Meanwhile, you can get better compilation performance, improved error messages, and most importantly, you may be able to use newly stabilized features of the language and of the standard library.
 


### PR DESCRIPTION
Last year the advisory board has accepted https://github.com/scalacenter/advisoryboard/blob/main/proposals/032-scala-version-guidance.md that was later marked as completed in https://github.com/scalacenter/advisoryboard/pull/164 by the introduction of https://scala-lang.org/development. While this page provides a clear guidance, it's very hard to find. I have no idea how to reach this page other than via direct link.

The proposal mentioned inconsistent communication in https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#what-version-of-scala-should-i-use - an article that is currently number one for most search engine queries for LTS vs Next.

This PR updates the mentioned post, aligning the communication to match the contents of https://scala-lang.org/development