### PR TITLE
Explain version choice on download page

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -76,14 +76,31 @@ Scala code runner version {{currentScalaRelease}} -- Copyright 2002-2022, LAMP/E
           </div>
         </div>
         
-	<div id="version-choice">
+        <div id="version-choice">
+
+          {% for release in site.data.scala-releases %}
+            {% assign version_slice = release.version | slice: 0, 2 %}
+            {% if release.category == 'current_version' %}
+              {% if version_slice == '3.' %}
+                {% unless release.title contains "LTS" %}
+                  {% assign scala_next_release = release %}
+                {% endunless %}
+                {% if release.title contains "LTS" %}
+                  {% assign scala_lts_release = release %}
+                {% endif %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+
+
           <h2>Which version of Scala should I choose?</h2>
           <p>There are 2 distribution lines of Scala 3:</p>
-          <ul>
-            <li><strong>Scala Next</strong> - The <strong>default</strong> to be used by most users, containing the latest features, bug fixes and improvements.</li>
-            <li><strong>Scala LTS</strong> - Advised to be used for publishing <strong>libraries</strong>. (Some especially conservative users might also choose it over Scala Next.)</li>
+          <ul style="list-style-type: disc; padding: 10px;">
+            <li><strong>Scala Next</strong> currently {{ scala_next_release.version }} - The <strong>default</strong> to be used by most users, containing the latest features, bug fixes and improvements.</li>
+            <li><strong>Scala LTS</strong> currently {{ scala_lts_release.version }} - Advised to be used for publishing <strong>libraries</strong>.</li>
           </ul>
         </div>
+        
         
 	<h2>Other ways to install Scala</h2>
         <div class="wrap">

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -75,7 +75,17 @@ Scala code runner version {{currentScalaRelease}} -- Copyright 2002-2022, LAMP/E
             </a>
           </div>
         </div>
-        <h2>Other ways to install Scala</h2>
+        
+	<div id="version-choice">
+          <h2>Which version of Scala should I choose?</h2>
+          <p>There are 2 distribution lines of Scala 3:</p>
+          <ul>
+            <li><strong>Scala Next</strong> - The <strong>default</strong> to be used by most users, containing the latest features, bug fixes and improvements.</li>
+            <li><strong>Scala LTS</strong> - Advised to be used for publishing <strong>libraries</strong>. (Some especially conservative users might also choose it over Scala Next.)</li>
+          </ul>
+        </div>
+        
+	<h2>Other ways to install Scala</h2>
         <div class="wrap">
           <a href="{{ site.baseurl }}/download/all.html" class="btn-download dl-find-all">
             <i class="fa fa-list-ul"></i>


### PR DESCRIPTION
This is a follow up to https://github.com/scala/scala-lang/pull/1790

Last year the advisory board has accepted https://github.com/scalacenter/advisoryboard/blob/main/proposals/032-scala-version-guidance.md that was later marked as completed in https://github.com/scalacenter/advisoryboard/pull/164 by the introduction of https://scala-lang.org/development. While this page provides a clear guidance, it's very hard to find.

The proposal mentioned explaining version choice on the download page, this PR provides such guidance.