### PR TITLE
Change download URL for Scala 2 releases

### DIFF
--- a/_downloads/2014-03-06-2.11.0-RC1.md
+++ b/_downloads/2014-03-06-2.11.0-RC1.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "24.73M"],
-  ["-main-windows", "scala-2.11.0-RC1.msi", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.msi", "Windows (msi installer)", "88.88M"],
-  ["-non-main-sys", "scala-2.11.0-RC1.zip", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.zip", "Windows", "24.74M"],
-  ["-non-main-sys", "scala-2.11.0-RC1.deb", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.deb", "Debian", "87.87M"],
-  ["-non-main-sys", "scala-2.11.0-RC1.rpm", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-2.11.0-RC1.rpm", "RPM package", "87.86M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC1.txz", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-docs-2.11.0-RC1.txz", "API docs", "36.02M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC1.zip", "https://downloads.lightbend.com/scala/2.11.0-RC1/scala-docs-2.11.0-RC1.zip", "API docs", "66.52M"],
+  ["-main-unixsys", "scala-2.11.0-RC1.tgz", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-2.11.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "24.73M"],
+  ["-main-windows", "scala-2.11.0-RC1.msi", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-2.11.0-RC1.msi", "Windows (msi installer)", "88.88M"],
+  ["-non-main-sys", "scala-2.11.0-RC1.zip", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-2.11.0-RC1.zip", "Windows", "24.74M"],
+  ["-non-main-sys", "scala-2.11.0-RC1.deb", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-2.11.0-RC1.deb", "Debian", "87.87M"],
+  ["-non-main-sys", "scala-2.11.0-RC1.rpm", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-2.11.0-RC1.rpm", "RPM package", "87.86M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC1.txz", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-docs-2.11.0-RC1.txz", "API docs", "36.02M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC1.zip", "https://github.com/scala/scala/releases/download/v2.11.0-RC1/scala-docs-2.11.0-RC1.zip", "API docs", "66.52M"],
   ["-non-main-sys", "scala-sources-2.11.0-RC1.zip", "https://github.com/scala/scala/archive/v2.11.0-RC1.tar.gz", "sources", ""]
 ]
 ---

--- a/_downloads/2014-03-20-2.11.0-RC3.md
+++ b/_downloads/2014-03-20-2.11.0-RC3.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.0-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.0-RC3.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "24.77M"],
-  ["-main-windows", "scala-2.11.0-RC3.msi", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.msi", "Windows (msi installer)", "88.95M"],
-  ["-non-main-sys", "scala-2.11.0-RC3.zip", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.zip", "Windows", "24.79M"],
-  ["-non-main-sys", "scala-2.11.0-RC3.deb", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.deb", "Debian", "87.98M"],
-  ["-non-main-sys", "scala-2.11.0-RC3.rpm", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-2.11.0-RC3.rpm", "RPM package", "87.96M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC3.txz", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-docs-2.11.0-RC3.txz", "API docs", "36.10M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC3.zip", "https://downloads.lightbend.com/scala/2.11.0-RC3/scala-docs-2.11.0-RC3.zip", "API docs", "66.59M"],
+  ["-main-unixsys", "scala-2.11.0-RC3.tgz", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-2.11.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "24.77M"],
+  ["-main-windows", "scala-2.11.0-RC3.msi", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-2.11.0-RC3.msi", "Windows (msi installer)", "88.95M"],
+  ["-non-main-sys", "scala-2.11.0-RC3.zip", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-2.11.0-RC3.zip", "Windows", "24.79M"],
+  ["-non-main-sys", "scala-2.11.0-RC3.deb", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-2.11.0-RC3.deb", "Debian", "87.98M"],
+  ["-non-main-sys", "scala-2.11.0-RC3.rpm", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-2.11.0-RC3.rpm", "RPM package", "87.96M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC3.txz", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-docs-2.11.0-RC3.txz", "API docs", "36.10M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC3.zip", "https://github.com/scala/scala/releases/download/v2.11.0-RC3/scala-docs-2.11.0-RC3.zip", "API docs", "66.59M"],
   ["-non-main-sys", "scala-sources-2.11.0-RC3.zip", "https://github.com/scala/scala/archive/v2.11.0-RC3.tar.gz", "sources", ""]
 ]
 ---

--- a/_downloads/2014-04-08-2.11.0-RC4.md
+++ b/_downloads/2014-04-08-2.11.0-RC4.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.0-RC4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.0-RC4.tgz", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.tgz", "Mac OS X, Unix, Cygwin", "24.79M"],
-  ["-main-windows", "scala-2.11.0-RC4.msi", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.msi", "Windows (msi installer)", "89.02M"],
-  ["-non-main-sys", "scala-2.11.0-RC4.zip", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.zip", "Windows", "24.81M"],
-  ["-non-main-sys", "scala-2.11.0-RC4.deb", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.deb", "Debian", "88.05M"],
-  ["-non-main-sys", "scala-2.11.0-RC4.rpm", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-2.11.0-RC4.rpm", "RPM package", "88.03M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC4.txz", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-docs-2.11.0-RC4.txz", "API docs", "36.12M"],
-  ["-non-main-sys", "scala-docs-2.11.0-RC4.zip", "https://downloads.lightbend.com/scala/2.11.0-RC4/scala-docs-2.11.0-RC4.zip", "API docs", "66.63M"],
+  ["-main-unixsys", "scala-2.11.0-RC4.tgz", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-2.11.0-RC4.tgz", "Mac OS X, Unix, Cygwin", "24.79M"],
+  ["-main-windows", "scala-2.11.0-RC4.msi", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-2.11.0-RC4.msi", "Windows (msi installer)", "89.02M"],
+  ["-non-main-sys", "scala-2.11.0-RC4.zip", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-2.11.0-RC4.zip", "Windows", "24.81M"],
+  ["-non-main-sys", "scala-2.11.0-RC4.deb", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-2.11.0-RC4.deb", "Debian", "88.05M"],
+  ["-non-main-sys", "scala-2.11.0-RC4.rpm", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-2.11.0-RC4.rpm", "RPM package", "88.03M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC4.txz", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-docs-2.11.0-RC4.txz", "API docs", "36.12M"],
+  ["-non-main-sys", "scala-docs-2.11.0-RC4.zip", "https://github.com/scala/scala/releases/download/v2.11.0-RC4/scala-docs-2.11.0-RC4.zip", "API docs", "66.63M"],
   ["-non-main-sys", "scala-sources-2.11.0-RC4.zip", "https://github.com/scala/scala/archive/v2.11.0-RC4.tar.gz", "sources", ""]
 ]
 ---

--- a/_downloads/2014-04-21-2.11.0.md
+++ b/_downloads/2014-04-21-2.11.0.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.0.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.0.tgz", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.tgz", "Mac OS X, Unix, Cygwin", "24.80M"],
-  ["-main-windows", "scala-2.11.0.msi", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.msi", "Windows (msi installer)", "89.00M"],
-  ["-non-main-sys", "scala-2.11.0.zip", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.zip", "Windows", "24.81M"],
-  ["-non-main-sys", "scala-2.11.0.deb", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.deb", "Debian", "88.03M"],
-  ["-non-main-sys", "scala-2.11.0.rpm", "https://downloads.lightbend.com/scala/2.11.0/scala-2.11.0.rpm", "RPM package", "88.03M"],
-  ["-non-main-sys", "scala-docs-2.11.0.txz", "https://downloads.lightbend.com/scala/2.11.0/scala-docs-2.11.0.txz", "API docs", "35.95M"],
-  ["-non-main-sys", "scala-docs-2.11.0.zip", "https://downloads.lightbend.com/scala/2.11.0/scala-docs-2.11.0.zip", "API docs", "66.59M"],
+  ["-main-unixsys", "scala-2.11.0.tgz", "https://github.com/scala/scala/releases/download/v2.11.0/scala-2.11.0.tgz", "Mac OS X, Unix, Cygwin", "24.80M"],
+  ["-main-windows", "scala-2.11.0.msi", "https://github.com/scala/scala/releases/download/v2.11.0/scala-2.11.0.msi", "Windows (msi installer)", "89.00M"],
+  ["-non-main-sys", "scala-2.11.0.zip", "https://github.com/scala/scala/releases/download/v2.11.0/scala-2.11.0.zip", "Windows", "24.81M"],
+  ["-non-main-sys", "scala-2.11.0.deb", "https://github.com/scala/scala/releases/download/v2.11.0/scala-2.11.0.deb", "Debian", "88.03M"],
+  ["-non-main-sys", "scala-2.11.0.rpm", "https://github.com/scala/scala/releases/download/v2.11.0/scala-2.11.0.rpm", "RPM package", "88.03M"],
+  ["-non-main-sys", "scala-docs-2.11.0.txz", "https://github.com/scala/scala/releases/download/v2.11.0/scala-docs-2.11.0.txz", "API docs", "35.95M"],
+  ["-non-main-sys", "scala-docs-2.11.0.zip", "https://github.com/scala/scala/releases/download/v2.11.0/scala-docs-2.11.0.zip", "API docs", "66.59M"],
   ["-non-main-sys", "scala-sources-2.11.0.zip", "https://github.com/scala/scala/archive/v2.11.0.tar.gz", "sources", ""]
 ]
 ---

--- a/_downloads/2014-05-21-2.11.1.md
+++ b/_downloads/2014-05-21-2.11.1.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.1.tgz", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.tgz", "Mac OS X, Unix, Cygwin", "24.50M"],
-  ["-main-windows", "scala-2.11.1.msi", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.msi", "Windows (msi installer)", "93.05M"],
-  ["-non-main-sys", "scala-2.11.1.zip", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.zip", "Windows", "24.51M"],
-  ["-non-main-sys", "scala-2.11.1.deb", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.deb", "Debian", "92.01M"],
-  ["-non-main-sys", "scala-2.11.1.rpm", "https://downloads.lightbend.com/scala/2.11.1/scala-2.11.1.rpm", "RPM package", "91.98M"],
-  ["-non-main-sys", "scala-docs-2.11.1.txz", "https://downloads.lightbend.com/scala/2.11.1/scala-docs-2.11.1.txz", "API docs", "39.51M"],
-  ["-non-main-sys", "scala-docs-2.11.1.zip", "https://downloads.lightbend.com/scala/2.11.1/scala-docs-2.11.1.zip", "API docs", "70.83M"],
+  ["-main-unixsys", "scala-2.11.1.tgz", "https://github.com/scala/scala/releases/download/v2.11.1/scala-2.11.1.tgz", "Mac OS X, Unix, Cygwin", "24.50M"],
+  ["-main-windows", "scala-2.11.1.msi", "https://github.com/scala/scala/releases/download/v2.11.1/scala-2.11.1.msi", "Windows (msi installer)", "93.05M"],
+  ["-non-main-sys", "scala-2.11.1.zip", "https://github.com/scala/scala/releases/download/v2.11.1/scala-2.11.1.zip", "Windows", "24.51M"],
+  ["-non-main-sys", "scala-2.11.1.deb", "https://github.com/scala/scala/releases/download/v2.11.1/scala-2.11.1.deb", "Debian", "92.01M"],
+  ["-non-main-sys", "scala-2.11.1.rpm", "https://github.com/scala/scala/releases/download/v2.11.1/scala-2.11.1.rpm", "RPM package", "91.98M"],
+  ["-non-main-sys", "scala-docs-2.11.1.txz", "https://github.com/scala/scala/releases/download/v2.11.1/scala-docs-2.11.1.txz", "API docs", "39.51M"],
+  ["-non-main-sys", "scala-docs-2.11.1.zip", "https://github.com/scala/scala/releases/download/v2.11.1/scala-docs-2.11.1.zip", "API docs", "70.83M"],
   ["-non-main-sys", "scala-sources-2.11.1.tar.gz", "https://github.com/scala/scala/archive/v2.11.1.tar.gz", "sources", ""]
 ]
 ---

--- a/_downloads/2014-07-24-2.11.2.md
+++ b/_downloads/2014-07-24-2.11.2.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.2.tgz", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.tgz", "Mac OS X, Unix, Cygwin", "25.26M"],
-  ["-main-windows", "scala-2.11.2.msi", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.msi", "Windows (msi installer)", "95.03M"],
-  ["-non-main-sys", "scala-2.11.2.zip", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.zip", "Windows", "25.27M"],
-  ["-non-main-sys", "scala-2.11.2.deb", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.deb", "Debian", "94.00M"],
-  ["-non-main-sys", "scala-2.11.2.rpm", "https://downloads.lightbend.com/scala/2.11.2/scala-2.11.2.rpm", "RPM package", "93.96M"],
-  ["-non-main-sys", "scala-docs-2.11.2.txz", "https://downloads.lightbend.com/scala/2.11.2/scala-docs-2.11.2.txz", "API docs", "40.48M"],
-  ["-non-main-sys", "scala-docs-2.11.2.zip", "https://downloads.lightbend.com/scala/2.11.2/scala-docs-2.11.2.zip", "API docs", "72.06M"],
+  ["-main-unixsys", "scala-2.11.2.tgz", "https://github.com/scala/scala/releases/download/v2.11.2/scala-2.11.2.tgz", "Mac OS X, Unix, Cygwin", "25.26M"],
+  ["-main-windows", "scala-2.11.2.msi", "https://github.com/scala/scala/releases/download/v2.11.2/scala-2.11.2.msi", "Windows (msi installer)", "95.03M"],
+  ["-non-main-sys", "scala-2.11.2.zip", "https://github.com/scala/scala/releases/download/v2.11.2/scala-2.11.2.zip", "Windows", "25.27M"],
+  ["-non-main-sys", "scala-2.11.2.deb", "https://github.com/scala/scala/releases/download/v2.11.2/scala-2.11.2.deb", "Debian", "94.00M"],
+  ["-non-main-sys", "scala-2.11.2.rpm", "https://github.com/scala/scala/releases/download/v2.11.2/scala-2.11.2.rpm", "RPM package", "93.96M"],
+  ["-non-main-sys", "scala-docs-2.11.2.txz", "https://github.com/scala/scala/releases/download/v2.11.2/scala-docs-2.11.2.txz", "API docs", "40.48M"],
+  ["-non-main-sys", "scala-docs-2.11.2.zip", "https://github.com/scala/scala/releases/download/v2.11.2/scala-docs-2.11.2.zip", "API docs", "72.06M"],
   ["-non-main-sys", "scala-sources-2.11.2.tar.gz", "https://github.com/scala/scala/archive/v2.11.2.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2014-10-30-2.11.4.md
+++ b/_downloads/2014-10-30-2.11.4.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.4.tgz", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.tgz", "Mac OS X, Unix, Cygwin", "25.28M"],
-  ["-main-windows", "scala-2.11.4.msi", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.msi", "Windows (msi installer)", "95.22M"],
-  ["-non-main-sys", "scala-2.11.4.zip", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.zip", "Windows", "25.29M"],
-  ["-non-main-sys", "scala-2.11.4.deb", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.deb", "Debian", "94.18M"],
-  ["-non-main-sys", "scala-2.11.4.rpm", "https://downloads.lightbend.com/scala/2.11.4/scala-2.11.4.rpm", "RPM package", "94.14M"],
-  ["-non-main-sys", "scala-docs-2.11.4.txz", "https://downloads.lightbend.com/scala/2.11.4/scala-docs-2.11.4.txz", "API docs", "40.59M"],
-  ["-non-main-sys", "scala-docs-2.11.4.zip", "https://downloads.lightbend.com/scala/2.11.4/scala-docs-2.11.4.zip", "API docs", "72.24M"],
+  ["-main-unixsys", "scala-2.11.4.tgz", "https://github.com/scala/scala/releases/download/v2.11.4/scala-2.11.4.tgz", "Mac OS X, Unix, Cygwin", "25.28M"],
+  ["-main-windows", "scala-2.11.4.msi", "https://github.com/scala/scala/releases/download/v2.11.4/scala-2.11.4.msi", "Windows (msi installer)", "95.22M"],
+  ["-non-main-sys", "scala-2.11.4.zip", "https://github.com/scala/scala/releases/download/v2.11.4/scala-2.11.4.zip", "Windows", "25.29M"],
+  ["-non-main-sys", "scala-2.11.4.deb", "https://github.com/scala/scala/releases/download/v2.11.4/scala-2.11.4.deb", "Debian", "94.18M"],
+  ["-non-main-sys", "scala-2.11.4.rpm", "https://github.com/scala/scala/releases/download/v2.11.4/scala-2.11.4.rpm", "RPM package", "94.14M"],
+  ["-non-main-sys", "scala-docs-2.11.4.txz", "https://github.com/scala/scala/releases/download/v2.11.4/scala-docs-2.11.4.txz", "API docs", "40.59M"],
+  ["-non-main-sys", "scala-docs-2.11.4.zip", "https://github.com/scala/scala/releases/download/v2.11.4/scala-docs-2.11.4.zip", "API docs", "72.24M"],
   ["-non-main-sys", "scala-sources-2.11.4.tar.gz", "https://github.com/scala/scala/archive/v2.11.4.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-01-14-2.11.5.md
+++ b/_downloads/2015-01-14-2.11.5.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.5.tgz", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.tgz", "Mac OS X, Unix, Cygwin", "25.88M"],
-  ["-main-windows", "scala-2.11.5.msi", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.msi", "Windows (msi installer)", "107.77M"],
-  ["-non-main-sys", "scala-2.11.5.zip", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.zip", "Windows", "25.93M"],
-  ["-non-main-sys", "scala-2.11.5.deb", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.deb", "Debian", "74.62M"],
-  ["-non-main-sys", "scala-2.11.5.rpm", "https://downloads.lightbend.com/scala/2.11.5/scala-2.11.5.rpm", "RPM package", "106.63M"],
-  ["-non-main-sys", "scala-docs-2.11.5.txz", "https://downloads.lightbend.com/scala/2.11.5/scala-docs-2.11.5.txz", "API docs", "45.95M"],
-  ["-non-main-sys", "scala-docs-2.11.5.zip", "https://downloads.lightbend.com/scala/2.11.5/scala-docs-2.11.5.zip", "API docs", "83.94M"],
+  ["-main-unixsys", "scala-2.11.5.tgz", "https://github.com/scala/scala/releases/download/v2.11.5/scala-2.11.5.tgz", "Mac OS X, Unix, Cygwin", "25.88M"],
+  ["-main-windows", "scala-2.11.5.msi", "https://github.com/scala/scala/releases/download/v2.11.5/scala-2.11.5.msi", "Windows (msi installer)", "107.77M"],
+  ["-non-main-sys", "scala-2.11.5.zip", "https://github.com/scala/scala/releases/download/v2.11.5/scala-2.11.5.zip", "Windows", "25.93M"],
+  ["-non-main-sys", "scala-2.11.5.deb", "https://github.com/scala/scala/releases/download/v2.11.5/scala-2.11.5.deb", "Debian", "74.62M"],
+  ["-non-main-sys", "scala-2.11.5.rpm", "https://github.com/scala/scala/releases/download/v2.11.5/scala-2.11.5.rpm", "RPM package", "106.63M"],
+  ["-non-main-sys", "scala-docs-2.11.5.txz", "https://github.com/scala/scala/releases/download/v2.11.5/scala-docs-2.11.5.txz", "API docs", "45.95M"],
+  ["-non-main-sys", "scala-docs-2.11.5.zip", "https://github.com/scala/scala/releases/download/v2.11.5/scala-docs-2.11.5.zip", "API docs", "83.94M"],
   ["-non-main-sys", "scala-sources-2.11.5.tar.gz", "https://github.com/scala/scala/archive/v2.11.5.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-03-05-2.10.5.md
+++ b/_downloads/2015-03-05-2.10.5.md
@@ -9,13 +9,13 @@ permalink: /download/2.10.5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.10.5.tgz", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.tgz", "Mac OS X, Unix, Cygwin", "28.54M"],
-  ["-main-windows", "scala-2.10.5.msi", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.msi", "Windows (msi installer)", "60.02M"],
-  ["-non-main-sys", "scala-2.10.5.zip", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.zip", "Windows", "28.63M"],
-  ["-non-main-sys", "scala-2.10.5.deb", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.deb", "Debian", "24.50M"],
-  ["-non-main-sys", "scala-2.10.5.rpm", "https://downloads.lightbend.com/scala/2.10.5/scala-2.10.5.rpm", "RPM package", "24.86M"],
-  ["-non-main-sys", "scala-docs-2.10.5.txz", "https://downloads.lightbend.com/scala/2.10.5/scala-docs-2.10.5.txz", "API docs", "3.66M"],
-  ["-non-main-sys", "scala-docs-2.10.5.zip", "https://downloads.lightbend.com/scala/2.10.5/scala-docs-2.10.5.zip", "API docs", "32.45M"],
+  ["-main-unixsys", "scala-2.10.5.tgz", "https://github.com/scala/scala/releases/download/v2.10.5/scala-2.10.5.tgz", "Mac OS X, Unix, Cygwin", "28.54M"],
+  ["-main-windows", "scala-2.10.5.msi", "https://github.com/scala/scala/releases/download/v2.10.5/scala-2.10.5.msi", "Windows (msi installer)", "60.02M"],
+  ["-non-main-sys", "scala-2.10.5.zip", "https://github.com/scala/scala/releases/download/v2.10.5/scala-2.10.5.zip", "Windows", "28.63M"],
+  ["-non-main-sys", "scala-2.10.5.deb", "https://github.com/scala/scala/releases/download/v2.10.5/scala-2.10.5.deb", "Debian", "24.50M"],
+  ["-non-main-sys", "scala-2.10.5.rpm", "https://github.com/scala/scala/releases/download/v2.10.5/scala-2.10.5.rpm", "RPM package", "24.86M"],
+  ["-non-main-sys", "scala-docs-2.10.5.txz", "https://github.com/scala/scala/releases/download/v2.10.5/scala-docs-2.10.5.txz", "API docs", "3.66M"],
+  ["-non-main-sys", "scala-docs-2.10.5.zip", "https://github.com/scala/scala/releases/download/v2.10.5/scala-docs-2.10.5.zip", "API docs", "32.45M"],
   ["-non-main-sys", "scala-sources-2.10.5.tar.gz", "https://github.com/scala/scala/archive/v2.10.5.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-03-05-2.11.6.md
+++ b/_downloads/2015-03-05-2.11.6.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.6.tgz", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.tgz", "Mac OS X, Unix, Cygwin", "25.87M"],
-  ["-main-windows", "scala-2.11.6.msi", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.msi", "Windows (msi installer)", "107.88M"],
-  ["-non-main-sys", "scala-2.11.6.zip", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.zip", "Windows", "25.92M"],
-  ["-non-main-sys", "scala-2.11.6.deb", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.deb", "Debian", "74.54M"],
-  ["-non-main-sys", "scala-2.11.6.rpm", "https://downloads.lightbend.com/scala/2.11.6/scala-2.11.6.rpm", "RPM package", "106.73M"],
-  ["-non-main-sys", "scala-docs-2.11.6.txz", "https://downloads.lightbend.com/scala/2.11.6/scala-docs-2.11.6.txz", "API docs", "45.93M"],
-  ["-non-main-sys", "scala-docs-2.11.6.zip", "https://downloads.lightbend.com/scala/2.11.6/scala-docs-2.11.6.zip", "API docs", "84.06M"],
+  ["-main-unixsys", "scala-2.11.6.tgz", "https://github.com/scala/scala/releases/download/v2.11.6/scala-2.11.6.tgz", "Mac OS X, Unix, Cygwin", "25.87M"],
+  ["-main-windows", "scala-2.11.6.msi", "https://github.com/scala/scala/releases/download/v2.11.6/scala-2.11.6.msi", "Windows (msi installer)", "107.88M"],
+  ["-non-main-sys", "scala-2.11.6.zip", "https://github.com/scala/scala/releases/download/v2.11.6/scala-2.11.6.zip", "Windows", "25.92M"],
+  ["-non-main-sys", "scala-2.11.6.deb", "https://github.com/scala/scala/releases/download/v2.11.6/scala-2.11.6.deb", "Debian", "74.54M"],
+  ["-non-main-sys", "scala-2.11.6.rpm", "https://github.com/scala/scala/releases/download/v2.11.6/scala-2.11.6.rpm", "RPM package", "106.73M"],
+  ["-non-main-sys", "scala-docs-2.11.6.txz", "https://github.com/scala/scala/releases/download/v2.11.6/scala-docs-2.11.6.txz", "API docs", "45.93M"],
+  ["-non-main-sys", "scala-docs-2.11.6.zip", "https://github.com/scala/scala/releases/download/v2.11.6/scala-docs-2.11.6.zip", "API docs", "84.06M"],
   ["-non-main-sys", "scala-sources-2.11.6.tar.gz", "https://github.com/scala/scala/archive/v2.11.6.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-05-05-2.12.0-M1.md
+++ b/_downloads/2015-05-05-2.12.0-M1.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-M1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M1.tgz", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.tgz", "Mac OS X, Unix, Cygwin", "23.85M"],
-  ["-main-windows", "scala-2.12.0-M1.msi", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.msi", "Windows (msi installer)", "102.77M"],
-  ["-non-main-sys", "scala-2.12.0-M1.zip", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.zip", "Windows", "23.90M"],
-  ["-non-main-sys", "scala-2.12.0-M1.deb", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.deb", "Debian", "70.35M"],
-  ["-non-main-sys", "scala-2.12.0-M1.rpm", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-2.12.0-M1.rpm", "RPM package", "101.61M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M1.txz", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-docs-2.12.0-M1.txz", "API docs", "43.72M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M1.zip", "https://downloads.lightbend.com/scala/2.12.0-M1/scala-docs-2.12.0-M1.zip", "API docs", "81.12M"],
+  ["-main-unixsys", "scala-2.12.0-M1.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-2.12.0-M1.tgz", "Mac OS X, Unix, Cygwin", "23.85M"],
+  ["-main-windows", "scala-2.12.0-M1.msi", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-2.12.0-M1.msi", "Windows (msi installer)", "102.77M"],
+  ["-non-main-sys", "scala-2.12.0-M1.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-2.12.0-M1.zip", "Windows", "23.90M"],
+  ["-non-main-sys", "scala-2.12.0-M1.deb", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-2.12.0-M1.deb", "Debian", "70.35M"],
+  ["-non-main-sys", "scala-2.12.0-M1.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-2.12.0-M1.rpm", "RPM package", "101.61M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M1.txz", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-docs-2.12.0-M1.txz", "API docs", "43.72M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M1.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M1/scala-docs-2.12.0-M1.zip", "API docs", "81.12M"],
   ["-non-main-sys", "scala-sources-2.12.0-M1.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M1.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-06-23-2.11.7.md
+++ b/_downloads/2015-06-23-2.11.7.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.7.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.7.tgz", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.tgz", "Mac OS X, Unix, Cygwin", "27.14M"],
-  ["-main-windows", "scala-2.11.7.msi", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.msi", "Windows (msi installer)", "110.71M"],
-  ["-non-main-sys", "scala-2.11.7.zip", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.zip", "Windows", "27.19M"],
-  ["-non-main-sys", "scala-2.11.7.deb", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.deb", "Debian", "76.66M"],
-  ["-non-main-sys", "scala-2.11.7.rpm", "https://downloads.lightbend.com/scala/2.11.7/scala-2.11.7.rpm", "RPM package", "109.54M"],
-  ["-non-main-sys", "scala-docs-2.11.7.txz", "https://downloads.lightbend.com/scala/2.11.7/scala-docs-2.11.7.txz", "API docs", "47.05M"],
-  ["-non-main-sys", "scala-docs-2.11.7.zip", "https://downloads.lightbend.com/scala/2.11.7/scala-docs-2.11.7.zip", "API docs", "85.73M"],
+  ["-main-unixsys", "scala-2.11.7.tgz", "https://github.com/scala/scala/releases/download/v2.11.7/scala-2.11.7.tgz", "Mac OS X, Unix, Cygwin", "27.14M"],
+  ["-main-windows", "scala-2.11.7.msi", "https://github.com/scala/scala/releases/download/v2.11.7/scala-2.11.7.msi", "Windows (msi installer)", "110.71M"],
+  ["-non-main-sys", "scala-2.11.7.zip", "https://github.com/scala/scala/releases/download/v2.11.7/scala-2.11.7.zip", "Windows", "27.19M"],
+  ["-non-main-sys", "scala-2.11.7.deb", "https://github.com/scala/scala/releases/download/v2.11.7/scala-2.11.7.deb", "Debian", "76.66M"],
+  ["-non-main-sys", "scala-2.11.7.rpm", "https://github.com/scala/scala/releases/download/v2.11.7/scala-2.11.7.rpm", "RPM package", "109.54M"],
+  ["-non-main-sys", "scala-docs-2.11.7.txz", "https://github.com/scala/scala/releases/download/v2.11.7/scala-docs-2.11.7.txz", "API docs", "47.05M"],
+  ["-non-main-sys", "scala-docs-2.11.7.zip", "https://github.com/scala/scala/releases/download/v2.11.7/scala-docs-2.11.7.zip", "API docs", "85.73M"],
   ["-non-main-sys", "scala-sources-2.11.7.tar.gz", "https://github.com/scala/scala/archive/v2.11.7.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-07-14-2.12.0-M2.md
+++ b/_downloads/2015-07-14-2.12.0-M2.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M2.tgz", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.tgz", "Mac OS X, Unix, Cygwin", "18.68M"],
-  ["-main-windows", "scala-2.12.0-M2.msi", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.msi", "Windows (msi installer)", "96.52M"],
-  ["-non-main-sys", "scala-2.12.0-M2.zip", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.zip", "Windows", "18.73M"],
-  ["-non-main-sys", "scala-2.12.0-M2.deb", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.deb", "Debian", "64.52M"],
-  ["-non-main-sys", "scala-2.12.0-M2.rpm", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-2.12.0-M2.rpm", "RPM package", "95.31M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M2.txz", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-docs-2.12.0-M2.txz", "API docs", "42.95M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M2.zip", "https://downloads.lightbend.com/scala/2.12.0-M2/scala-docs-2.12.0-M2.zip", "API docs", "80.11M"],
+  ["-main-unixsys", "scala-2.12.0-M2.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-2.12.0-M2.tgz", "Mac OS X, Unix, Cygwin", "18.68M"],
+  ["-main-windows", "scala-2.12.0-M2.msi", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-2.12.0-M2.msi", "Windows (msi installer)", "96.52M"],
+  ["-non-main-sys", "scala-2.12.0-M2.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-2.12.0-M2.zip", "Windows", "18.73M"],
+  ["-non-main-sys", "scala-2.12.0-M2.deb", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-2.12.0-M2.deb", "Debian", "64.52M"],
+  ["-non-main-sys", "scala-2.12.0-M2.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-2.12.0-M2.rpm", "RPM package", "95.31M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M2.txz", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-docs-2.12.0-M2.txz", "API docs", "42.95M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M2.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M2/scala-docs-2.12.0-M2.zip", "API docs", "80.11M"],
   ["-non-main-sys", "scala-sources-2.12.0-M2.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M2.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-09-18-2.10.6.md
+++ b/_downloads/2015-09-18-2.10.6.md
@@ -9,13 +9,13 @@ permalink: /download/2.10.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.10.6.tgz", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.tgz", "Max OS X, Unix, Cygwin", "28.54M"],
-  ["-main-windows", "scala.msi", "https://downloads.lightbend.com/scala/2.10.6/scala.msi", "Windows (msi installer)", "58.50M"],
-  ["-non-main-sys", "scala-2.10.6.zip", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.zip", "Windows", "28.63M"],
-  ["-non-main-sys", "scala-2.10.6.deb", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.deb", "Debian", "24.50M"],
-  ["-non-main-sys", "scala-2.10.6.rpm", "https://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.rpm", "RPM package", "24.86M"],
-  ["-non-main-sys", "scala-docs-2.10.6.txz", "https://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.txz", "API docs", "3.27M"],
-  ["-non-main-sys", "scala-docs-2.10.6.zip", "https://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.zip", "API docs", "30.94M"],
+  ["-main-unixsys", "scala-2.10.6.tgz", "https://github.com/scala/scala/releases/download/v2.10.6/scala-2.10.6.tgz", "Max OS X, Unix, Cygwin", "28.54M"],
+  ["-main-windows", "scala-2.10.6.msi", "https://github.com/scala/scala/releases/download/v2.10.6/scala-2.10.6.msi", "Windows (msi installer)", "58.50M"],
+  ["-non-main-sys", "scala-2.10.6.zip", "https://github.com/scala/scala/releases/download/v2.10.6/scala-2.10.6.zip", "Windows", "28.63M"],
+  ["-non-main-sys", "scala-2.10.6.deb", "https://github.com/scala/scala/releases/download/v2.10.6/scala-2.10.6.deb", "Debian", "24.50M"],
+  ["-non-main-sys", "scala-2.10.6.rpm", "https://github.com/scala/scala/releases/download/v2.10.6/scala-2.10.6.rpm", "RPM package", "24.86M"],
+  ["-non-main-sys", "scala-docs-2.10.6.txz", "https://github.com/scala/scala/releases/download/v2.10.6/scala-docs-2.10.6.txz", "API docs", "3.27M"],
+  ["-non-main-sys", "scala-docs-2.10.6.zip", "https://github.com/scala/scala/releases/download/v2.10.6/scala-docs-2.10.6.zip", "API docs", "30.94M"],
   ["-non-main-sys", "scala-sources-2.10.6.tar.gz", "https://github.com/scala/scala/archive/v2.10.6.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2015-10-06-2.12.0-M3.md
+++ b/_downloads/2015-10-06-2.12.0-M3.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M3.tgz", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.tgz", "Mac OS X, Unix, Cygwin", "19.97M"],
-  ["-main-windows", "scala-2.12.0-M3.msi", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.msi", "Windows (msi installer)", "97.75M"],
-  ["-non-main-sys", "scala-2.12.0-M3.zip", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.zip", "Windows", "20.01M"],
-  ["-non-main-sys", "scala-2.12.0-M3.deb", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.deb", "Debian", "65.62M"],
-  ["-non-main-sys", "scala-2.12.0-M3.rpm", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-2.12.0-M3.rpm", "RPM package", "96.55M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M3.txz", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-docs-2.12.0-M3.txz", "API docs", "42.99M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M3.zip", "https://downloads.lightbend.com/scala/2.12.0-M3/scala-docs-2.12.0-M3.zip", "API docs", "80.08M"],
+  ["-main-unixsys", "scala-2.12.0-M3.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-2.12.0-M3.tgz", "Mac OS X, Unix, Cygwin", "19.97M"],
+  ["-main-windows", "scala-2.12.0-M3.msi", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-2.12.0-M3.msi", "Windows (msi installer)", "97.75M"],
+  ["-non-main-sys", "scala-2.12.0-M3.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-2.12.0-M3.zip", "Windows", "20.01M"],
+  ["-non-main-sys", "scala-2.12.0-M3.deb", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-2.12.0-M3.deb", "Debian", "65.62M"],
+  ["-non-main-sys", "scala-2.12.0-M3.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-2.12.0-M3.rpm", "RPM package", "96.55M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M3.txz", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-docs-2.12.0-M3.txz", "API docs", "42.99M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M3.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M3/scala-docs-2.12.0-M3.zip", "API docs", "80.08M"],
   ["-non-main-sys", "scala-sources-2.12.0-M3.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M3.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-03-08-2.11.8.md
+++ b/_downloads/2016-03-08-2.11.8.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.8.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.8.tgz", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.tgz", "Mac OS X, Unix, Cygwin", "27.35M"],
-  ["-main-windows", "scala-2.11.8.msi", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.msi", "Windows (msi installer)", "109.35M"],
-  ["-non-main-sys", "scala-2.11.8.zip", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.zip", "Windows", "27.40M"],
-  ["-non-main-sys", "scala-2.11.8.deb", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.deb", "Debian", "76.02M"],
-  ["-non-main-sys", "scala-2.11.8.rpm", "https://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.rpm", "RPM package", "108.16M"],
-  ["-non-main-sys", "scala-docs-2.11.8.txz", "https://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.txz", "API docs", "46.00M"],
-  ["-non-main-sys", "scala-docs-2.11.8.zip", "https://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.zip", "API docs", "84.21M"],
+  ["-main-unixsys", "scala-2.11.8.tgz", "https://github.com/scala/scala/releases/download/v2.11.8/scala-2.11.8.tgz", "Mac OS X, Unix, Cygwin", "27.35M"],
+  ["-main-windows", "scala-2.11.8.msi", "https://github.com/scala/scala/releases/download/v2.11.8/scala-2.11.8.msi", "Windows (msi installer)", "109.35M"],
+  ["-non-main-sys", "scala-2.11.8.zip", "https://github.com/scala/scala/releases/download/v2.11.8/scala-2.11.8.zip", "Windows", "27.40M"],
+  ["-non-main-sys", "scala-2.11.8.deb", "https://github.com/scala/scala/releases/download/v2.11.8/scala-2.11.8.deb", "Debian", "76.02M"],
+  ["-non-main-sys", "scala-2.11.8.rpm", "https://github.com/scala/scala/releases/download/v2.11.8/scala-2.11.8.rpm", "RPM package", "108.16M"],
+  ["-non-main-sys", "scala-docs-2.11.8.txz", "https://github.com/scala/scala/releases/download/v2.11.8/scala-docs-2.11.8.txz", "API docs", "46.00M"],
+  ["-non-main-sys", "scala-docs-2.11.8.zip", "https://github.com/scala/scala/releases/download/v2.11.8/scala-docs-2.11.8.zip", "API docs", "84.21M"],
   ["-non-main-sys", "scala-sources-2.11.8.tar.gz", "https://github.com/scala/scala/archive/v2.11.8.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-04-11-2.12.0-M4.md
+++ b/_downloads/2016-04-11-2.12.0-M4.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M4.tgz", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.tgz", "Mac OS X, Unix, Cygwin", "18.04M"],
-  ["-main-windows", "scala-2.12.0-M4.msi", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.msi", "Windows (msi installer)", "121.31M"],
-  ["-non-main-sys", "scala-2.12.0-M4.zip", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.zip", "Windows", "18.08M"],
-  ["-non-main-sys", "scala-2.12.0-M4.deb", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.deb", "Debian", "139.42M"],
-  ["-non-main-sys", "scala-2.12.0-M4.rpm", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-2.12.0-M4.rpm", "RPM package", "120.90M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M4.txz", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-docs-2.12.0-M4.txz", "API docs", "52.77M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M4.zip", "https://downloads.lightbend.com/scala/2.12.0-M4/scala-docs-2.12.0-M4.zip", "API docs", "105.18M"],
+  ["-main-unixsys", "scala-2.12.0-M4.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-2.12.0-M4.tgz", "Mac OS X, Unix, Cygwin", "18.04M"],
+  ["-main-windows", "scala-2.12.0-M4.msi", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-2.12.0-M4.msi", "Windows (msi installer)", "121.31M"],
+  ["-non-main-sys", "scala-2.12.0-M4.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-2.12.0-M4.zip", "Windows", "18.08M"],
+  ["-non-main-sys", "scala-2.12.0-M4.deb", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-2.12.0-M4.deb", "Debian", "139.42M"],
+  ["-non-main-sys", "scala-2.12.0-M4.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-2.12.0-M4.rpm", "RPM package", "120.90M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M4.txz", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-docs-2.12.0-M4.txz", "API docs", "52.77M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M4.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M4/scala-docs-2.12.0-M4.zip", "API docs", "105.18M"],
   ["-non-main-sys", "scala-sources-2.12.0-M4.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M4.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-06-29-2.12.0-M5.md
+++ b/_downloads/2016-06-29-2.12.0-M5.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-M5.tgz", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.tgz", "Mac OS X, Unix, Cygwin", "17.53M"],
-  ["-main-windows", "scala-2.12.0-M5.msi", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.msi", "Windows (msi installer)", "120.72M"],
-  ["-non-main-sys", "scala-2.12.0-M5.zip", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.zip", "Windows", "17.57M"],
-  ["-non-main-sys", "scala-2.12.0-M5.deb", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.deb", "Debian", "138.34M"],
-  ["-non-main-sys", "scala-2.12.0-M5.rpm", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-2.12.0-M5.rpm", "RPM package", "120.32M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M5.txz", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-docs-2.12.0-M5.txz", "API docs", "52.64M"],
-  ["-non-main-sys", "scala-docs-2.12.0-M5.zip", "https://downloads.lightbend.com/scala/2.12.0-M5/scala-docs-2.12.0-M5.zip", "API docs", "105.09M"],
+  ["-main-unixsys", "scala-2.12.0-M5.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-2.12.0-M5.tgz", "Mac OS X, Unix, Cygwin", "17.53M"],
+  ["-main-windows", "scala-2.12.0-M5.msi", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-2.12.0-M5.msi", "Windows (msi installer)", "120.72M"],
+  ["-non-main-sys", "scala-2.12.0-M5.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-2.12.0-M5.zip", "Windows", "17.57M"],
+  ["-non-main-sys", "scala-2.12.0-M5.deb", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-2.12.0-M5.deb", "Debian", "138.34M"],
+  ["-non-main-sys", "scala-2.12.0-M5.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-2.12.0-M5.rpm", "RPM package", "120.32M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M5.txz", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-docs-2.12.0-M5.txz", "API docs", "52.64M"],
+  ["-non-main-sys", "scala-docs-2.12.0-M5.zip", "https://github.com/scala/scala/releases/download/v2.12.0-M5/scala-docs-2.12.0-M5.zip", "API docs", "105.09M"],
   ["-non-main-sys", "scala-sources-2.12.0-M5.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-M5.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-09-06-2.12.0-RC1.md
+++ b/_downloads/2016-09-06-2.12.0-RC1.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "17.65M"],
-  ["-main-windows", "scala-2.12.0-RC1.msi", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.msi", "Windows (msi installer)", "116.21M"],
-  ["-non-main-sys", "scala-2.12.0-RC1.zip", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.zip", "Windows", "17.69M"],
-  ["-non-main-sys", "scala-2.12.0-RC1.deb", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.deb", "Debian", "133.97M"],
-  ["-non-main-sys", "scala-2.12.0-RC1.rpm", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-2.12.0-RC1.rpm", "RPM package", "115.82M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC1.txz", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-docs-2.12.0-RC1.txz", "API docs", "50.75M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC1.zip", "https://downloads.lightbend.com/scala/2.12.0-RC1/scala-docs-2.12.0-RC1.zip", "API docs", "100.45M"],
+  ["-main-unixsys", "scala-2.12.0-RC1.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-2.12.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "17.65M"],
+  ["-main-windows", "scala-2.12.0-RC1.msi", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-2.12.0-RC1.msi", "Windows (msi installer)", "116.21M"],
+  ["-non-main-sys", "scala-2.12.0-RC1.zip", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-2.12.0-RC1.zip", "Windows", "17.69M"],
+  ["-non-main-sys", "scala-2.12.0-RC1.deb", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-2.12.0-RC1.deb", "Debian", "133.97M"],
+  ["-non-main-sys", "scala-2.12.0-RC1.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-2.12.0-RC1.rpm", "RPM package", "115.82M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC1.txz", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-docs-2.12.0-RC1.txz", "API docs", "50.75M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC1.zip", "https://github.com/scala/scala/releases/download/v2.12.0-RC1/scala-docs-2.12.0-RC1.zip", "API docs", "100.45M"],
   ["-non-main-sys", "scala-sources-2.12.0-RC1.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-RC1.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-10-18-2.12.0-RC2.md
+++ b/_downloads/2016-10-18-2.12.0-RC2.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.0-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.12.0-RC2.tgz", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
-  ["-main-windows", "scala-2.12.0-RC2.msi", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.msi", "Windows (msi installer)", "117.88M"],
-  ["-non-main-sys", "scala-2.12.0-RC2.zip", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.zip", "Windows", "19.28M"],
-  ["-non-main-sys", "scala-2.12.0-RC2.deb", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.deb", "Debian", "137.24M"],
-  ["-non-main-sys", "scala-2.12.0-RC2.rpm", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-2.12.0-RC2.rpm", "RPM package", "117.49M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC2.txz", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-docs-2.12.0-RC2.txz", "API docs", "50.79M"],
-  ["-non-main-sys", "scala-docs-2.12.0-RC2.zip", "https://downloads.lightbend.com/scala/2.12.0-RC2/scala-docs-2.12.0-RC2.zip", "API docs", "100.52M"],
+  ["-main-unixsys", "scala-2.12.0-RC2.tgz", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-2.12.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
+  ["-main-windows", "scala-2.12.0-RC2.msi", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-2.12.0-RC2.msi", "Windows (msi installer)", "117.88M"],
+  ["-non-main-sys", "scala-2.12.0-RC2.zip", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-2.12.0-RC2.zip", "Windows", "19.28M"],
+  ["-non-main-sys", "scala-2.12.0-RC2.deb", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-2.12.0-RC2.deb", "Debian", "137.24M"],
+  ["-non-main-sys", "scala-2.12.0-RC2.rpm", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-2.12.0-RC2.rpm", "RPM package", "117.49M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC2.txz", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-docs-2.12.0-RC2.txz", "API docs", "50.79M"],
+  ["-non-main-sys", "scala-docs-2.12.0-RC2.zip", "https://github.com/scala/scala/releases/download/v2.12.0-RC2/scala-docs-2.12.0-RC2.zip", "API docs", "100.52M"],
   ["-non-main-sys", "scala-sources-2.12.0-RC2.tar.gz", "https://github.com/scala/scala/archive/v2.12.0-RC2.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-11-03-2.12.0.md
+++ b/_downloads/2016-11-03-2.12.0.md
@@ -10,13 +10,13 @@ requirements: "Scala 2.12 requires version 8 of the Java platform, as provided b
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.0/
 resources: [
-  ["-main-unixsys", "scala-2.12.0.tgz", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
-  ["-main-windows", "scala-2.12.0.msi", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.msi", "Windows (msi installer)", "117.78M"],
-  ["-non-main-sys", "scala-2.12.0.zip", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.zip", "Windows", "19.28M"],
-  ["-non-main-sys", "scala-2.12.0.deb", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.deb", "Debian", "137.14M"],
-  ["-non-main-sys", "scala-2.12.0.rpm", "https://downloads.lightbend.com/scala/2.12.0/scala-2.12.0.rpm", "RPM package", "117.39M"],
-  ["-non-main-sys", "scala-docs-2.12.0.txz", "https://downloads.lightbend.com/scala/2.12.0/scala-docs-2.12.0.txz", "API docs", "50.74M"],
-  ["-non-main-sys", "scala-docs-2.12.0.zip", "https://downloads.lightbend.com/scala/2.12.0/scala-docs-2.12.0.zip", "API docs", "100.40M"],
+  ["-main-unixsys", "scala-2.12.0.tgz", "https://github.com/scala/scala/releases/download/v2.12.0/scala-2.12.0.tgz", "Mac OS X, Unix, Cygwin", "19.24M"],
+  ["-main-windows", "scala-2.12.0.msi", "https://github.com/scala/scala/releases/download/v2.12.0/scala-2.12.0.msi", "Windows (msi installer)", "117.78M"],
+  ["-non-main-sys", "scala-2.12.0.zip", "https://github.com/scala/scala/releases/download/v2.12.0/scala-2.12.0.zip", "Windows", "19.28M"],
+  ["-non-main-sys", "scala-2.12.0.deb", "https://github.com/scala/scala/releases/download/v2.12.0/scala-2.12.0.deb", "Debian", "137.14M"],
+  ["-non-main-sys", "scala-2.12.0.rpm", "https://github.com/scala/scala/releases/download/v2.12.0/scala-2.12.0.rpm", "RPM package", "117.39M"],
+  ["-non-main-sys", "scala-docs-2.12.0.txz", "https://github.com/scala/scala/releases/download/v2.12.0/scala-docs-2.12.0.txz", "API docs", "50.74M"],
+  ["-non-main-sys", "scala-docs-2.12.0.zip", "https://github.com/scala/scala/releases/download/v2.12.0/scala-docs-2.12.0.zip", "API docs", "100.40M"],
   ["-non-main-sys", "scala-sources-2.12.0.tar.gz", "https://github.com/scala/scala/archive/v2.12.0.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2016-12-05-2.12.1.md
+++ b/_downloads/2016-12-05-2.12.1.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.1/
 resources: [
-  ["-main-unixsys", "scala-2.12.1.tgz", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
-  ["-main-windows", "scala-2.12.1.msi", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],
-  ["-non-main-sys", "scala-2.12.1.zip", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.zip", "Windows", "18.83M"],
-  ["-non-main-sys", "scala-2.12.1.deb", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.deb", "Debian", "144.65M"],
-  ["-non-main-sys", "scala-2.12.1.rpm", "https://downloads.lightbend.com/scala/2.12.1/scala-2.12.1.rpm", "RPM package", "125.29M"],
-  ["-non-main-sys", "scala-docs-2.12.1.txz", "https://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.txz", "API docs", "55.89M"],
-  ["-non-main-sys", "scala-docs-2.12.1.zip", "https://downloads.lightbend.com/scala/2.12.1/scala-docs-2.12.1.zip", "API docs", "109.10M"],
+  ["-main-unixsys", "scala-2.12.1.tgz", "https://github.com/scala/scala/releases/download/v2.12.1/scala-2.12.1.tgz", "Mac OS X, Unix, Cygwin", "18.79M"],
+  ["-main-windows", "scala-2.12.1.msi", "https://github.com/scala/scala/releases/download/v2.12.1/scala-2.12.1.msi", "Windows (msi installer)", "125.84M"],
+  ["-non-main-sys", "scala-2.12.1.zip", "https://github.com/scala/scala/releases/download/v2.12.1/scala-2.12.1.zip", "Windows", "18.83M"],
+  ["-non-main-sys", "scala-2.12.1.deb", "https://github.com/scala/scala/releases/download/v2.12.1/scala-2.12.1.deb", "Debian", "144.65M"],
+  ["-non-main-sys", "scala-2.12.1.rpm", "https://github.com/scala/scala/releases/download/v2.12.1/scala-2.12.1.rpm", "RPM package", "125.29M"],
+  ["-non-main-sys", "scala-docs-2.12.1.txz", "https://github.com/scala/scala/releases/download/v2.12.1/scala-docs-2.12.1.txz", "API docs", "55.89M"],
+  ["-non-main-sys", "scala-docs-2.12.1.zip", "https://github.com/scala/scala/releases/download/v2.12.1/scala-docs-2.12.1.zip", "API docs", "109.10M"],
   ["-non-main-sys", "scala-sources-2.12.1.tar.gz", "https://github.com/scala/scala/archive/v2.12.1.tar.gz", "Sources", "5.99M"]
 ]
 ---

--- a/_downloads/2017-04-17-2.13.0-M1.md
+++ b/_downloads/2017-04-17-2.13.0-M1.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-M1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.8 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-M1.tgz", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.tgz", "Mac OS X, Unix, Cygwin", "16.95M"],
-  ["-main-windows", "scala-2.13.0-M1.msi", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.msi", "Windows (msi installer)", "112.80M"],
-  ["-non-main-sys", "scala-2.13.0-M1.zip", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.zip", "Windows", "16.99M"],
-  ["-non-main-sys", "scala-2.13.0-M1.deb", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.deb", "Debian", "129.84M"],
-  ["-non-main-sys", "scala-2.13.0-M1.rpm", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-2.13.0-M1.rpm", "RPM package", "112.38M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M1.txz", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-docs-2.13.0-M1.txz", "API docs", "50.57M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M1.zip", "https://downloads.lightbend.com/scala/2.13.0-M1/scala-docs-2.13.0-M1.zip", "API docs", "97.90M"],
+  ["-main-unixsys", "scala-2.13.0-M1.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-2.13.0-M1.tgz", "Mac OS X, Unix, Cygwin", "16.95M"],
+  ["-main-windows", "scala-2.13.0-M1.msi", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-2.13.0-M1.msi", "Windows (msi installer)", "112.80M"],
+  ["-non-main-sys", "scala-2.13.0-M1.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-2.13.0-M1.zip", "Windows", "16.99M"],
+  ["-non-main-sys", "scala-2.13.0-M1.deb", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-2.13.0-M1.deb", "Debian", "129.84M"],
+  ["-non-main-sys", "scala-2.13.0-M1.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-2.13.0-M1.rpm", "RPM package", "112.38M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M1.txz", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-docs-2.13.0-M1.txz", "API docs", "50.57M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M1.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M1/scala-docs-2.13.0-M1.zip", "API docs", "97.90M"],
   ["-non-main-sys", "scala-sources-2.13.0-M1.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-M1.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-04-18-2.11.11.md
+++ b/_downloads/2017-04-18-2.11.11.md
@@ -9,13 +9,13 @@ permalink: /download/2.11.11.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires the Java runtime version 1.6 or later, which can be downloaded <a href='https://www.java.com/'>here</a>."
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 resources: [
-  ["-main-unixsys", "scala-2.11.11.tgz", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz", "Mac OS X, Unix, Cygwin", "27.74M"],
-  ["-main-windows", "scala-2.11.11.msi", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.msi", "Windows (msi installer)", "110.04M"],
-  ["-non-main-sys", "scala-2.11.11.zip", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.zip", "Windows", "27.79M"],
-  ["-non-main-sys", "scala-2.11.11.deb", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.deb", "Debian", "76.61M"],
-  ["-non-main-sys", "scala-2.11.11.rpm", "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.rpm", "RPM package", "108.81M"],
-  ["-non-main-sys", "scala-docs-2.11.11.txz", "https://downloads.lightbend.com/scala/2.11.11/scala-docs-2.11.11.txz", "API docs", "46.35M"],
-  ["-non-main-sys", "scala-docs-2.11.11.zip", "https://downloads.lightbend.com/scala/2.11.11/scala-docs-2.11.11.zip", "API docs", "84.49M"],
+  ["-main-unixsys", "scala-2.11.11.tgz", "https://github.com/scala/scala/releases/download/v2.11.11/scala-2.11.11.tgz", "Mac OS X, Unix, Cygwin", "27.74M"],
+  ["-main-windows", "scala-2.11.11.msi", "https://github.com/scala/scala/releases/download/v2.11.11/scala-2.11.11.msi", "Windows (msi installer)", "110.04M"],
+  ["-non-main-sys", "scala-2.11.11.zip", "https://github.com/scala/scala/releases/download/v2.11.11/scala-2.11.11.zip", "Windows", "27.79M"],
+  ["-non-main-sys", "scala-2.11.11.deb", "https://github.com/scala/scala/releases/download/v2.11.11/scala-2.11.11.deb", "Debian", "76.61M"],
+  ["-non-main-sys", "scala-2.11.11.rpm", "https://github.com/scala/scala/releases/download/v2.11.11/scala-2.11.11.rpm", "RPM package", "108.81M"],
+  ["-non-main-sys", "scala-docs-2.11.11.txz", "https://github.com/scala/scala/releases/download/v2.11.11/scala-docs-2.11.11.txz", "API docs", "46.35M"],
+  ["-non-main-sys", "scala-docs-2.11.11.zip", "https://github.com/scala/scala/releases/download/v2.11.11/scala-docs-2.11.11.zip", "API docs", "84.49M"],
   ["-non-main-sys", "scala-sources-2.11.11.tar.gz", "https://github.com/scala/scala/archive/v2.11.11.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-04-18-2.12.2.md
+++ b/_downloads/2017-04-18-2.12.2.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.2/
 resources: [
-  ["-main-unixsys", "scala-2.12.2.tgz", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.tgz", "Mac OS X, Unix, Cygwin", "18.69M"],
-  ["-main-windows", "scala-2.12.2.msi", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.msi", "Windows (msi installer)", "126.44M"],
-  ["-non-main-sys", "scala-2.12.2.zip", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.zip", "Windows", "18.73M"],
-  ["-non-main-sys", "scala-2.12.2.deb", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.deb", "Debian", "145.14M"],
-  ["-non-main-sys", "scala-2.12.2.rpm", "https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.rpm", "RPM package", "125.88M"],
-  ["-non-main-sys", "scala-docs-2.12.2.txz", "https://downloads.lightbend.com/scala/2.12.2/scala-docs-2.12.2.txz", "API docs", "56.51M"],
-  ["-non-main-sys", "scala-docs-2.12.2.zip", "https://downloads.lightbend.com/scala/2.12.2/scala-docs-2.12.2.zip", "API docs", "109.80M"],
+  ["-main-unixsys", "scala-2.12.2.tgz", "https://github.com/scala/scala/releases/download/v2.12.2/scala-2.12.2.tgz", "Mac OS X, Unix, Cygwin", "18.69M"],
+  ["-main-windows", "scala-2.12.2.msi", "https://github.com/scala/scala/releases/download/v2.12.2/scala-2.12.2.msi", "Windows (msi installer)", "126.44M"],
+  ["-non-main-sys", "scala-2.12.2.zip", "https://github.com/scala/scala/releases/download/v2.12.2/scala-2.12.2.zip", "Windows", "18.73M"],
+  ["-non-main-sys", "scala-2.12.2.deb", "https://github.com/scala/scala/releases/download/v2.12.2/scala-2.12.2.deb", "Debian", "145.14M"],
+  ["-non-main-sys", "scala-2.12.2.rpm", "https://github.com/scala/scala/releases/download/v2.12.2/scala-2.12.2.rpm", "RPM package", "125.88M"],
+  ["-non-main-sys", "scala-docs-2.12.2.txz", "https://github.com/scala/scala/releases/download/v2.12.2/scala-docs-2.12.2.txz", "API docs", "56.51M"],
+  ["-non-main-sys", "scala-docs-2.12.2.zip", "https://github.com/scala/scala/releases/download/v2.12.2/scala-docs-2.12.2.zip", "API docs", "109.80M"],
   ["-non-main-sys", "scala-sources-2.12.2.tar.gz", "https://github.com/scala/scala/archive/v2.12.2.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-07-26-2.12.3.md
+++ b/_downloads/2017-07-26-2.12.3.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.3/
 resources: [
-  ["-main-unixsys", "scala-2.12.3.tgz", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.tgz", "Mac OS X, Unix, Cygwin", "18.85M"],
-  ["-main-windows", "scala-2.12.3.msi", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.msi", "Windows (msi installer)", "126.93M"],
-  ["-non-main-sys", "scala-2.12.3.zip", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.zip", "Windows", "18.89M"],
-  ["-non-main-sys", "scala-2.12.3.deb", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.deb", "Debian", "145.78M"],
-  ["-non-main-sys", "scala-2.12.3.rpm", "https://downloads.lightbend.com/scala/2.12.3/scala-2.12.3.rpm", "RPM package", "126.36M"],
-  ["-non-main-sys", "scala-docs-2.12.3.txz", "https://downloads.lightbend.com/scala/2.12.3/scala-docs-2.12.3.txz", "API docs", "56.64M"],
-  ["-non-main-sys", "scala-docs-2.12.3.zip", "https://downloads.lightbend.com/scala/2.12.3/scala-docs-2.12.3.zip", "API docs", "110.14M"],
+  ["-main-unixsys", "scala-2.12.3.tgz", "https://github.com/scala/scala/releases/download/v2.12.3/scala-2.12.3.tgz", "Mac OS X, Unix, Cygwin", "18.85M"],
+  ["-main-windows", "scala-2.12.3.msi", "https://github.com/scala/scala/releases/download/v2.12.3/scala-2.12.3.msi", "Windows (msi installer)", "126.93M"],
+  ["-non-main-sys", "scala-2.12.3.zip", "https://github.com/scala/scala/releases/download/v2.12.3/scala-2.12.3.zip", "Windows", "18.89M"],
+  ["-non-main-sys", "scala-2.12.3.deb", "https://github.com/scala/scala/releases/download/v2.12.3/scala-2.12.3.deb", "Debian", "145.78M"],
+  ["-non-main-sys", "scala-2.12.3.rpm", "https://github.com/scala/scala/releases/download/v2.12.3/scala-2.12.3.rpm", "RPM package", "126.36M"],
+  ["-non-main-sys", "scala-docs-2.12.3.txz", "https://github.com/scala/scala/releases/download/v2.12.3/scala-docs-2.12.3.txz", "API docs", "56.64M"],
+  ["-non-main-sys", "scala-docs-2.12.3.zip", "https://github.com/scala/scala/releases/download/v2.12.3/scala-docs-2.12.3.zip", "API docs", "110.14M"],
   ["-non-main-sys", "scala-sources-2.12.3.tar.gz", "https://github.com/scala/scala/archive/v2.12.3.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-08-08-2.13.0-M2.md
+++ b/_downloads/2017-08-08-2.13.0-M2.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-M2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-M2.tgz", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.tgz", "Mac OS X, Unix, Cygwin", "16.85M"],
-  ["-main-windows", "scala-2.13.0-M2.msi", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.msi", "Windows (msi installer)", "111.91M"],
-  ["-non-main-sys", "scala-2.13.0-M2.zip", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.zip", "Windows", "16.89M"],
-  ["-non-main-sys", "scala-2.13.0-M2.deb", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.deb", "Debian", "128.86M"],
-  ["-non-main-sys", "scala-2.13.0-M2.rpm", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.rpm", "RPM package", "111.50M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M2.txz", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-docs-2.13.0-M2.txz", "API docs", "50.13M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M2.zip", "https://downloads.lightbend.com/scala/2.13.0-M2/scala-docs-2.13.0-M2.zip", "API docs", "97.10M"],
+  ["-main-unixsys", "scala-2.13.0-M2.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-2.13.0-M2.tgz", "Mac OS X, Unix, Cygwin", "16.85M"],
+  ["-main-windows", "scala-2.13.0-M2.msi", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-2.13.0-M2.msi", "Windows (msi installer)", "111.91M"],
+  ["-non-main-sys", "scala-2.13.0-M2.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-2.13.0-M2.zip", "Windows", "16.89M"],
+  ["-non-main-sys", "scala-2.13.0-M2.deb", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-2.13.0-M2.deb", "Debian", "128.86M"],
+  ["-non-main-sys", "scala-2.13.0-M2.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-2.13.0-M2.rpm", "RPM package", "111.50M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M2.txz", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-docs-2.13.0-M2.txz", "API docs", "50.13M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M2.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M2/scala-docs-2.13.0-M2.zip", "API docs", "97.10M"],
   ["-non-main-sys", "scala-sources-2.13.0-M2.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-M2.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-10-17-2.12.4.md
+++ b/_downloads/2017-10-17-2.12.4.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.4/
 resources: [
-  ["-main-unixsys", "scala-2.12.4.tgz", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.tgz", "Mac OS X, Unix, Cygwin", "18.83M"],
-  ["-main-windows", "scala-2.12.4.msi", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.msi", "Windows (msi installer)", "126.38M"],
-  ["-non-main-sys", "scala-2.12.4.zip", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.zip", "Windows", "18.87M"],
-  ["-non-main-sys", "scala-2.12.4.deb", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.deb", "Debian", "145.23M"],
-  ["-non-main-sys", "scala-2.12.4.rpm", "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.rpm", "RPM package", "125.81M"],
-  ["-non-main-sys", "scala-docs-2.12.4.txz", "https://downloads.lightbend.com/scala/2.12.4/scala-docs-2.12.4.txz", "API docs", "56.52M"],
-  ["-non-main-sys", "scala-docs-2.12.4.zip", "https://downloads.lightbend.com/scala/2.12.4/scala-docs-2.12.4.zip", "API docs", "109.65M"],
+  ["-main-unixsys", "scala-2.12.4.tgz", "https://github.com/scala/scala/releases/download/v2.12.4/scala-2.12.4.tgz", "Mac OS X, Unix, Cygwin", "18.83M"],
+  ["-main-windows", "scala-2.12.4.msi", "https://github.com/scala/scala/releases/download/v2.12.4/scala-2.12.4.msi", "Windows (msi installer)", "126.38M"],
+  ["-non-main-sys", "scala-2.12.4.zip", "https://github.com/scala/scala/releases/download/v2.12.4/scala-2.12.4.zip", "Windows", "18.87M"],
+  ["-non-main-sys", "scala-2.12.4.deb", "https://github.com/scala/scala/releases/download/v2.12.4/scala-2.12.4.deb", "Debian", "145.23M"],
+  ["-non-main-sys", "scala-2.12.4.rpm", "https://github.com/scala/scala/releases/download/v2.12.4/scala-2.12.4.rpm", "RPM package", "125.81M"],
+  ["-non-main-sys", "scala-docs-2.12.4.txz", "https://github.com/scala/scala/releases/download/v2.12.4/scala-docs-2.12.4.txz", "API docs", "56.52M"],
+  ["-non-main-sys", "scala-docs-2.12.4.zip", "https://github.com/scala/scala/releases/download/v2.12.4/scala-docs-2.12.4.zip", "API docs", "109.65M"],
   ["-non-main-sys", "scala-sources-2.12.4.tar.gz", "https://github.com/scala/scala/archive/v2.12.4.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-11-09-2.10.7.md
+++ b/_downloads/2017-11-09-2.10.7.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.10.7/
 resources: [
-  ["-main-unixsys", "scala-2.10.7.tgz", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.tgz", "Mac OS X, Unix, Cygwin", "28.60M"],
-  ["-main-windows", "scala.msi", "https://downloads.lightbend.com/scala/2.10.7/scala.msi", "Windows (msi installer)", "58.58M"],
-  ["-non-main-sys", "scala-2.10.7.zip", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.zip", "Windows", "28.70M"],
-  ["-non-main-sys", "scala-2.10.7.deb", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.deb", "Debian", "24.56M"],
-  ["-non-main-sys", "scala-2.10.7.rpm", "https://downloads.lightbend.com/scala/2.10.7/scala-2.10.7.rpm", "RPM package", "24.93M"],
-  ["-non-main-sys", "scala-docs-2.10.7.txz", "https://downloads.lightbend.com/scala/2.10.7/scala-docs-2.10.7.txz", "API docs", "3.25M"],
-  ["-non-main-sys", "scala-docs-2.10.7.zip", "https://downloads.lightbend.com/scala/2.10.7/scala-docs-2.10.7.zip", "API docs", "30.95M"],
+  ["-main-unixsys", "scala-2.10.7.tgz", "https://github.com/scala/scala/releases/download/v2.10.7/scala-2.10.7.tgz", "Mac OS X, Unix, Cygwin", "28.60M"],
+  ["-main-windows", "scala-2.10.7.msi", "https://github.com/scala/scala/releases/download/v2.10.7/scala-2.10.7.msi", "Windows (msi installer)", "58.58M"],
+  ["-non-main-sys", "scala-2.10.7.zip", "https://github.com/scala/scala/releases/download/v2.10.7/scala-2.10.7.zip", "Windows", "28.70M"],
+  ["-non-main-sys", "scala-2.10.7.deb", "https://github.com/scala/scala/releases/download/v2.10.7/scala-2.10.7.deb", "Debian", "24.56M"],
+  ["-non-main-sys", "scala-2.10.7.rpm", "https://github.com/scala/scala/releases/download/v2.10.7/scala-2.10.7.rpm", "RPM package", "24.93M"],
+  ["-non-main-sys", "scala-docs-2.10.7.txz", "https://github.com/scala/scala/releases/download/v2.10.7/scala-docs-2.10.7.txz", "API docs", "3.25M"],
+  ["-non-main-sys", "scala-docs-2.10.7.zip", "https://github.com/scala/scala/releases/download/v2.10.7/scala-docs-2.10.7.zip", "API docs", "30.95M"],
   ["-non-main-sys", "scala-sources-2.10.7.tar.gz", "https://github.com/scala/scala/archive/v2.10.7.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2017-11-09-2.11.12.md
+++ b/_downloads/2017-11-09-2.11.12.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.11.12/
 resources: [
-  ["-main-unixsys", "scala-2.11.12.tgz", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.tgz", "Mac OS X, Unix, Cygwin", "27.77M"],
-  ["-main-windows", "scala-2.11.12.msi", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.msi", "Windows (msi installer)", "109.82M"],
-  ["-non-main-sys", "scala-2.11.12.zip", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.zip", "Windows", "27.82M"],
-  ["-non-main-sys", "scala-2.11.12.deb", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.deb", "Debian", "76.44M"],
-  ["-non-main-sys", "scala-2.11.12.rpm", "https://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.rpm", "RPM package", "108.60M"],
-  ["-non-main-sys", "scala-docs-2.11.12.txz", "https://downloads.lightbend.com/scala/2.11.12/scala-docs-2.11.12.txz", "API docs", "46.17M"],
-  ["-non-main-sys", "scala-docs-2.11.12.zip", "https://downloads.lightbend.com/scala/2.11.12/scala-docs-2.11.12.zip", "API docs", "84.26M"],
+  ["-main-unixsys", "scala-2.11.12.tgz", "https://github.com/scala/scala/releases/download/v2.11.12/scala-2.11.12.tgz", "Mac OS X, Unix, Cygwin", "27.77M"],
+  ["-main-windows", "scala-2.11.12.msi", "https://github.com/scala/scala/releases/download/v2.11.12/scala-2.11.12.msi", "Windows (msi installer)", "109.82M"],
+  ["-non-main-sys", "scala-2.11.12.zip", "https://github.com/scala/scala/releases/download/v2.11.12/scala-2.11.12.zip", "Windows", "27.82M"],
+  ["-non-main-sys", "scala-2.11.12.deb", "https://github.com/scala/scala/releases/download/v2.11.12/scala-2.11.12.deb", "Debian", "76.44M"],
+  ["-non-main-sys", "scala-2.11.12.rpm", "https://github.com/scala/scala/releases/download/v2.11.12/scala-2.11.12.rpm", "RPM package", "108.60M"],
+  ["-non-main-sys", "scala-docs-2.11.12.txz", "https://github.com/scala/scala/releases/download/v2.11.12/scala-docs-2.11.12.txz", "API docs", "46.17M"],
+  ["-non-main-sys", "scala-docs-2.11.12.zip", "https://github.com/scala/scala/releases/download/v2.11.12/scala-docs-2.11.12.zip", "API docs", "84.26M"],
   ["-non-main-sys", "scala-sources-2.11.12.tar.gz", "https://github.com/scala/scala/archive/v2.11.12.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2018-01-31-2.13.0-M3.md
+++ b/_downloads/2018-01-31-2.13.0-M3.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-M3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-M3.tgz", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.tgz", "Mac OS X, Unix, Cygwin", "17.31M"],
-  ["-main-windows", "scala-2.13.0-M3.msi", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.msi", "Windows (msi installer)", "114.28M"],
-  ["-non-main-sys", "scala-2.13.0-M3.zip", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.zip", "Windows", "17.35M"],
-  ["-non-main-sys", "scala-2.13.0-M3.deb", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.deb", "Debian", "132.66M"],
-  ["-non-main-sys", "scala-2.13.0-M3.rpm", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-2.13.0-M3.rpm", "RPM package", "114.82M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M3.txz", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-docs-2.13.0-M3.txz", "API docs", "51.24M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M3.zip", "https://downloads.lightbend.com/scala/2.13.0-M3/scala-docs-2.13.0-M3.zip", "API docs", "100.01M"],
+  ["-main-unixsys", "scala-2.13.0-M3.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-2.13.0-M3.tgz", "Mac OS X, Unix, Cygwin", "17.31M"],
+  ["-main-windows", "scala-2.13.0-M3.msi", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-2.13.0-M3.msi", "Windows (msi installer)", "114.28M"],
+  ["-non-main-sys", "scala-2.13.0-M3.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-2.13.0-M3.zip", "Windows", "17.35M"],
+  ["-non-main-sys", "scala-2.13.0-M3.deb", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-2.13.0-M3.deb", "Debian", "132.66M"],
+  ["-non-main-sys", "scala-2.13.0-M3.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-2.13.0-M3.rpm", "RPM package", "114.82M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M3.txz", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-docs-2.13.0-M3.txz", "API docs", "51.24M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M3.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M3/scala-docs-2.13.0-M3.zip", "API docs", "100.01M"],
   ["-non-main-sys", "scala-sources-2.13.0-M3.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-M3.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2018-03-15-2.12.5.md
+++ b/_downloads/2018-03-15-2.12.5.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.5/
 resources: [
-  ["-main-unixsys", "scala-2.12.5.tgz", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.tgz", "Mac OS X, Unix, Cygwin", "19.36M"],
-  ["-main-windows", "scala-2.12.5.msi", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.msi", "Windows (msi installer)", "123.65M"],
-  ["-non-main-sys", "scala-2.12.5.zip", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.zip", "Windows", "19.40M"],
-  ["-non-main-sys", "scala-2.12.5.deb", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.deb", "Debian", "143.95M"],
-  ["-non-main-sys", "scala-2.12.5.rpm", "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.rpm", "RPM package", "123.97M"],
-  ["-non-main-sys", "scala-docs-2.12.5.txz", "https://downloads.lightbend.com/scala/2.12.5/scala-docs-2.12.5.txz", "API docs", "53.14M"],
-  ["-non-main-sys", "scala-docs-2.12.5.zip", "https://downloads.lightbend.com/scala/2.12.5/scala-docs-2.12.5.zip", "API docs", "107.38M"],
+  ["-main-unixsys", "scala-2.12.5.tgz", "https://github.com/scala/scala/releases/download/v2.12.5/scala-2.12.5.tgz", "Mac OS X, Unix, Cygwin", "19.36M"],
+  ["-main-windows", "scala-2.12.5.msi", "https://github.com/scala/scala/releases/download/v2.12.5/scala-2.12.5.msi", "Windows (msi installer)", "123.65M"],
+  ["-non-main-sys", "scala-2.12.5.zip", "https://github.com/scala/scala/releases/download/v2.12.5/scala-2.12.5.zip", "Windows", "19.40M"],
+  ["-non-main-sys", "scala-2.12.5.deb", "https://github.com/scala/scala/releases/download/v2.12.5/scala-2.12.5.deb", "Debian", "143.95M"],
+  ["-non-main-sys", "scala-2.12.5.rpm", "https://github.com/scala/scala/releases/download/v2.12.5/scala-2.12.5.rpm", "RPM package", "123.97M"],
+  ["-non-main-sys", "scala-docs-2.12.5.txz", "https://github.com/scala/scala/releases/download/v2.12.5/scala-docs-2.12.5.txz", "API docs", "53.14M"],
+  ["-non-main-sys", "scala-docs-2.12.5.zip", "https://github.com/scala/scala/releases/download/v2.12.5/scala-docs-2.12.5.zip", "API docs", "107.38M"],
   ["-non-main-sys", "scala-sources-2.12.5.tar.gz", "https://github.com/scala/scala/archive/v2.12.5.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2018-04-27-2.12.6.md
+++ b/_downloads/2018-04-27-2.12.6.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.6/
 resources: [
-  ["-main-unixsys", "scala-2.12.6.tgz", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.tgz", "Mac OS X, Unix, Cygwin", "19.39M"],
-  ["-main-windows", "scala-2.12.6.msi", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.msi", "Windows (msi installer)", "123.67M"],
-  ["-non-main-sys", "scala-2.12.6.zip", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.zip", "Windows", "19.43M"],
-  ["-non-main-sys", "scala-2.12.6.deb", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.deb", "Debian", "143.99M"],
-  ["-non-main-sys", "scala-2.12.6.rpm", "https://downloads.lightbend.com/scala/2.12.6/scala-2.12.6.rpm", "RPM package", "123.98M"],
-  ["-non-main-sys", "scala-docs-2.12.6.txz", "https://downloads.lightbend.com/scala/2.12.6/scala-docs-2.12.6.txz", "API docs", "53.14M"],
-  ["-non-main-sys", "scala-docs-2.12.6.zip", "https://downloads.lightbend.com/scala/2.12.6/scala-docs-2.12.6.zip", "API docs", "107.37M"],
+  ["-main-unixsys", "scala-2.12.6.tgz", "https://github.com/scala/scala/releases/download/v2.12.6/scala-2.12.6.tgz", "Mac OS X, Unix, Cygwin", "19.39M"],
+  ["-main-windows", "scala-2.12.6.msi", "https://github.com/scala/scala/releases/download/v2.12.6/scala-2.12.6.msi", "Windows (msi installer)", "123.67M"],
+  ["-non-main-sys", "scala-2.12.6.zip", "https://github.com/scala/scala/releases/download/v2.12.6/scala-2.12.6.zip", "Windows", "19.43M"],
+  ["-non-main-sys", "scala-2.12.6.deb", "https://github.com/scala/scala/releases/download/v2.12.6/scala-2.12.6.deb", "Debian", "143.99M"],
+  ["-non-main-sys", "scala-2.12.6.rpm", "https://github.com/scala/scala/releases/download/v2.12.6/scala-2.12.6.rpm", "RPM package", "123.98M"],
+  ["-non-main-sys", "scala-docs-2.12.6.txz", "https://github.com/scala/scala/releases/download/v2.12.6/scala-docs-2.12.6.txz", "API docs", "53.14M"],
+  ["-non-main-sys", "scala-docs-2.12.6.zip", "https://github.com/scala/scala/releases/download/v2.12.6/scala-docs-2.12.6.zip", "API docs", "107.37M"],
   ["-non-main-sys", "scala-sources-2.12.6.tar.gz", "https://github.com/scala/scala/archive/v2.12.6.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2018-05-15-2.13.0-M4.md
+++ b/_downloads/2018-05-15-2.13.0-M4.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-M4.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-M4.tgz", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.tgz", "Mac OS X, Unix, Cygwin", "16.54M"],
-  ["-main-windows", "scala-2.13.0-M4.msi", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.msi", "Windows (msi installer)", "97.55M"],
-  ["-non-main-sys", "scala-2.13.0-M4.zip", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.zip", "Windows", "16.58M"],
-  ["-non-main-sys", "scala-2.13.0-M4.deb", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.deb", "Debian", "482.84M"],
-  ["-non-main-sys", "scala-2.13.0-M4.rpm", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-2.13.0-M4.rpm", "RPM package", "98.11M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M4.txz", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-docs-2.13.0-M4.txz", "API docs", "41.69M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M4.zip", "https://downloads.lightbend.com/scala/2.13.0-M4/scala-docs-2.13.0-M4.zip", "API docs", "84.12M"],
+  ["-main-unixsys", "scala-2.13.0-M4.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-2.13.0-M4.tgz", "Mac OS X, Unix, Cygwin", "16.54M"],
+  ["-main-windows", "scala-2.13.0-M4.msi", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-2.13.0-M4.msi", "Windows (msi installer)", "97.55M"],
+  ["-non-main-sys", "scala-2.13.0-M4.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-2.13.0-M4.zip", "Windows", "16.58M"],
+  ["-non-main-sys", "scala-2.13.0-M4.deb", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-2.13.0-M4.deb", "Debian", "482.84M"],
+  ["-non-main-sys", "scala-2.13.0-M4.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-2.13.0-M4.rpm", "RPM package", "98.11M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M4.txz", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-docs-2.13.0-M4.txz", "API docs", "41.69M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M4.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M4/scala-docs-2.13.0-M4.zip", "API docs", "84.12M"],
   ["-non-main-sys", "scala-sources-2.13.0-M4.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-M4.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2018-08-30-2.13.0-M5.md
+++ b/_downloads/2018-08-30-2.13.0-M5.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-M5.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-M5.tgz", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.tgz", "Mac OS X, Unix, Cygwin", "16.90M"],
-  ["-main-windows", "scala-2.13.0-M5.msi", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.msi", "Windows (msi installer)", "103.19M"],
-  ["-non-main-sys", "scala-2.13.0-M5.zip", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.zip", "Windows", "16.94M"],
-  ["-non-main-sys", "scala-2.13.0-M5.deb", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.deb", "Debian", "524.89M"],
-  ["-non-main-sys", "scala-2.13.0-M5.rpm", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-2.13.0-M5.rpm", "RPM package", "103.68M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M5.txz", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-docs-2.13.0-M5.txz", "API docs", "44.40M"],
-  ["-non-main-sys", "scala-docs-2.13.0-M5.zip", "https://downloads.lightbend.com/scala/2.13.0-M5/scala-docs-2.13.0-M5.zip", "API docs", "89.44M"],
+  ["-main-unixsys", "scala-2.13.0-M5.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-2.13.0-M5.tgz", "Mac OS X, Unix, Cygwin", "16.90M"],
+  ["-main-windows", "scala-2.13.0-M5.msi", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-2.13.0-M5.msi", "Windows (msi installer)", "103.19M"],
+  ["-non-main-sys", "scala-2.13.0-M5.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-2.13.0-M5.zip", "Windows", "16.94M"],
+  ["-non-main-sys", "scala-2.13.0-M5.deb", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-2.13.0-M5.deb", "Debian", "524.89M"],
+  ["-non-main-sys", "scala-2.13.0-M5.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-2.13.0-M5.rpm", "RPM package", "103.68M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M5.txz", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-docs-2.13.0-M5.txz", "API docs", "44.40M"],
+  ["-non-main-sys", "scala-docs-2.13.0-M5.zip", "https://github.com/scala/scala/releases/download/v2.13.0-M5/scala-docs-2.13.0-M5.zip", "API docs", "89.44M"],
   ["-non-main-sys", "scala-sources-2.13.0-M5.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-M5.tar.gz", "Sources", "6.45M"]
 ]
 ---

--- a/_downloads/2018-09-27-2.12.7.md
+++ b/_downloads/2018-09-27-2.12.7.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://opensource.org/licenses/BSD-3-Clause">3-clause BSD license</a>
 api_docs: https://www.scala-lang.org/api/2.12.7/
 resources: [
-  ["-main-unixsys", "scala-2.12.7.tgz", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.tgz", "Mac OS X, Unix, Cygwin", "19.47M"],
-  ["-main-windows", "scala-2.12.7.msi", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.msi", "Windows (msi installer)", "123.87M"],
-  ["-non-main-sys", "scala-2.12.7.zip", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.zip", "Windows", "19.51M"],
-  ["-non-main-sys", "scala-2.12.7.deb", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.deb", "Debian", "144.27M"],
-  ["-non-main-sys", "scala-2.12.7.rpm", "https://downloads.lightbend.com/scala/2.12.7/scala-2.12.7.rpm", "RPM package", "124.19M"],
-  ["-non-main-sys", "scala-docs-2.12.7.txz", "https://downloads.lightbend.com/scala/2.12.7/scala-docs-2.12.7.txz", "API docs", "53.18M"],
-  ["-non-main-sys", "scala-docs-2.12.7.zip", "https://downloads.lightbend.com/scala/2.12.7/scala-docs-2.12.7.zip", "API docs", "107.50M"],
+  ["-main-unixsys", "scala-2.12.7.tgz", "https://github.com/scala/scala/releases/download/v2.12.7/scala-2.12.7.tgz", "Mac OS X, Unix, Cygwin", "19.47M"],
+  ["-main-windows", "scala-2.12.7.msi", "https://github.com/scala/scala/releases/download/v2.12.7/scala-2.12.7.msi", "Windows (msi installer)", "123.87M"],
+  ["-non-main-sys", "scala-2.12.7.zip", "https://github.com/scala/scala/releases/download/v2.12.7/scala-2.12.7.zip", "Windows", "19.51M"],
+  ["-non-main-sys", "scala-2.12.7.deb", "https://github.com/scala/scala/releases/download/v2.12.7/scala-2.12.7.deb", "Debian", "144.27M"],
+  ["-non-main-sys", "scala-2.12.7.rpm", "https://github.com/scala/scala/releases/download/v2.12.7/scala-2.12.7.rpm", "RPM package", "124.19M"],
+  ["-non-main-sys", "scala-docs-2.12.7.txz", "https://github.com/scala/scala/releases/download/v2.12.7/scala-docs-2.12.7.txz", "API docs", "53.18M"],
+  ["-non-main-sys", "scala-docs-2.12.7.zip", "https://github.com/scala/scala/releases/download/v2.12.7/scala-docs-2.12.7.zip", "API docs", "107.50M"],
   ["-non-main-sys", "scala-sources-2.12.7.tar.gz", "https://github.com/scala/scala/archive/v2.12.7.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2018-12-04-2.12.8.md
+++ b/_downloads/2018-12-04-2.12.8.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.8/
 resources: [
-  ["-main-unixsys", "scala-2.12.8.tgz", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.tgz", "Mac OS X, Unix, Cygwin", "19.52M"],
-  ["-main-windows", "scala-2.12.8.msi", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.msi", "Windows (msi installer)", "123.96M"],
-  ["-non-main-sys", "scala-2.12.8.zip", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.zip", "Windows", "19.56M"],
-  ["-non-main-sys", "scala-2.12.8.deb", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.deb", "Debian", "144.40M"],
-  ["-non-main-sys", "scala-2.12.8.rpm", "https://downloads.lightbend.com/scala/2.12.8/scala-2.12.8.rpm", "RPM package", "124.27M"],
-  ["-non-main-sys", "scala-docs-2.12.8.txz", "https://downloads.lightbend.com/scala/2.12.8/scala-docs-2.12.8.txz", "API docs", "53.21M"],
-  ["-non-main-sys", "scala-docs-2.12.8.zip", "https://downloads.lightbend.com/scala/2.12.8/scala-docs-2.12.8.zip", "API docs", "107.53M"],
+  ["-main-unixsys", "scala-2.12.8.tgz", "https://github.com/scala/scala/releases/download/v2.12.8/scala-2.12.8.tgz", "Mac OS X, Unix, Cygwin", "19.52M"],
+  ["-main-windows", "scala-2.12.8.msi", "https://github.com/scala/scala/releases/download/v2.12.8/scala-2.12.8.msi", "Windows (msi installer)", "123.96M"],
+  ["-non-main-sys", "scala-2.12.8.zip", "https://github.com/scala/scala/releases/download/v2.12.8/scala-2.12.8.zip", "Windows", "19.56M"],
+  ["-non-main-sys", "scala-2.12.8.deb", "https://github.com/scala/scala/releases/download/v2.12.8/scala-2.12.8.deb", "Debian", "144.40M"],
+  ["-non-main-sys", "scala-2.12.8.rpm", "https://github.com/scala/scala/releases/download/v2.12.8/scala-2.12.8.rpm", "RPM package", "124.27M"],
+  ["-non-main-sys", "scala-docs-2.12.8.txz", "https://github.com/scala/scala/releases/download/v2.12.8/scala-docs-2.12.8.txz", "API docs", "53.21M"],
+  ["-non-main-sys", "scala-docs-2.12.8.zip", "https://github.com/scala/scala/releases/download/v2.12.8/scala-docs-2.12.8.zip", "API docs", "107.53M"],
   ["-non-main-sys", "scala-sources-2.12.8.tar.gz", "https://github.com/scala/scala/archive/v2.12.8.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2019-04-08-2.13.0-RC1.md
+++ b/_downloads/2019-04-08-2.13.0-RC1.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-RC1.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-RC1.tgz", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-2.13.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "18.35M"],
-  ["-main-windows", "scala-2.13.0-RC1.msi", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-2.13.0-RC1.msi", "Windows (msi installer)", "114.30M"],
-  ["-non-main-sys", "scala-2.13.0-RC1.zip", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-2.13.0-RC1.zip", "Windows", "18.39M"],
-  ["-non-main-sys", "scala-2.13.0-RC1.deb", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-2.13.0-RC1.deb", "Debian", "579.65M"],
-  ["-non-main-sys", "scala-2.13.0-RC1.rpm", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-2.13.0-RC1.rpm", "RPM package", "114.69M"],
-  ["-non-main-sys", "scala-docs-2.13.0-RC1.txz", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-docs-2.13.0-RC1.txz", "API docs", "48.48M"],
-  ["-non-main-sys", "scala-docs-2.13.0-RC1.zip", "https://downloads.lightbend.com/scala/2.13.0-RC1/scala-docs-2.13.0-RC1.zip", "API docs", "99.25M"],
+  ["-main-unixsys", "scala-2.13.0-RC1.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-2.13.0-RC1.tgz", "Mac OS X, Unix, Cygwin", "18.35M"],
+  ["-main-windows", "scala-2.13.0-RC1.msi", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-2.13.0-RC1.msi", "Windows (msi installer)", "114.30M"],
+  ["-non-main-sys", "scala-2.13.0-RC1.zip", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-2.13.0-RC1.zip", "Windows", "18.39M"],
+  ["-non-main-sys", "scala-2.13.0-RC1.deb", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-2.13.0-RC1.deb", "Debian", "579.65M"],
+  ["-non-main-sys", "scala-2.13.0-RC1.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-2.13.0-RC1.rpm", "RPM package", "114.69M"],
+  ["-non-main-sys", "scala-docs-2.13.0-RC1.txz", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-docs-2.13.0-RC1.txz", "API docs", "48.48M"],
+  ["-non-main-sys", "scala-docs-2.13.0-RC1.zip", "https://github.com/scala/scala/releases/download/v2.13.0-RC1/scala-docs-2.13.0-RC1.zip", "API docs", "99.25M"],
   ["-non-main-sys", "scala-sources-2.13.0-RC1.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-RC1.tar.gz", "Sources", "6.88M"]
 ]
 ---

--- a/_downloads/2019-05-17-2.13.0-RC2.md
+++ b/_downloads/2019-05-17-2.13.0-RC2.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-RC2.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-RC2.tgz", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-2.13.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
-  ["-main-windows", "scala-2.13.0-RC2.msi", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-2.13.0-RC2.msi", "Windows (msi installer)", "114.72M"],
-  ["-non-main-sys", "scala-2.13.0-RC2.zip", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-2.13.0-RC2.zip", "Windows", "18.55M"],
-  ["-non-main-sys", "scala-2.13.0-RC2.deb", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-2.13.0-RC2.deb", "Debian", "581.68M"],
-  ["-non-main-sys", "scala-2.13.0-RC2.rpm", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-2.13.0-RC2.rpm", "RPM package", "115.12M"],
-  ["-non-main-sys", "scala-docs-2.13.0-RC2.txz", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-docs-2.13.0-RC2.txz", "API docs", "48.56M"],
-  ["-non-main-sys", "scala-docs-2.13.0-RC2.zip", "https://downloads.lightbend.com/scala/2.13.0-RC2/scala-docs-2.13.0-RC2.zip", "API docs", "99.53M"],
+  ["-main-unixsys", "scala-2.13.0-RC2.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-2.13.0-RC2.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
+  ["-main-windows", "scala-2.13.0-RC2.msi", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-2.13.0-RC2.msi", "Windows (msi installer)", "114.72M"],
+  ["-non-main-sys", "scala-2.13.0-RC2.zip", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-2.13.0-RC2.zip", "Windows", "18.55M"],
+  ["-non-main-sys", "scala-2.13.0-RC2.deb", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-2.13.0-RC2.deb", "Debian", "581.68M"],
+  ["-non-main-sys", "scala-2.13.0-RC2.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-2.13.0-RC2.rpm", "RPM package", "115.12M"],
+  ["-non-main-sys", "scala-docs-2.13.0-RC2.txz", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-docs-2.13.0-RC2.txz", "API docs", "48.56M"],
+  ["-non-main-sys", "scala-docs-2.13.0-RC2.zip", "https://github.com/scala/scala/releases/download/v2.13.0-RC2/scala-docs-2.13.0-RC2.zip", "API docs", "99.53M"],
   ["-non-main-sys", "scala-sources-2.13.0-RC2.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-RC2.tar.gz", "Sources", "6.7M"]
 ]
 ---

--- a/_downloads/2019-05-31-2.13.0-RC3.md
+++ b/_downloads/2019-05-31-2.13.0-RC3.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.0-RC3.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 resources: [
-  ["-main-unixsys", "scala-2.13.0-RC3.tgz", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-2.13.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
-  ["-main-windows", "scala-2.13.0-RC3.msi", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-2.13.0-RC3.msi", "Windows (msi installer)", "114.70M"],
-  ["-non-main-sys", "scala-2.13.0-RC3.zip", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-2.13.0-RC3.zip", "Windows", "18.55M"],
-  ["-non-main-sys", "scala-2.13.0-RC3.deb", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-2.13.0-RC3.deb", "Debian", "581.54M"],
-  ["-non-main-sys", "scala-2.13.0-RC3.rpm", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-2.13.0-RC3.rpm", "RPM package", "115.11M"],
-  ["-non-main-sys", "scala-docs-2.13.0-RC3.txz", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-docs-2.13.0-RC3.txz", "API docs", "48.53M"],
-  ["-non-main-sys", "scala-docs-2.13.0-RC3.zip", "https://downloads.lightbend.com/scala/2.13.0-RC3/scala-docs-2.13.0-RC3.zip", "API docs", "99.51M"],
+  ["-main-unixsys", "scala-2.13.0-RC3.tgz", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-2.13.0-RC3.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
+  ["-main-windows", "scala-2.13.0-RC3.msi", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-2.13.0-RC3.msi", "Windows (msi installer)", "114.70M"],
+  ["-non-main-sys", "scala-2.13.0-RC3.zip", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-2.13.0-RC3.zip", "Windows", "18.55M"],
+  ["-non-main-sys", "scala-2.13.0-RC3.deb", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-2.13.0-RC3.deb", "Debian", "581.54M"],
+  ["-non-main-sys", "scala-2.13.0-RC3.rpm", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-2.13.0-RC3.rpm", "RPM package", "115.11M"],
+  ["-non-main-sys", "scala-docs-2.13.0-RC3.txz", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-docs-2.13.0-RC3.txz", "API docs", "48.53M"],
+  ["-non-main-sys", "scala-docs-2.13.0-RC3.zip", "https://github.com/scala/scala/releases/download/v2.13.0-RC3/scala-docs-2.13.0-RC3.zip", "API docs", "99.51M"],
   ["-non-main-sys", "scala-sources-2.13.0-RC3.tar.gz", "https://github.com/scala/scala/archive/v2.13.0-RC3.tar.gz", "Sources", "6.7M"]
 ]
 ---

--- a/_downloads/2019-06-11-2.13.0.md
+++ b/_downloads/2019-06-11-2.13.0.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.0/
 resources: [
-  ["-main-unixsys", "scala-2.13.0.tgz", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
-  ["-main-windows", "scala-2.13.0.msi", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.msi", "Windows (msi installer)", "114.63M"],
-  ["-non-main-sys", "scala-2.13.0.zip", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.zip", "Windows", "18.55M"],
-  ["-non-main-sys", "scala-2.13.0.deb", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.deb", "Debian", "581.44M"],
-  ["-non-main-sys", "scala-2.13.0.rpm", "https://downloads.lightbend.com/scala/2.13.0/scala-2.13.0.rpm", "RPM package", "115.04M"],
-  ["-non-main-sys", "scala-docs-2.13.0.txz", "https://downloads.lightbend.com/scala/2.13.0/scala-docs-2.13.0.txz", "API docs", "48.47M"],
-  ["-non-main-sys", "scala-docs-2.13.0.zip", "https://downloads.lightbend.com/scala/2.13.0/scala-docs-2.13.0.zip", "API docs", "99.41M"],
+  ["-main-unixsys", "scala-2.13.0.tgz", "https://github.com/scala/scala/releases/download/v2.13.0/scala-2.13.0.tgz", "Mac OS X, Unix, Cygwin", "18.51M"],
+  ["-main-windows", "scala-2.13.0.msi", "https://github.com/scala/scala/releases/download/v2.13.0/scala-2.13.0.msi", "Windows (msi installer)", "114.63M"],
+  ["-non-main-sys", "scala-2.13.0.zip", "https://github.com/scala/scala/releases/download/v2.13.0/scala-2.13.0.zip", "Windows", "18.55M"],
+  ["-non-main-sys", "scala-2.13.0.deb", "https://github.com/scala/scala/releases/download/v2.13.0/scala-2.13.0.deb", "Debian", "581.44M"],
+  ["-non-main-sys", "scala-2.13.0.rpm", "https://github.com/scala/scala/releases/download/v2.13.0/scala-2.13.0.rpm", "RPM package", "115.04M"],
+  ["-non-main-sys", "scala-docs-2.13.0.txz", "https://github.com/scala/scala/releases/download/v2.13.0/scala-docs-2.13.0.txz", "API docs", "48.47M"],
+  ["-non-main-sys", "scala-docs-2.13.0.zip", "https://github.com/scala/scala/releases/download/v2.13.0/scala-docs-2.13.0.zip", "API docs", "99.41M"],
   ["-non-main-sys", "scala-sources-2.13.0.tar.gz", "https://github.com/scala/scala/archive/v2.13.0.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2019-08-05-2.12.9.md
+++ b/_downloads/2019-08-05-2.12.9.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.9/
 resources: [
-  ["-main-unixsys", "scala-2.12.9.tgz", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.tgz", "Mac OS X, Unix, Cygwin", "19.69M"],
-  ["-main-windows", "scala-2.12.9.msi", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.msi", "Windows (msi installer)", "124.01M"],
-  ["-non-main-sys", "scala-2.12.9.zip", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.zip", "Windows", "19.73M"],
-  ["-non-main-sys", "scala-2.12.9.deb", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.deb", "Debian", "144.65M"],
-  ["-non-main-sys", "scala-2.12.9.rpm", "https://downloads.lightbend.com/scala/2.12.9/scala-2.12.9.rpm", "RPM package", "124.32M"],
-  ["-non-main-sys", "scala-docs-2.12.9.txz", "https://downloads.lightbend.com/scala/2.12.9/scala-docs-2.12.9.txz", "API docs", "53.19M"],
-  ["-non-main-sys", "scala-docs-2.12.9.zip", "https://downloads.lightbend.com/scala/2.12.9/scala-docs-2.12.9.zip", "API docs", "107.41M"],
+  ["-main-unixsys", "scala-2.12.9.tgz", "https://github.com/scala/scala/releases/download/v2.12.9/scala-2.12.9.tgz", "Mac OS X, Unix, Cygwin", "19.69M"],
+  ["-main-windows", "scala-2.12.9.msi", "https://github.com/scala/scala/releases/download/v2.12.9/scala-2.12.9.msi", "Windows (msi installer)", "124.01M"],
+  ["-non-main-sys", "scala-2.12.9.zip", "https://github.com/scala/scala/releases/download/v2.12.9/scala-2.12.9.zip", "Windows", "19.73M"],
+  ["-non-main-sys", "scala-2.12.9.deb", "https://github.com/scala/scala/releases/download/v2.12.9/scala-2.12.9.deb", "Debian", "144.65M"],
+  ["-non-main-sys", "scala-2.12.9.rpm", "https://github.com/scala/scala/releases/download/v2.12.9/scala-2.12.9.rpm", "RPM package", "124.32M"],
+  ["-non-main-sys", "scala-docs-2.12.9.txz", "https://github.com/scala/scala/releases/download/v2.12.9/scala-docs-2.12.9.txz", "API docs", "53.19M"],
+  ["-non-main-sys", "scala-docs-2.12.9.zip", "https://github.com/scala/scala/releases/download/v2.12.9/scala-docs-2.12.9.zip", "API docs", "107.41M"],
   ["-non-main-sys", "scala-sources-2.12.9.tar.gz", "https://github.com/scala/scala/archive/v2.12.9.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2019-09-10-2.12.10.md
+++ b/_downloads/2019-09-10-2.12.10.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.10/
 resources: [
-  ["-main-unixsys", "scala-2.12.10.tgz", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz", "Mac OS X, Unix, Cygwin", "19.71M"],
-  ["-main-windows", "scala-2.12.10.msi", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.msi", "Windows (msi installer)", "124M"],
-  ["-non-main-sys", "scala-2.12.10.zip", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.zip", "Windows", "19.75M"],
-  ["-non-main-sys", "scala-2.12.10.deb", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.deb", "Debian", "144.88M"],
-  ["-non-main-sys", "scala-2.12.10.rpm", "https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.rpm", "RPM package", "124.52M"],
-  ["-non-main-sys", "scala-docs-2.12.10.txz", "https://downloads.lightbend.com/scala/2.12.10/scala-docs-2.12.10.txz", "API docs", "53.21M"],
-  ["-non-main-sys", "scala-docs-2.12.10.zip", "https://downloads.lightbend.com/scala/2.12.10/scala-docs-2.12.10.zip", "API docs", "107.63M"],
+  ["-main-unixsys", "scala-2.12.10.tgz", "https://github.com/scala/scala/releases/download/v2.12.10/scala-2.12.10.tgz", "Mac OS X, Unix, Cygwin", "19.71M"],
+  ["-main-windows", "scala-2.12.10.msi", "https://github.com/scala/scala/releases/download/v2.12.10/scala-2.12.10.msi", "Windows (msi installer)", "124M"],
+  ["-non-main-sys", "scala-2.12.10.zip", "https://github.com/scala/scala/releases/download/v2.12.10/scala-2.12.10.zip", "Windows", "19.75M"],
+  ["-non-main-sys", "scala-2.12.10.deb", "https://github.com/scala/scala/releases/download/v2.12.10/scala-2.12.10.deb", "Debian", "144.88M"],
+  ["-non-main-sys", "scala-2.12.10.rpm", "https://github.com/scala/scala/releases/download/v2.12.10/scala-2.12.10.rpm", "RPM package", "124.52M"],
+  ["-non-main-sys", "scala-docs-2.12.10.txz", "https://github.com/scala/scala/releases/download/v2.12.10/scala-docs-2.12.10.txz", "API docs", "53.21M"],
+  ["-non-main-sys", "scala-docs-2.12.10.zip", "https://github.com/scala/scala/releases/download/v2.12.10/scala-docs-2.12.10.zip", "API docs", "107.63M"],
   ["-non-main-sys", "scala-sources-2.12.10.tar.gz", "https://github.com/scala/scala/archive/v2.12.10.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2019-09-18-2.13.1.md
+++ b/_downloads/2019-09-18-2.13.1.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.1/
 resources: [
-  ["-main-unixsys", "scala-2.13.1.tgz", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.tgz", "Mac OS X, Unix, Cygwin", "18.77M"],
-  ["-main-windows", "scala-2.13.1.msi", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.msi", "Windows (msi installer)", "115.13M"],
-  ["-non-main-sys", "scala-2.13.1.zip", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.zip", "Windows", "18.81M"],
-  ["-non-main-sys", "scala-2.13.1.deb", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.deb", "Debian", "582.81M"],
-  ["-non-main-sys", "scala-2.13.1.rpm", "https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.rpm", "RPM package", "115.52M"],
-  ["-non-main-sys", "scala-docs-2.13.1.txz", "https://downloads.lightbend.com/scala/2.13.1/scala-docs-2.13.1.txz", "API docs", "48.58M"],
-  ["-non-main-sys", "scala-docs-2.13.1.zip", "https://downloads.lightbend.com/scala/2.13.1/scala-docs-2.13.1.zip", "API docs", "99.67M"],
+  ["-main-unixsys", "scala-2.13.1.tgz", "https://github.com/scala/scala/releases/download/v2.13.1/scala-2.13.1.tgz", "Mac OS X, Unix, Cygwin", "18.77M"],
+  ["-main-windows", "scala-2.13.1.msi", "https://github.com/scala/scala/releases/download/v2.13.1/scala-2.13.1.msi", "Windows (msi installer)", "115.13M"],
+  ["-non-main-sys", "scala-2.13.1.zip", "https://github.com/scala/scala/releases/download/v2.13.1/scala-2.13.1.zip", "Windows", "18.81M"],
+  ["-non-main-sys", "scala-2.13.1.deb", "https://github.com/scala/scala/releases/download/v2.13.1/scala-2.13.1.deb", "Debian", "582.81M"],
+  ["-non-main-sys", "scala-2.13.1.rpm", "https://github.com/scala/scala/releases/download/v2.13.1/scala-2.13.1.rpm", "RPM package", "115.52M"],
+  ["-non-main-sys", "scala-docs-2.13.1.txz", "https://github.com/scala/scala/releases/download/v2.13.1/scala-docs-2.13.1.txz", "API docs", "48.58M"],
+  ["-non-main-sys", "scala-docs-2.13.1.zip", "https://github.com/scala/scala/releases/download/v2.13.1/scala-docs-2.13.1.zip", "API docs", "99.67M"],
   ["-non-main-sys", "scala-sources-2.13.1.tar.gz", "https://github.com/scala/scala/archive/v2.13.1.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2020-03-16-2.12.11.md
+++ b/_downloads/2020-03-16-2.12.11.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.11/
 resources: [
-  ["-main-unixsys", "scala-2.12.11.tgz", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.tgz", "Mac OS X, Unix, Cygwin", "19.83M"],
-  ["-main-windows", "scala-2.12.11.msi", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.msi", "Windows (msi installer)", "124.33M"],
-  ["-non-main-sys", "scala-2.12.11.zip", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.zip", "Windows", "19.88M"],
-  ["-non-main-sys", "scala-2.12.11.deb", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.deb", "Debian", "145.11M"],
-  ["-non-main-sys", "scala-2.12.11.rpm", "https://downloads.lightbend.com/scala/2.12.11/scala-2.12.11.rpm", "RPM package", "124.63M"],
-  ["-non-main-sys", "scala-docs-2.12.11.txz", "https://downloads.lightbend.com/scala/2.12.11/scala-docs-2.12.11.txz", "API docs", "53.14M"],
-  ["-non-main-sys", "scala-docs-2.12.11.zip", "https://downloads.lightbend.com/scala/2.12.11/scala-docs-2.12.11.zip", "API docs", "107.61M"],
+  ["-main-unixsys", "scala-2.12.11.tgz", "https://github.com/scala/scala/releases/download/v2.12.11/scala-2.12.11.tgz", "Mac OS X, Unix, Cygwin", "19.83M"],
+  ["-main-windows", "scala-2.12.11.msi", "https://github.com/scala/scala/releases/download/v2.12.11/scala-2.12.11.msi", "Windows (msi installer)", "124.33M"],
+  ["-non-main-sys", "scala-2.12.11.zip", "https://github.com/scala/scala/releases/download/v2.12.11/scala-2.12.11.zip", "Windows", "19.88M"],
+  ["-non-main-sys", "scala-2.12.11.deb", "https://github.com/scala/scala/releases/download/v2.12.11/scala-2.12.11.deb", "Debian", "145.11M"],
+  ["-non-main-sys", "scala-2.12.11.rpm", "https://github.com/scala/scala/releases/download/v2.12.11/scala-2.12.11.rpm", "RPM package", "124.63M"],
+  ["-non-main-sys", "scala-docs-2.12.11.txz", "https://github.com/scala/scala/releases/download/v2.12.11/scala-docs-2.12.11.txz", "API docs", "53.14M"],
+  ["-non-main-sys", "scala-docs-2.12.11.zip", "https://github.com/scala/scala/releases/download/v2.12.11/scala-docs-2.12.11.zip", "API docs", "107.61M"],
   ["-non-main-sys", "scala-sources-2.12.11.tar.gz", "https://github.com/scala/scala/archive/v2.12.11.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2020-04-22-2.13.2.md
+++ b/_downloads/2020-04-22-2.13.2.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.2/
 resources: [
-  ["-main-unixsys", "scala-2.13.2.tgz", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.tgz", "Mac OS X, Unix, Cygwin", "21.07M"],
-  ["-main-windows", "scala-2.13.2.msi", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.msi", "Windows (msi installer)", "126.89M"],
-  ["-non-main-sys", "scala-2.13.2.zip", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.zip", "Windows", "21.11M"],
-  ["-non-main-sys", "scala-2.13.2.deb", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.deb", "Debian", "615.00M"],
-  ["-non-main-sys", "scala-2.13.2.rpm", "https://downloads.lightbend.com/scala/2.13.2/scala-2.13.2.rpm", "RPM package", "127.22M"],
-  ["-non-main-sys", "scala-docs-2.13.2.txz", "https://downloads.lightbend.com/scala/2.13.2/scala-docs-2.13.2.txz", "API docs", "56.06M"],
-  ["-non-main-sys", "scala-docs-2.13.2.zip", "https://downloads.lightbend.com/scala/2.13.2/scala-docs-2.13.2.zip", "API docs", "109.18M"],
+  ["-main-unixsys", "scala-2.13.2.tgz", "https://github.com/scala/scala/releases/download/v2.13.2/scala-2.13.2.tgz", "Mac OS X, Unix, Cygwin", "21.07M"],
+  ["-main-windows", "scala-2.13.2.msi", "https://github.com/scala/scala/releases/download/v2.13.2/scala-2.13.2.msi", "Windows (msi installer)", "126.89M"],
+  ["-non-main-sys", "scala-2.13.2.zip", "https://github.com/scala/scala/releases/download/v2.13.2/scala-2.13.2.zip", "Windows", "21.11M"],
+  ["-non-main-sys", "scala-2.13.2.deb", "https://github.com/scala/scala/releases/download/v2.13.2/scala-2.13.2.deb", "Debian", "615.00M"],
+  ["-non-main-sys", "scala-2.13.2.rpm", "https://github.com/scala/scala/releases/download/v2.13.2/scala-2.13.2.rpm", "RPM package", "127.22M"],
+  ["-non-main-sys", "scala-docs-2.13.2.txz", "https://github.com/scala/scala/releases/download/v2.13.2/scala-docs-2.13.2.txz", "API docs", "56.06M"],
+  ["-non-main-sys", "scala-docs-2.13.2.zip", "https://github.com/scala/scala/releases/download/v2.13.2/scala-docs-2.13.2.zip", "API docs", "109.18M"],
   ["-non-main-sys", "scala-sources-2.13.2.tar.gz", "https://github.com/scala/scala/archive/v2.13.2.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2020-06-25-2.13.3.md
+++ b/_downloads/2020-06-25-2.13.3.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.3/
 resources: [
-  ["-main-unixsys", "scala-2.13.3.tgz", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.tgz", "Mac OS X, Unix, Cygwin", "21.38M"],
-  ["-main-windows", "scala-2.13.3.msi", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.msi", "Windows (msi installer)", "125.76M"],
-  ["-non-main-sys", "scala-2.13.3.zip", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.zip", "Windows", "21.42M"],
-  ["-non-main-sys", "scala-2.13.3.deb", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.deb", "Debian", "618.18M"],
-  ["-non-main-sys", "scala-2.13.3.rpm", "https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.rpm", "RPM package", "126.08M"],
-  ["-non-main-sys", "scala-docs-2.13.3.txz", "https://downloads.lightbend.com/scala/2.13.3/scala-docs-2.13.3.txz", "API docs", "54.44M"],
-  ["-non-main-sys", "scala-docs-2.13.3.zip", "https://downloads.lightbend.com/scala/2.13.3/scala-docs-2.13.3.zip", "API docs", "107.75M"],
+  ["-main-unixsys", "scala-2.13.3.tgz", "https://github.com/scala/scala/releases/download/v2.13.3/scala-2.13.3.tgz", "Mac OS X, Unix, Cygwin", "21.38M"],
+  ["-main-windows", "scala-2.13.3.msi", "https://github.com/scala/scala/releases/download/v2.13.3/scala-2.13.3.msi", "Windows (msi installer)", "125.76M"],
+  ["-non-main-sys", "scala-2.13.3.zip", "https://github.com/scala/scala/releases/download/v2.13.3/scala-2.13.3.zip", "Windows", "21.42M"],
+  ["-non-main-sys", "scala-2.13.3.deb", "https://github.com/scala/scala/releases/download/v2.13.3/scala-2.13.3.deb", "Debian", "618.18M"],
+  ["-non-main-sys", "scala-2.13.3.rpm", "https://github.com/scala/scala/releases/download/v2.13.3/scala-2.13.3.rpm", "RPM package", "126.08M"],
+  ["-non-main-sys", "scala-docs-2.13.3.txz", "https://github.com/scala/scala/releases/download/v2.13.3/scala-docs-2.13.3.txz", "API docs", "54.44M"],
+  ["-non-main-sys", "scala-docs-2.13.3.zip", "https://github.com/scala/scala/releases/download/v2.13.3/scala-docs-2.13.3.zip", "API docs", "107.75M"],
   ["-non-main-sys", "scala-sources-2.13.3.tar.gz", "https://github.com/scala/scala/archive/v2.13.3.tar.gz", "Sources", "7.1M"]
 ]
 ---

--- a/_downloads/2020-07-13-2.12.12.md
+++ b/_downloads/2020-07-13-2.12.12.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.12/
 resources: [
-  ["-main-unixsys", "scala-2.12.12.tgz", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.tgz", "Mac OS X, Unix, Cygwin", "19.87M"],
-  ["-main-windows", "scala-2.12.12.msi", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.msi", "Windows (msi installer)", "124.70M"],
-  ["-non-main-sys", "scala-2.12.12.zip", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.zip", "Windows", "19.91M"],
-  ["-non-main-sys", "scala-2.12.12.deb", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.deb", "Debian", "145.51M"],
-  ["-non-main-sys", "scala-2.12.12.rpm", "https://downloads.lightbend.com/scala/2.12.12/scala-2.12.12.rpm", "RPM package", "124.99M"],
-  ["-non-main-sys", "scala-docs-2.12.12.txz", "https://downloads.lightbend.com/scala/2.12.12/scala-docs-2.12.12.txz", "API docs", "53.28M"],
-  ["-non-main-sys", "scala-docs-2.12.12.zip", "https://downloads.lightbend.com/scala/2.12.12/scala-docs-2.12.12.zip", "API docs", "107.95M"],
+  ["-main-unixsys", "scala-2.12.12.tgz", "https://github.com/scala/scala/releases/download/v2.12.12/scala-2.12.12.tgz", "Mac OS X, Unix, Cygwin", "19.87M"],
+  ["-main-windows", "scala-2.12.12.msi", "https://github.com/scala/scala/releases/download/v2.12.12/scala-2.12.12.msi", "Windows (msi installer)", "124.70M"],
+  ["-non-main-sys", "scala-2.12.12.zip", "https://github.com/scala/scala/releases/download/v2.12.12/scala-2.12.12.zip", "Windows", "19.91M"],
+  ["-non-main-sys", "scala-2.12.12.deb", "https://github.com/scala/scala/releases/download/v2.12.12/scala-2.12.12.deb", "Debian", "145.51M"],
+  ["-non-main-sys", "scala-2.12.12.rpm", "https://github.com/scala/scala/releases/download/v2.12.12/scala-2.12.12.rpm", "RPM package", "124.99M"],
+  ["-non-main-sys", "scala-docs-2.12.12.txz", "https://github.com/scala/scala/releases/download/v2.12.12/scala-docs-2.12.12.txz", "API docs", "53.28M"],
+  ["-non-main-sys", "scala-docs-2.12.12.zip", "https://github.com/scala/scala/releases/download/v2.12.12/scala-docs-2.12.12.zip", "API docs", "107.95M"],
   ["-non-main-sys", "scala-sources-2.12.12.tar.gz", "https://github.com/scala/scala/archive/v2.12.12.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2020-11-19-2.13.4.md
+++ b/_downloads/2020-11-19-2.13.4.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.4/
 resources: [
-  ["-main-unixsys", "scala-2.13.4.tgz", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.tgz", "Mac OS X, Unix, Cygwin", "21.91M"],
-  ["-main-windows", "scala-2.13.4.msi", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.msi", "Windows (msi installer)", "128.68M"],
-  ["-non-main-sys", "scala-2.13.4.zip", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.zip", "Windows", "21.95M"],
-  ["-non-main-sys", "scala-2.13.4.deb", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.deb", "Debian", "638.88M"],
-  ["-non-main-sys", "scala-2.13.4.rpm", "https://downloads.lightbend.com/scala/2.13.4/scala-2.13.4.rpm", "RPM package", "128.96M"],
-  ["-non-main-sys", "scala-docs-2.13.4.txz", "https://downloads.lightbend.com/scala/2.13.4/scala-docs-2.13.4.txz", "API docs", "55.80M"],
-  ["-non-main-sys", "scala-docs-2.13.4.zip", "https://downloads.lightbend.com/scala/2.13.4/scala-docs-2.13.4.zip", "API docs", "110.16M"],
+  ["-main-unixsys", "scala-2.13.4.tgz", "https://github.com/scala/scala/releases/download/v2.13.4/scala-2.13.4.tgz", "Mac OS X, Unix, Cygwin", "21.91M"],
+  ["-main-windows", "scala-2.13.4.msi", "https://github.com/scala/scala/releases/download/v2.13.4/scala-2.13.4.msi", "Windows (msi installer)", "128.68M"],
+  ["-non-main-sys", "scala-2.13.4.zip", "https://github.com/scala/scala/releases/download/v2.13.4/scala-2.13.4.zip", "Windows", "21.95M"],
+  ["-non-main-sys", "scala-2.13.4.deb", "https://github.com/scala/scala/releases/download/v2.13.4/scala-2.13.4.deb", "Debian", "638.88M"],
+  ["-non-main-sys", "scala-2.13.4.rpm", "https://github.com/scala/scala/releases/download/v2.13.4/scala-2.13.4.rpm", "RPM package", "128.96M"],
+  ["-non-main-sys", "scala-docs-2.13.4.txz", "https://github.com/scala/scala/releases/download/v2.13.4/scala-docs-2.13.4.txz", "API docs", "55.80M"],
+  ["-non-main-sys", "scala-docs-2.13.4.zip", "https://github.com/scala/scala/releases/download/v2.13.4/scala-docs-2.13.4.zip", "API docs", "110.16M"],
   ["-non-main-sys", "scala-sources-2.13.4.tar.gz", "https://github.com/scala/scala/archive/v2.13.4.tar.gz", "Sources", "7.0M"]
 ]
 ---

--- a/_downloads/2021-01-12-2.12.13.md
+++ b/_downloads/2021-01-12-2.12.13.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.13/
 resources: [
-  ["-main-unixsys", "scala-2.12.13.tgz", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.tgz", "Mac OS X, Unix, Cygwin", "20.03M"],
-  ["-main-windows", "scala-2.12.13.msi", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.msi", "Windows (msi installer)", "125.69M"],
-  ["-non-main-sys", "scala-2.12.13.zip", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.zip", "Windows", "20.07M"],
-  ["-non-main-sys", "scala-2.12.13.deb", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.deb", "Debian", "146.65M"],
-  ["-non-main-sys", "scala-2.12.13.rpm", "https://downloads.lightbend.com/scala/2.12.13/scala-2.12.13.rpm", "RPM package", "125.95M"],
-  ["-non-main-sys", "scala-docs-2.12.13.txz", "https://downloads.lightbend.com/scala/2.12.13/scala-docs-2.12.13.txz", "API docs", "53.62M"],
-  ["-non-main-sys", "scala-docs-2.12.13.zip", "https://downloads.lightbend.com/scala/2.12.13/scala-docs-2.12.13.zip", "API docs", "108.84M"],
+  ["-main-unixsys", "scala-2.12.13.tgz", "https://github.com/scala/scala/releases/download/v2.12.13/scala-2.12.13.tgz", "Mac OS X, Unix, Cygwin", "20.03M"],
+  ["-main-windows", "scala-2.12.13.msi", "https://github.com/scala/scala/releases/download/v2.12.13/scala-2.12.13.msi", "Windows (msi installer)", "125.69M"],
+  ["-non-main-sys", "scala-2.12.13.zip", "https://github.com/scala/scala/releases/download/v2.12.13/scala-2.12.13.zip", "Windows", "20.07M"],
+  ["-non-main-sys", "scala-2.12.13.deb", "https://github.com/scala/scala/releases/download/v2.12.13/scala-2.12.13.deb", "Debian", "146.65M"],
+  ["-non-main-sys", "scala-2.12.13.rpm", "https://github.com/scala/scala/releases/download/v2.12.13/scala-2.12.13.rpm", "RPM package", "125.95M"],
+  ["-non-main-sys", "scala-docs-2.12.13.txz", "https://github.com/scala/scala/releases/download/v2.12.13/scala-docs-2.12.13.txz", "API docs", "53.62M"],
+  ["-non-main-sys", "scala-docs-2.12.13.zip", "https://github.com/scala/scala/releases/download/v2.12.13/scala-docs-2.12.13.zip", "API docs", "108.84M"],
   ["-non-main-sys", "scala-sources-2.12.13.tar.gz", "https://github.com/scala/scala/archive/v2.12.13.tar.gz", "Sources", "6.8M"]
 ]
 ---

--- a/_downloads/2021-02-22-2.13.5.md
+++ b/_downloads/2021-02-22-2.13.5.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.5/
 resources: [
-  ["-main-unixsys", "scala-2.13.5.tgz", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.tgz", "Mac OS X, Unix, Cygwin", "21.98M"],
-  ["-main-windows", "scala-2.13.5.msi", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.msi", "Windows (msi installer)", "130.48M"],
-  ["-non-main-sys", "scala-2.13.5.zip", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.zip", "Windows", "22.02M"],
-  ["-non-main-sys", "scala-2.13.5.deb", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.deb", "Debian", "641.63M"],
-  ["-non-main-sys", "scala-2.13.5.rpm", "https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.rpm", "RPM package", "130.73M"],
-  ["-non-main-sys", "scala-docs-2.13.5.txz", "https://downloads.lightbend.com/scala/2.13.5/scala-docs-2.13.5.txz", "API docs", "57.73M"],
-  ["-non-main-sys", "scala-docs-2.13.5.zip", "https://downloads.lightbend.com/scala/2.13.5/scala-docs-2.13.5.zip", "API docs", "111.89M"],
+  ["-main-unixsys", "scala-2.13.5.tgz", "https://github.com/scala/scala/releases/download/v2.13.5/scala-2.13.5.tgz", "Mac OS X, Unix, Cygwin", "21.98M"],
+  ["-main-windows", "scala-2.13.5.msi", "https://github.com/scala/scala/releases/download/v2.13.5/scala-2.13.5.msi", "Windows (msi installer)", "130.48M"],
+  ["-non-main-sys", "scala-2.13.5.zip", "https://github.com/scala/scala/releases/download/v2.13.5/scala-2.13.5.zip", "Windows", "22.02M"],
+  ["-non-main-sys", "scala-2.13.5.deb", "https://github.com/scala/scala/releases/download/v2.13.5/scala-2.13.5.deb", "Debian", "641.63M"],
+  ["-non-main-sys", "scala-2.13.5.rpm", "https://github.com/scala/scala/releases/download/v2.13.5/scala-2.13.5.rpm", "RPM package", "130.73M"],
+  ["-non-main-sys", "scala-docs-2.13.5.txz", "https://github.com/scala/scala/releases/download/v2.13.5/scala-docs-2.13.5.txz", "API docs", "57.73M"],
+  ["-non-main-sys", "scala-docs-2.13.5.zip", "https://github.com/scala/scala/releases/download/v2.13.5/scala-docs-2.13.5.zip", "API docs", "111.89M"],
   ["-non-main-sys", "scala-sources-2.13.5.tar.gz", "https://github.com/scala/scala/archive/v2.13.5.tar.gz", "Sources", "8.0M"]
 ]
 ---

--- a/_downloads/2021-05-17-2.13.6.md
+++ b/_downloads/2021-05-17-2.13.6.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.6.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.6/
 resources: [
-  ["-main-unixsys", "scala-2.13.6.tgz", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.tgz", "Mac OS X, Unix, Cygwin", "22.32M"],
-  ["-main-windows", "scala-2.13.6.msi", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.msi", "Windows (msi installer)", "131.46M"],
-  ["-non-main-sys", "scala-2.13.6.zip", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.zip", "Windows", "22.36M"],
-  ["-non-main-sys", "scala-2.13.6.deb", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.deb", "Debian", "646.94M"],
-  ["-non-main-sys", "scala-2.13.6.rpm", "https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.rpm", "RPM package", "131.73M"],
-  ["-non-main-sys", "scala-docs-2.13.6.txz", "https://downloads.lightbend.com/scala/2.13.6/scala-docs-2.13.6.txz", "API docs", "58.10M"],
-  ["-non-main-sys", "scala-docs-2.13.6.zip", "https://downloads.lightbend.com/scala/2.13.6/scala-docs-2.13.6.zip", "API docs", "112.56M"],
+  ["-main-unixsys", "scala-2.13.6.tgz", "https://github.com/scala/scala/releases/download/v2.13.6/scala-2.13.6.tgz", "Mac OS X, Unix, Cygwin", "22.32M"],
+  ["-main-windows", "scala-2.13.6.msi", "https://github.com/scala/scala/releases/download/v2.13.6/scala-2.13.6.msi", "Windows (msi installer)", "131.46M"],
+  ["-non-main-sys", "scala-2.13.6.zip", "https://github.com/scala/scala/releases/download/v2.13.6/scala-2.13.6.zip", "Windows", "22.36M"],
+  ["-non-main-sys", "scala-2.13.6.deb", "https://github.com/scala/scala/releases/download/v2.13.6/scala-2.13.6.deb", "Debian", "646.94M"],
+  ["-non-main-sys", "scala-2.13.6.rpm", "https://github.com/scala/scala/releases/download/v2.13.6/scala-2.13.6.rpm", "RPM package", "131.73M"],
+  ["-non-main-sys", "scala-docs-2.13.6.txz", "https://github.com/scala/scala/releases/download/v2.13.6/scala-docs-2.13.6.txz", "API docs", "58.10M"],
+  ["-non-main-sys", "scala-docs-2.13.6.zip", "https://github.com/scala/scala/releases/download/v2.13.6/scala-docs-2.13.6.zip", "API docs", "112.56M"],
   ["-non-main-sys", "scala-sources-2.13.6.tar.gz", "https://github.com/scala/scala/archive/v2.13.6.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2021-05-28-2.12.14.md
+++ b/_downloads/2021-05-28-2.12.14.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.14/
 resources: [
-  ["-main-unixsys", "scala-2.12.14.tgz", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.tgz", "Mac OS X, Unix, Cygwin", "20.11M"],
-  ["-main-windows", "scala-2.12.14.msi", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.msi", "Windows (msi installer)", "125.83M"],
-  ["-non-main-sys", "scala-2.12.14.zip", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.zip", "Windows", "20.15M"],
-  ["-non-main-sys", "scala-2.12.14.deb", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.deb", "Debian", "146.87M"],
-  ["-non-main-sys", "scala-2.12.14.rpm", "https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.rpm", "RPM package", "126.09M"],
-  ["-non-main-sys", "scala-docs-2.12.14.txz", "https://downloads.lightbend.com/scala/2.12.14/scala-docs-2.12.14.txz", "API docs", "53.68M"],
-  ["-non-main-sys", "scala-docs-2.12.14.zip", "https://downloads.lightbend.com/scala/2.12.14/scala-docs-2.12.14.zip", "API docs", "108.88M"],
+  ["-main-unixsys", "scala-2.12.14.tgz", "https://github.com/scala/scala/releases/download/v2.12.14/scala-2.12.14.tgz", "Mac OS X, Unix, Cygwin", "20.11M"],
+  ["-main-windows", "scala-2.12.14.msi", "https://github.com/scala/scala/releases/download/v2.12.14/scala-2.12.14.msi", "Windows (msi installer)", "125.83M"],
+  ["-non-main-sys", "scala-2.12.14.zip", "https://github.com/scala/scala/releases/download/v2.12.14/scala-2.12.14.zip", "Windows", "20.15M"],
+  ["-non-main-sys", "scala-2.12.14.deb", "https://github.com/scala/scala/releases/download/v2.12.14/scala-2.12.14.deb", "Debian", "146.87M"],
+  ["-non-main-sys", "scala-2.12.14.rpm", "https://github.com/scala/scala/releases/download/v2.12.14/scala-2.12.14.rpm", "RPM package", "126.09M"],
+  ["-non-main-sys", "scala-docs-2.12.14.txz", "https://github.com/scala/scala/releases/download/v2.12.14/scala-docs-2.12.14.txz", "API docs", "53.68M"],
+  ["-non-main-sys", "scala-docs-2.12.14.zip", "https://github.com/scala/scala/releases/download/v2.12.14/scala-docs-2.12.14.zip", "API docs", "108.88M"],
   ["-non-main-sys", "scala-sources-2.12.14.tar.gz", "https://github.com/scala/scala/archive/v2.12.14.tar.gz", "Sources", ""]
 ]
 ---

--- a/_downloads/2021-09-14-2.12.15.md
+++ b/_downloads/2021-09-14-2.12.15.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.12.15/
 resources: [
-  ["-main-unixsys", "scala-2.12.15.tgz", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.tgz", "Mac OS X, Unix, Cygwin", "20.11M"],
-  ["-main-windows", "scala-2.12.15.msi", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.msi", "Windows (msi installer)", "125.48M"],
-  ["-non-main-sys", "scala-2.12.15.zip", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.zip", "Windows", "20.15M"],
-  ["-non-main-sys", "scala-2.12.15.deb", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.deb", "Debian", "146.51M"],
-  ["-non-main-sys", "scala-2.12.15.rpm", "https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.rpm", "RPM package", "125.73M"],
-  ["-non-main-sys", "scala-docs-2.12.15.txz", "https://downloads.lightbend.com/scala/2.12.15/scala-docs-2.12.15.txz", "API docs", "53.58M"],
-  ["-non-main-sys", "scala-docs-2.12.15.zip", "https://downloads.lightbend.com/scala/2.12.15/scala-docs-2.12.15.zip", "API docs", "108.54M"],
+  ["-main-unixsys", "scala-2.12.15.tgz", "https://github.com/scala/scala/releases/download/v2.12.15/scala-2.12.15.tgz", "Mac OS X, Unix, Cygwin", "20.11M"],
+  ["-main-windows", "scala-2.12.15.msi", "https://github.com/scala/scala/releases/download/v2.12.15/scala-2.12.15.msi", "Windows (msi installer)", "125.48M"],
+  ["-non-main-sys", "scala-2.12.15.zip", "https://github.com/scala/scala/releases/download/v2.12.15/scala-2.12.15.zip", "Windows", "20.15M"],
+  ["-non-main-sys", "scala-2.12.15.deb", "https://github.com/scala/scala/releases/download/v2.12.15/scala-2.12.15.deb", "Debian", "146.51M"],
+  ["-non-main-sys", "scala-2.12.15.rpm", "https://github.com/scala/scala/releases/download/v2.12.15/scala-2.12.15.rpm", "RPM package", "125.73M"],
+  ["-non-main-sys", "scala-docs-2.12.15.txz", "https://github.com/scala/scala/releases/download/v2.12.15/scala-docs-2.12.15.txz", "API docs", "53.58M"],
+  ["-non-main-sys", "scala-docs-2.12.15.zip", "https://github.com/scala/scala/releases/download/v2.12.15/scala-docs-2.12.15.zip", "API docs", "108.54M"],
   ["-non-main-sys", "scala-sources-2.12.15.tar.gz", "https://github.com/scala/scala/archive/v2.12.15.tar.gz", "Sources", "6.6M"]
 ]
 ---

--- a/_downloads/2021-11-01-2.13.7.md
+++ b/_downloads/2021-11-01-2.13.7.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.7/
 resources: [
-  ["-main-unixsys", "scala-2.13.7.tgz", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.tgz", "Mac OS X, Unix, Cygwin", "22.64M"],
-  ["-main-windows", "scala-2.13.7.msi", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.msi", "Windows (msi installer)", "134.43M"],
-  ["-non-main-sys", "scala-2.13.7.zip", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.zip", "Windows", "22.68M"],
-  ["-non-main-sys", "scala-2.13.7.deb", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.deb", "Debian", "654.10M"],
-  ["-non-main-sys", "scala-2.13.7.rpm", "https://downloads.lightbend.com/scala/2.13.7/scala-2.13.7.rpm", "RPM package", "134.66M"],
-  ["-non-main-sys", "scala-docs-2.13.7.txz", "https://downloads.lightbend.com/scala/2.13.7/scala-docs-2.13.7.txz", "API docs", "59.45M"],
-  ["-non-main-sys", "scala-docs-2.13.7.zip", "https://downloads.lightbend.com/scala/2.13.7/scala-docs-2.13.7.zip", "API docs", "115.16M"],
+  ["-main-unixsys", "scala-2.13.7.tgz", "https://github.com/scala/scala/releases/download/v2.13.7/scala-2.13.7.tgz", "Mac OS X, Unix, Cygwin", "22.64M"],
+  ["-main-windows", "scala-2.13.7.msi", "https://github.com/scala/scala/releases/download/v2.13.7/scala-2.13.7.msi", "Windows (msi installer)", "134.43M"],
+  ["-non-main-sys", "scala-2.13.7.zip", "https://github.com/scala/scala/releases/download/v2.13.7/scala-2.13.7.zip", "Windows", "22.68M"],
+  ["-non-main-sys", "scala-2.13.7.deb", "https://github.com/scala/scala/releases/download/v2.13.7/scala-2.13.7.deb", "Debian", "654.10M"],
+  ["-non-main-sys", "scala-2.13.7.rpm", "https://github.com/scala/scala/releases/download/v2.13.7/scala-2.13.7.rpm", "RPM package", "134.66M"],
+  ["-non-main-sys", "scala-docs-2.13.7.txz", "https://github.com/scala/scala/releases/download/v2.13.7/scala-docs-2.13.7.txz", "API docs", "59.45M"],
+  ["-non-main-sys", "scala-docs-2.13.7.zip", "https://github.com/scala/scala/releases/download/v2.13.7/scala-docs-2.13.7.zip", "API docs", "115.16M"],
   ["-non-main-sys", "scala-sources-2.13.7.tar.gz", "https://github.com/scala/scala/archive/v2.13.7.tar.gz", "Sources", "7.4M"]
 ]
 ---

--- a/_downloads/2022-01-12-2.13.8.md
+++ b/_downloads/2022-01-12-2.13.8.md
@@ -10,13 +10,13 @@ requirements: "This Scala software distribution can be installed on any Unix-lik
 license: <a href="https://www.scala-lang.org/license/">Apache License, Version 2.0</a>
 api_docs: https://www.scala-lang.org/api/2.13.8/
 resources: [
-  ["-main-unixsys", "scala-2.13.8.tgz", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.tgz", "Mac OS X, Unix, Cygwin", "22.65M"],
-  ["-main-windows", "scala-2.13.8.msi", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.msi", "Windows (msi installer)", "134.43M"],
-  ["-non-main-sys", "scala-2.13.8.zip", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.zip", "Windows", "22.69M"],
-  ["-non-main-sys", "scala-2.13.8.deb", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.deb", "Debian", "654.12M"],
-  ["-non-main-sys", "scala-2.13.8.rpm", "https://downloads.lightbend.com/scala/2.13.8/scala-2.13.8.rpm", "RPM package", "134.67M"],
-  ["-non-main-sys", "scala-docs-2.13.8.txz", "https://downloads.lightbend.com/scala/2.13.8/scala-docs-2.13.8.txz", "API docs", "60.19M"],
-  ["-non-main-sys", "scala-docs-2.13.8.zip", "https://downloads.lightbend.com/scala/2.13.8/scala-docs-2.13.8.zip", "API docs", "115.17M"],
+  ["-main-unixsys", "scala-2.13.8.tgz", "https://github.com/scala/scala/releases/download/v2.13.8/scala-2.13.8.tgz", "Mac OS X, Unix, Cygwin", "22.65M"],
+  ["-main-windows", "scala-2.13.8.msi", "https://github.com/scala/scala/releases/download/v2.13.8/scala-2.13.8.msi", "Windows (msi installer)", "134.43M"],
+  ["-non-main-sys", "scala-2.13.8.zip", "https://github.com/scala/scala/releases/download/v2.13.8/scala-2.13.8.zip", "Windows", "22.69M"],
+  ["-non-main-sys", "scala-2.13.8.deb", "https://github.com/scala/scala/releases/download/v2.13.8/scala-2.13.8.deb", "Debian", "654.12M"],
+  ["-non-main-sys", "scala-2.13.8.rpm", "https://github.com/scala/scala/releases/download/v2.13.8/scala-2.13.8.rpm", "RPM package", "134.67M"],
+  ["-non-main-sys", "scala-docs-2.13.8.txz", "https://github.com/scala/scala/releases/download/v2.13.8/scala-docs-2.13.8.txz", "API docs", "60.19M"],
+  ["-non-main-sys", "scala-docs-2.13.8.zip", "https://github.com/scala/scala/releases/download/v2.13.8/scala-docs-2.13.8.zip", "API docs", "115.17M"],
   ["-non-main-sys", "scala-sources-2.13.8.tar.gz", "https://github.com/scala/scala/archive/v2.13.8.tar.gz", "Sources", "7.5M"]
 ]
 ---

--- a/_downloads/2022-06-10-2.12.16.md
+++ b/_downloads/2022-06-10-2.12.16.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.16.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.12.16/
 resources: [
-  ["-main-unixsys", "scala-2.12.16.tgz", "https://downloads.lightbend.com/scala/2.12.16/scala-2.12.16.tgz", "Mac OS X, Unix, Cygwin", "20.06M"],
-  ["-main-windows", "scala-2.12.16.msi", "https://downloads.lightbend.com/scala/2.12.16/scala-2.12.16.msi", "Windows (msi installer)", "126.66M"],
-  ["-non-main-sys", "scala-2.12.16.zip", "https://downloads.lightbend.com/scala/2.12.16/scala-2.12.16.zip", "Windows", "20.10M"],
-  ["-non-main-sys", "scala-2.12.16.deb", "https://downloads.lightbend.com/scala/2.12.16/scala-2.12.16.deb", "Debian", "147.62M"],
-  ["-non-main-sys", "scala-2.12.16.rpm", "https://downloads.lightbend.com/scala/2.12.16/scala-2.12.16.rpm", "RPM package", "126.91M"],
-  ["-non-main-sys", "scala-docs-2.12.16.txz", "https://downloads.lightbend.com/scala/2.12.16/scala-docs-2.12.16.txz", "API docs", "54.84M"],
-  ["-non-main-sys", "scala-docs-2.12.16.zip", "https://downloads.lightbend.com/scala/2.12.16/scala-docs-2.12.16.zip", "API docs", "109.79M"],
+  ["-main-unixsys", "scala-2.12.16.tgz", "https://github.com/scala/scala/releases/download/v2.12.16/scala-2.12.16.tgz", "Mac OS X, Unix, Cygwin", "20.06M"],
+  ["-main-windows", "scala-2.12.16.msi", "https://github.com/scala/scala/releases/download/v2.12.16/scala-2.12.16.msi", "Windows (msi installer)", "126.66M"],
+  ["-non-main-sys", "scala-2.12.16.zip", "https://github.com/scala/scala/releases/download/v2.12.16/scala-2.12.16.zip", "Windows", "20.10M"],
+  ["-non-main-sys", "scala-2.12.16.deb", "https://github.com/scala/scala/releases/download/v2.12.16/scala-2.12.16.deb", "Debian", "147.62M"],
+  ["-non-main-sys", "scala-2.12.16.rpm", "https://github.com/scala/scala/releases/download/v2.12.16/scala-2.12.16.rpm", "RPM package", "126.91M"],
+  ["-non-main-sys", "scala-docs-2.12.16.txz", "https://github.com/scala/scala/releases/download/v2.12.16/scala-docs-2.12.16.txz", "API docs", "54.84M"],
+  ["-non-main-sys", "scala-docs-2.12.16.zip", "https://github.com/scala/scala/releases/download/v2.12.16/scala-docs-2.12.16.zip", "API docs", "109.79M"],
   ["-non-main-sys", "scala-sources-2.12.16.tar.gz", "https://github.com/scala/scala/archive/v2.12.16.tar.gz", "Sources", "6.6M"]
 ]
 ---

--- a/_downloads/2022-09-16-2.12.17.md
+++ b/_downloads/2022-09-16-2.12.17.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.17.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.12.17/
 resources: [
-  ["-main-unixsys", "scala-2.12.17.tgz", "https://downloads.lightbend.com/scala/2.12.17/scala-2.12.17.tgz", "Mac OS X, Unix, Cygwin", "19.99M"],
-  ["-main-windows", "scala-2.12.17.msi", "https://downloads.lightbend.com/scala/2.12.17/scala-2.12.17.msi", "Windows (msi installer)", "126.57M"],
-  ["-non-main-sys", "scala-2.12.17.zip", "https://downloads.lightbend.com/scala/2.12.17/scala-2.12.17.zip", "Windows", "20.03M"],
-  ["-non-main-sys", "scala-2.12.17.deb", "https://downloads.lightbend.com/scala/2.12.17/scala-2.12.17.deb", "Debian", "147.47M"],
-  ["-non-main-sys", "scala-2.12.17.rpm", "https://downloads.lightbend.com/scala/2.12.17/scala-2.12.17.rpm", "RPM package", "126.81M"],
-  ["-non-main-sys", "scala-docs-2.12.17.txz", "https://downloads.lightbend.com/scala/2.12.17/scala-docs-2.12.17.txz", "API docs", "54.86M"],
-  ["-non-main-sys", "scala-docs-2.12.17.zip", "https://downloads.lightbend.com/scala/2.12.17/scala-docs-2.12.17.zip", "API docs", "109.77M"],
+  ["-main-unixsys", "scala-2.12.17.tgz", "https://github.com/scala/scala/releases/download/v2.12.17/scala-2.12.17.tgz", "Mac OS X, Unix, Cygwin", "19.99M"],
+  ["-main-windows", "scala-2.12.17.msi", "https://github.com/scala/scala/releases/download/v2.12.17/scala-2.12.17.msi", "Windows (msi installer)", "126.57M"],
+  ["-non-main-sys", "scala-2.12.17.zip", "https://github.com/scala/scala/releases/download/v2.12.17/scala-2.12.17.zip", "Windows", "20.03M"],
+  ["-non-main-sys", "scala-2.12.17.deb", "https://github.com/scala/scala/releases/download/v2.12.17/scala-2.12.17.deb", "Debian", "147.47M"],
+  ["-non-main-sys", "scala-2.12.17.rpm", "https://github.com/scala/scala/releases/download/v2.12.17/scala-2.12.17.rpm", "RPM package", "126.81M"],
+  ["-non-main-sys", "scala-docs-2.12.17.txz", "https://github.com/scala/scala/releases/download/v2.12.17/scala-docs-2.12.17.txz", "API docs", "54.86M"],
+  ["-non-main-sys", "scala-docs-2.12.17.zip", "https://github.com/scala/scala/releases/download/v2.12.17/scala-docs-2.12.17.zip", "API docs", "109.77M"],
   ["-non-main-sys", "scala-sources-2.12.17.tar.gz", "https://github.com/scala/scala/archive/v2.12.17.tar.gz", "Sources", "7.2M"]
 ]
 ---

--- a/_downloads/2022-09-21-2.13.9.md
+++ b/_downloads/2022-09-21-2.13.9.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.9.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.9/
 resources: [
-  ["-main-unixsys", "scala-2.13.9.tgz", "https://downloads.lightbend.com/scala/2.13.9/scala-2.13.9.tgz", "Mac OS X, Unix, Cygwin", "22.51M"],
-  ["-main-windows", "scala-2.13.9.msi", "https://downloads.lightbend.com/scala/2.13.9/scala-2.13.9.msi", "Windows (msi installer)", "134.73M"],
-  ["-non-main-sys", "scala-2.13.9.zip", "https://downloads.lightbend.com/scala/2.13.9/scala-2.13.9.zip", "Windows", "22.55M"],
-  ["-non-main-sys", "scala-2.13.9.deb", "https://downloads.lightbend.com/scala/2.13.9/scala-2.13.9.deb", "Debian", "655.23M"],
-  ["-non-main-sys", "scala-2.13.9.rpm", "https://downloads.lightbend.com/scala/2.13.9/scala-2.13.9.rpm", "RPM package", "134.97M"],
-  ["-non-main-sys", "scala-docs-2.13.9.txz", "https://downloads.lightbend.com/scala/2.13.9/scala-docs-2.13.9.txz", "API docs", "60.52M"],
-  ["-non-main-sys", "scala-docs-2.13.9.zip", "https://downloads.lightbend.com/scala/2.13.9/scala-docs-2.13.9.zip", "API docs", "115.60M"],
+  ["-main-unixsys", "scala-2.13.9.tgz", "https://github.com/scala/scala/releases/download/v2.13.9/scala-2.13.9.tgz", "Mac OS X, Unix, Cygwin", "22.51M"],
+  ["-main-windows", "scala-2.13.9.msi", "https://github.com/scala/scala/releases/download/v2.13.9/scala-2.13.9.msi", "Windows (msi installer)", "134.73M"],
+  ["-non-main-sys", "scala-2.13.9.zip", "https://github.com/scala/scala/releases/download/v2.13.9/scala-2.13.9.zip", "Windows", "22.55M"],
+  ["-non-main-sys", "scala-2.13.9.deb", "https://github.com/scala/scala/releases/download/v2.13.9/scala-2.13.9.deb", "Debian", "655.23M"],
+  ["-non-main-sys", "scala-2.13.9.rpm", "https://github.com/scala/scala/releases/download/v2.13.9/scala-2.13.9.rpm", "RPM package", "134.97M"],
+  ["-non-main-sys", "scala-docs-2.13.9.txz", "https://github.com/scala/scala/releases/download/v2.13.9/scala-docs-2.13.9.txz", "API docs", "60.52M"],
+  ["-non-main-sys", "scala-docs-2.13.9.zip", "https://github.com/scala/scala/releases/download/v2.13.9/scala-docs-2.13.9.zip", "API docs", "115.60M"],
   ["-non-main-sys", "scala-sources-2.13.9.tar.gz", "https://github.com/scala/scala/archive/v2.13.9.tar.gz", "Sources", "7.2M"]
 ]
 ---

--- a/_downloads/2022-10-13-2.13.10.md
+++ b/_downloads/2022-10-13-2.13.10.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.10.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.10/
 resources: [
-  ["-main-unixsys", "scala-2.13.10.tgz", "https://downloads.lightbend.com/scala/2.13.10/scala-2.13.10.tgz", "Mac OS X, Unix, Cygwin", "22.57M"],
-  ["-main-windows", "scala-2.13.10.msi", "https://downloads.lightbend.com/scala/2.13.10/scala-2.13.10.msi", "Windows (msi installer)", "134.74M"],
-  ["-non-main-sys", "scala-2.13.10.zip", "https://downloads.lightbend.com/scala/2.13.10/scala-2.13.10.zip", "Windows", "22.62M"],
-  ["-non-main-sys", "scala-2.13.10.deb", "https://downloads.lightbend.com/scala/2.13.10/scala-2.13.10.deb", "Debian", "654.81M"],
-  ["-non-main-sys", "scala-2.13.10.rpm", "https://downloads.lightbend.com/scala/2.13.10/scala-2.13.10.rpm", "RPM package", "134.98M"],
-  ["-non-main-sys", "scala-docs-2.13.10.txz", "https://downloads.lightbend.com/scala/2.13.10/scala-docs-2.13.10.txz", "API docs", "60.44M"],
-  ["-non-main-sys", "scala-docs-2.13.10.zip", "https://downloads.lightbend.com/scala/2.13.10/scala-docs-2.13.10.zip", "API docs", "115.56M"],
+  ["-main-unixsys", "scala-2.13.10.tgz", "https://github.com/scala/scala/releases/download/v2.13.10/scala-2.13.10.tgz", "Mac OS X, Unix, Cygwin", "22.57M"],
+  ["-main-windows", "scala-2.13.10.msi", "https://github.com/scala/scala/releases/download/v2.13.10/scala-2.13.10.msi", "Windows (msi installer)", "134.74M"],
+  ["-non-main-sys", "scala-2.13.10.zip", "https://github.com/scala/scala/releases/download/v2.13.10/scala-2.13.10.zip", "Windows", "22.62M"],
+  ["-non-main-sys", "scala-2.13.10.deb", "https://github.com/scala/scala/releases/download/v2.13.10/scala-2.13.10.deb", "Debian", "654.81M"],
+  ["-non-main-sys", "scala-2.13.10.rpm", "https://github.com/scala/scala/releases/download/v2.13.10/scala-2.13.10.rpm", "RPM package", "134.98M"],
+  ["-non-main-sys", "scala-docs-2.13.10.txz", "https://github.com/scala/scala/releases/download/v2.13.10/scala-docs-2.13.10.txz", "API docs", "60.44M"],
+  ["-non-main-sys", "scala-docs-2.13.10.zip", "https://github.com/scala/scala/releases/download/v2.13.10/scala-docs-2.13.10.zip", "API docs", "115.56M"],
   ["-non-main-sys", "scala-sources-2.13.10.tar.gz", "https://github.com/scala/scala/archive/v2.13.10.tar.gz", "Sources", "7.3M"]
 ]
 ---

--- a/_downloads/2023-06-07-2.12.18.md
+++ b/_downloads/2023-06-07-2.12.18.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.18.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.12.18/
 resources: [
-  ["-main-unixsys", "scala-2.12.18.tgz", "https://downloads.lightbend.com/scala/2.12.18/scala-2.12.18.tgz", "Mac OS X, Unix, Cygwin", "20.01M"],
-  ["-main-windows", "scala-2.12.18.msi", "https://downloads.lightbend.com/scala/2.12.18/scala-2.12.18.msi", "Windows (msi installer)", "126.62M"],
-  ["-non-main-sys", "scala-2.12.18.zip", "https://downloads.lightbend.com/scala/2.12.18/scala-2.12.18.zip", "Windows", "20.05M"],
-  ["-non-main-sys", "scala-2.12.18.deb", "https://downloads.lightbend.com/scala/2.12.18/scala-2.12.18.deb", "Debian", "147.54M"],
-  ["-non-main-sys", "scala-2.12.18.rpm", "https://downloads.lightbend.com/scala/2.12.18/scala-2.12.18.rpm", "RPM package", "126.87M"],
-  ["-non-main-sys", "scala-docs-2.12.18.txz", "https://downloads.lightbend.com/scala/2.12.18/scala-docs-2.12.18.txz", "API docs", "54.87M"],
-  ["-non-main-sys", "scala-docs-2.12.18.zip", "https://downloads.lightbend.com/scala/2.12.18/scala-docs-2.12.18.zip", "API docs", "109.80M"],
+  ["-main-unixsys", "scala-2.12.18.tgz", "https://github.com/scala/scala/releases/download/v2.12.18/scala-2.12.18.tgz", "Mac OS X, Unix, Cygwin", "20.01M"],
+  ["-main-windows", "scala-2.12.18.msi", "https://github.com/scala/scala/releases/download/v2.12.18/scala-2.12.18.msi", "Windows (msi installer)", "126.62M"],
+  ["-non-main-sys", "scala-2.12.18.zip", "https://github.com/scala/scala/releases/download/v2.12.18/scala-2.12.18.zip", "Windows", "20.05M"],
+  ["-non-main-sys", "scala-2.12.18.deb", "https://github.com/scala/scala/releases/download/v2.12.18/scala-2.12.18.deb", "Debian", "147.54M"],
+  ["-non-main-sys", "scala-2.12.18.rpm", "https://github.com/scala/scala/releases/download/v2.12.18/scala-2.12.18.rpm", "RPM package", "126.87M"],
+  ["-non-main-sys", "scala-docs-2.12.18.txz", "https://github.com/scala/scala/releases/download/v2.12.18/scala-docs-2.12.18.txz", "API docs", "54.87M"],
+  ["-non-main-sys", "scala-docs-2.12.18.zip", "https://github.com/scala/scala/releases/download/v2.12.18/scala-docs-2.12.18.zip", "API docs", "109.80M"],
   ["-non-main-sys", "scala-sources-2.12.18.tar.gz", "https://github.com/scala/scala/archive/v2.12.18.tar.gz", "Sources", "6.6M"]
 ]
 ---

--- a/_downloads/2023-06-07-2.13.11.md
+++ b/_downloads/2023-06-07-2.13.11.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.11.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.11/
 resources: [
-  ["-main-unixsys", "scala-2.13.11.tgz", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.tgz", "Mac OS X, Unix, Cygwin", "22.88M"],
-  ["-main-windows", "scala-2.13.11.msi", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.msi", "Windows (msi installer)", "134.98M"],
-  ["-non-main-sys", "scala-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.zip", "Windows", "22.92M"],
-  ["-non-main-sys", "scala-2.13.11.deb", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.deb", "Debian", "657.15M"],
-  ["-non-main-sys", "scala-2.13.11.rpm", "https://downloads.lightbend.com/scala/2.13.11/scala-2.13.11.rpm", "RPM package", "135.21M"],
-  ["-non-main-sys", "scala-docs-2.13.11.txz", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.txz", "API docs", "60.37M"],
-  ["-non-main-sys", "scala-docs-2.13.11.zip", "https://downloads.lightbend.com/scala/2.13.11/scala-docs-2.13.11.zip", "API docs", "115.51M"],
+  ["-main-unixsys", "scala-2.13.11.tgz", "https://github.com/scala/scala/releases/download/v2.13.11/scala-2.13.11.tgz", "Mac OS X, Unix, Cygwin", "22.88M"],
+  ["-main-windows", "scala-2.13.11.msi", "https://github.com/scala/scala/releases/download/v2.13.11/scala-2.13.11.msi", "Windows (msi installer)", "134.98M"],
+  ["-non-main-sys", "scala-2.13.11.zip", "https://github.com/scala/scala/releases/download/v2.13.11/scala-2.13.11.zip", "Windows", "22.92M"],
+  ["-non-main-sys", "scala-2.13.11.deb", "https://github.com/scala/scala/releases/download/v2.13.11/scala-2.13.11.deb", "Debian", "657.15M"],
+  ["-non-main-sys", "scala-2.13.11.rpm", "https://github.com/scala/scala/releases/download/v2.13.11/scala-2.13.11.rpm", "RPM package", "135.21M"],
+  ["-non-main-sys", "scala-docs-2.13.11.txz", "https://github.com/scala/scala/releases/download/v2.13.11/scala-docs-2.13.11.txz", "API docs", "60.37M"],
+  ["-non-main-sys", "scala-docs-2.13.11.zip", "https://github.com/scala/scala/releases/download/v2.13.11/scala-docs-2.13.11.zip", "API docs", "115.51M"],
   ["-non-main-sys", "scala-sources-2.13.11.tar.gz", "https://github.com/scala/scala/archive/v2.13.11.tar.gz", "Sources", "8.3M"]
 ]
 ---

--- a/_downloads/2023-09-11-2.13.12.md
+++ b/_downloads/2023-09-11-2.13.12.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.12.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.12/
 resources: [
-  ["-main-unixsys", "scala-2.13.12.tgz", "https://downloads.lightbend.com/scala/2.13.12/scala-2.13.12.tgz", "Mac OS X, Unix, Cygwin", "22.90M"],
-  ["-main-windows", "scala-2.13.12.msi", "https://downloads.lightbend.com/scala/2.13.12/scala-2.13.12.msi", "Windows (msi installer)", "135.06M"],
-  ["-non-main-sys", "scala-2.13.12.zip", "https://downloads.lightbend.com/scala/2.13.12/scala-2.13.12.zip", "Windows", "22.94M"],
-  ["-non-main-sys", "scala-2.13.12.deb", "https://downloads.lightbend.com/scala/2.13.12/scala-2.13.12.deb", "Debian", "657.91M"],
-  ["-non-main-sys", "scala-2.13.12.rpm", "https://downloads.lightbend.com/scala/2.13.12/scala-2.13.12.rpm", "RPM package", "135.28M"],
-  ["-non-main-sys", "scala-docs-2.13.12.txz", "https://downloads.lightbend.com/scala/2.13.12/scala-docs-2.13.12.txz", "API docs", "60.39M"],
-  ["-non-main-sys", "scala-docs-2.13.12.zip", "https://downloads.lightbend.com/scala/2.13.12/scala-docs-2.13.12.zip", "API docs", "115.56M"],
+  ["-main-unixsys", "scala-2.13.12.tgz", "https://github.com/scala/scala/releases/download/v2.13.12/scala-2.13.12.tgz", "Mac OS X, Unix, Cygwin", "22.90M"],
+  ["-main-windows", "scala-2.13.12.msi", "https://github.com/scala/scala/releases/download/v2.13.12/scala-2.13.12.msi", "Windows (msi installer)", "135.06M"],
+  ["-non-main-sys", "scala-2.13.12.zip", "https://github.com/scala/scala/releases/download/v2.13.12/scala-2.13.12.zip", "Windows", "22.94M"],
+  ["-non-main-sys", "scala-2.13.12.deb", "https://github.com/scala/scala/releases/download/v2.13.12/scala-2.13.12.deb", "Debian", "657.91M"],
+  ["-non-main-sys", "scala-2.13.12.rpm", "https://github.com/scala/scala/releases/download/v2.13.12/scala-2.13.12.rpm", "RPM package", "135.28M"],
+  ["-non-main-sys", "scala-docs-2.13.12.txz", "https://github.com/scala/scala/releases/download/v2.13.12/scala-docs-2.13.12.txz", "API docs", "60.39M"],
+  ["-non-main-sys", "scala-docs-2.13.12.zip", "https://github.com/scala/scala/releases/download/v2.13.12/scala-docs-2.13.12.zip", "API docs", "115.56M"],
   ["-non-main-sys", "scala-sources-2.13.12.tar.gz", "https://github.com/scala/scala/archive/v2.13.12.tar.gz", "Sources", "7.7M"]
 ]
 ---

--- a/_downloads/2024-02-20-2.12.19.md
+++ b/_downloads/2024-02-20-2.12.19.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.19.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.12.19/
 resources: [
-  ["-main-unixsys", "scala-2.12.19.tgz", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.tgz", "Mac OS X, Unix, Cygwin", "20.08M"],
-  ["-main-windows", "scala-2.12.19.msi", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.msi", "Windows (msi installer)", "126.70M"],
-  ["-non-main-sys", "scala-2.12.19.zip", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.zip", "Windows", "20.12M"],
-  ["-non-main-sys", "scala-2.12.19.deb", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.deb", "Debian", "147.69M"],
-  ["-non-main-sys", "scala-2.12.19.rpm", "https://downloads.lightbend.com/scala/2.12.19/scala-2.12.19.rpm", "RPM package", "126.95M"],
-  ["-non-main-sys", "scala-docs-2.12.19.txz", "https://downloads.lightbend.com/scala/2.12.19/scala-docs-2.12.19.txz", "API docs", "54.88M"],
-  ["-non-main-sys", "scala-docs-2.12.19.zip", "https://downloads.lightbend.com/scala/2.12.19/scala-docs-2.12.19.zip", "API docs", "109.81M"],
+  ["-main-unixsys", "scala-2.12.19.tgz", "https://github.com/scala/scala/releases/download/v2.12.19/scala-2.12.19.tgz", "Mac OS X, Unix, Cygwin", "20.08M"],
+  ["-main-windows", "scala-2.12.19.msi", "https://github.com/scala/scala/releases/download/v2.12.19/scala-2.12.19.msi", "Windows (msi installer)", "126.70M"],
+  ["-non-main-sys", "scala-2.12.19.zip", "https://github.com/scala/scala/releases/download/v2.12.19/scala-2.12.19.zip", "Windows", "20.12M"],
+  ["-non-main-sys", "scala-2.12.19.deb", "https://github.com/scala/scala/releases/download/v2.12.19/scala-2.12.19.deb", "Debian", "147.69M"],
+  ["-non-main-sys", "scala-2.12.19.rpm", "https://github.com/scala/scala/releases/download/v2.12.19/scala-2.12.19.rpm", "RPM package", "126.95M"],
+  ["-non-main-sys", "scala-docs-2.12.19.txz", "https://github.com/scala/scala/releases/download/v2.12.19/scala-docs-2.12.19.txz", "API docs", "54.88M"],
+  ["-non-main-sys", "scala-docs-2.12.19.zip", "https://github.com/scala/scala/releases/download/v2.12.19/scala-docs-2.12.19.zip", "API docs", "109.81M"],
   ["-non-main-sys", "scala-sources-2.12.19.tar.gz", "https://github.com/scala/scala/archive/v2.12.19.tar.gz", "Sources", "6.7M"]
 ]
 ---

--- a/_downloads/2024-02-26-2.13.13.md
+++ b/_downloads/2024-02-26-2.13.13.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.13.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.13/
 resources: [
-  ["-main-unixsys", "scala-2.13.13.tgz", "https://downloads.lightbend.com/scala/2.13.13/scala-2.13.13.tgz", "Mac OS X, Unix, Cygwin", "23.02M"],
-  ["-main-windows", "scala-2.13.13.msi", "https://downloads.lightbend.com/scala/2.13.13/scala-2.13.13.msi", "Windows (msi installer)", "136.04M"],
-  ["-non-main-sys", "scala-2.13.13.zip", "https://downloads.lightbend.com/scala/2.13.13/scala-2.13.13.zip", "Windows", "23.06M"],
-  ["-non-main-sys", "scala-2.13.13.deb", "https://downloads.lightbend.com/scala/2.13.13/scala-2.13.13.deb", "Debian", "659.89M"],
-  ["-non-main-sys", "scala-2.13.13.rpm", "https://downloads.lightbend.com/scala/2.13.13/scala-2.13.13.rpm", "RPM package", "136.27M"],
-  ["-non-main-sys", "scala-docs-2.13.13.txz", "https://downloads.lightbend.com/scala/2.13.13/scala-docs-2.13.13.txz", "API docs", "60.81M"],
-  ["-non-main-sys", "scala-docs-2.13.13.zip", "https://downloads.lightbend.com/scala/2.13.13/scala-docs-2.13.13.zip", "API docs", "116.40M"],
+  ["-main-unixsys", "scala-2.13.13.tgz", "https://github.com/scala/scala/releases/download/v2.13.13/scala-2.13.13.tgz", "Mac OS X, Unix, Cygwin", "23.02M"],
+  ["-main-windows", "scala-2.13.13.msi", "https://github.com/scala/scala/releases/download/v2.13.13/scala-2.13.13.msi", "Windows (msi installer)", "136.04M"],
+  ["-non-main-sys", "scala-2.13.13.zip", "https://github.com/scala/scala/releases/download/v2.13.13/scala-2.13.13.zip", "Windows", "23.06M"],
+  ["-non-main-sys", "scala-2.13.13.deb", "https://github.com/scala/scala/releases/download/v2.13.13/scala-2.13.13.deb", "Debian", "659.89M"],
+  ["-non-main-sys", "scala-2.13.13.rpm", "https://github.com/scala/scala/releases/download/v2.13.13/scala-2.13.13.rpm", "RPM package", "136.27M"],
+  ["-non-main-sys", "scala-docs-2.13.13.txz", "https://github.com/scala/scala/releases/download/v2.13.13/scala-docs-2.13.13.txz", "API docs", "60.81M"],
+  ["-non-main-sys", "scala-docs-2.13.13.zip", "https://github.com/scala/scala/releases/download/v2.13.13/scala-docs-2.13.13.zip", "API docs", "116.40M"],
   ["-non-main-sys", "scala-sources-2.13.13.tar.gz", "https://github.com/scala/scala/archive/v2.13.13.tar.gz", "Sources", "7.5M"]
 ]
 ---

--- a/_downloads/2024-05-01-2.13.14.md
+++ b/_downloads/2024-05-01-2.13.14.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.14.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.14/
 resources: [
-  ["-main-unixsys", "scala-2.13.14.tgz", "https://downloads.lightbend.com/scala/2.13.14/scala-2.13.14.tgz", "Mac OS X, Unix, Cygwin", "23.31M"],
-  ["-main-windows", "scala-2.13.14.msi", "https://downloads.lightbend.com/scala/2.13.14/scala-2.13.14.msi", "Windows (msi installer)", "137.83M"],
-  ["-non-main-sys", "scala-2.13.14.zip", "https://downloads.lightbend.com/scala/2.13.14/scala-2.13.14.zip", "Windows", "23.35M"],
-  ["-non-main-sys", "scala-2.13.14.deb", "https://downloads.lightbend.com/scala/2.13.14/scala-2.13.14.deb", "Debian", "663.46M"],
-  ["-non-main-sys", "scala-2.13.14.rpm", "https://downloads.lightbend.com/scala/2.13.14/scala-2.13.14.rpm", "RPM package", "138.07M"],
-  ["-non-main-sys", "scala-docs-2.13.14.txz", "https://downloads.lightbend.com/scala/2.13.14/scala-docs-2.13.14.txz", "API docs", "61.61M"],
-  ["-non-main-sys", "scala-docs-2.13.14.zip", "https://downloads.lightbend.com/scala/2.13.14/scala-docs-2.13.14.zip", "API docs", "117.91M"],
+  ["-main-unixsys", "scala-2.13.14.tgz", "https://github.com/scala/scala/releases/download/v2.13.14/scala-2.13.14.tgz", "Mac OS X, Unix, Cygwin", "23.31M"],
+  ["-main-windows", "scala-2.13.14.msi", "https://github.com/scala/scala/releases/download/v2.13.14/scala-2.13.14.msi", "Windows (msi installer)", "137.83M"],
+  ["-non-main-sys", "scala-2.13.14.zip", "https://github.com/scala/scala/releases/download/v2.13.14/scala-2.13.14.zip", "Windows", "23.35M"],
+  ["-non-main-sys", "scala-2.13.14.deb", "https://github.com/scala/scala/releases/download/v2.13.14/scala-2.13.14.deb", "Debian", "663.46M"],
+  ["-non-main-sys", "scala-2.13.14.rpm", "https://github.com/scala/scala/releases/download/v2.13.14/scala-2.13.14.rpm", "RPM package", "138.07M"],
+  ["-non-main-sys", "scala-docs-2.13.14.txz", "https://github.com/scala/scala/releases/download/v2.13.14/scala-docs-2.13.14.txz", "API docs", "61.61M"],
+  ["-non-main-sys", "scala-docs-2.13.14.zip", "https://github.com/scala/scala/releases/download/v2.13.14/scala-docs-2.13.14.zip", "API docs", "117.91M"],
   ["-non-main-sys", "scala-sources-2.13.14.tar.gz", "https://github.com/scala/scala/archive/v2.13.14.tar.gz", "Sources", "8.0M"]
 ]
 ---

--- a/_downloads/2024-09-04-2.12.20.md
+++ b/_downloads/2024-09-04-2.12.20.md
@@ -9,13 +9,13 @@ permalink: /download/2.12.20.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.12.20/
 resources: [
-  ["-main-unixsys", "scala-2.12.20.tgz", "https://downloads.lightbend.com/scala/2.12.20/scala-2.12.20.tgz", "Mac OS X, Unix, Cygwin", "20.08M"],
-  ["-main-windows", "scala-2.12.20.msi", "https://downloads.lightbend.com/scala/2.12.20/scala-2.12.20.msi", "Windows (msi installer)", "126.72M"],
-  ["-non-main-sys", "scala-2.12.20.zip", "https://downloads.lightbend.com/scala/2.12.20/scala-2.12.20.zip", "Windows", "20.12M"],
-  ["-non-main-sys", "scala-2.12.20.deb", "https://downloads.lightbend.com/scala/2.12.20/scala-2.12.20.deb", "Debian", "147.72M"],
-  ["-non-main-sys", "scala-2.12.20.rpm", "https://downloads.lightbend.com/scala/2.12.20/scala-2.12.20.rpm", "RPM package", "126.98M"],
-  ["-non-main-sys", "scala-docs-2.12.20.txz", "https://downloads.lightbend.com/scala/2.12.20/scala-docs-2.12.20.txz", "API docs", "54.84M"],
-  ["-non-main-sys", "scala-docs-2.12.20.zip", "https://downloads.lightbend.com/scala/2.12.20/scala-docs-2.12.20.zip", "API docs", "109.84M"],
+  ["-main-unixsys", "scala-2.12.20.tgz", "https://github.com/scala/scala/releases/download/v2.12.20/scala-2.12.20.tgz", "Mac OS X, Unix, Cygwin", "20.08M"],
+  ["-main-windows", "scala-2.12.20.msi", "https://github.com/scala/scala/releases/download/v2.12.20/scala-2.12.20.msi", "Windows (msi installer)", "126.72M"],
+  ["-non-main-sys", "scala-2.12.20.zip", "https://github.com/scala/scala/releases/download/v2.12.20/scala-2.12.20.zip", "Windows", "20.12M"],
+  ["-non-main-sys", "scala-2.12.20.deb", "https://github.com/scala/scala/releases/download/v2.12.20/scala-2.12.20.deb", "Debian", "147.72M"],
+  ["-non-main-sys", "scala-2.12.20.rpm", "https://github.com/scala/scala/releases/download/v2.12.20/scala-2.12.20.rpm", "RPM package", "126.98M"],
+  ["-non-main-sys", "scala-docs-2.12.20.txz", "https://github.com/scala/scala/releases/download/v2.12.20/scala-docs-2.12.20.txz", "API docs", "54.84M"],
+  ["-non-main-sys", "scala-docs-2.12.20.zip", "https://github.com/scala/scala/releases/download/v2.12.20/scala-docs-2.12.20.zip", "API docs", "109.84M"],
   ["-non-main-sys", "scala-sources-2.12.20.tar.gz", "https://github.com/scala/scala/archive/v2.12.20.tar.gz", "Sources", "7.3M"]
 ]
 ---

--- a/_downloads/2024-09-25-2.13.15.md
+++ b/_downloads/2024-09-25-2.13.15.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.15.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.15/
 resources: [
-  ["-main-unixsys", "scala-2.13.15.tgz", "https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.tgz", "Mac OS X, Unix, Cygwin", "23.36M"],
-  ["-main-windows", "scala-2.13.15.msi", "https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.msi", "Windows (msi installer)", "137.94M"],
-  ["-non-main-sys", "scala-2.13.15.zip", "https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.zip", "Windows", "23.40M"],
-  ["-non-main-sys", "scala-2.13.15.deb", "https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.deb", "Debian", "664.03M"],
-  ["-non-main-sys", "scala-2.13.15.rpm", "https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.rpm", "RPM package", "138.18M"],
-  ["-non-main-sys", "scala-docs-2.13.15.txz", "https://downloads.lightbend.com/scala/2.13.15/scala-docs-2.13.15.txz", "API docs", "61.67M"],
-  ["-non-main-sys", "scala-docs-2.13.15.zip", "https://downloads.lightbend.com/scala/2.13.15/scala-docs-2.13.15.zip", "API docs", "117.96M"],
+  ["-main-unixsys", "scala-2.13.15.tgz", "https://github.com/scala/scala/releases/download/v2.13.15/scala-2.13.15.tgz", "Mac OS X, Unix, Cygwin", "23.36M"],
+  ["-main-windows", "scala-2.13.15.msi", "https://github.com/scala/scala/releases/download/v2.13.15/scala-2.13.15.msi", "Windows (msi installer)", "137.94M"],
+  ["-non-main-sys", "scala-2.13.15.zip", "https://github.com/scala/scala/releases/download/v2.13.15/scala-2.13.15.zip", "Windows", "23.40M"],
+  ["-non-main-sys", "scala-2.13.15.deb", "https://github.com/scala/scala/releases/download/v2.13.15/scala-2.13.15.deb", "Debian", "664.03M"],
+  ["-non-main-sys", "scala-2.13.15.rpm", "https://github.com/scala/scala/releases/download/v2.13.15/scala-2.13.15.rpm", "RPM package", "138.18M"],
+  ["-non-main-sys", "scala-docs-2.13.15.txz", "https://github.com/scala/scala/releases/download/v2.13.15/scala-docs-2.13.15.txz", "API docs", "61.67M"],
+  ["-non-main-sys", "scala-docs-2.13.15.zip", "https://github.com/scala/scala/releases/download/v2.13.15/scala-docs-2.13.15.zip", "API docs", "117.96M"],
   ["-non-main-sys", "scala-sources-2.13.15.tar.gz", "https://github.com/scala/scala/archive/v2.13.15.tar.gz", "Sources", "7.8M"]
 ]
 ---

--- a/_downloads/2025-01-15-2.13.16.md
+++ b/_downloads/2025-01-15-2.13.16.md
@@ -9,13 +9,13 @@ permalink: /download/2.13.16.html
 requirements: "This Scala software distribution can be installed on any Unix-like or Windows system. It requires Java 8 or later, available <a href='https://www.java.com/'>here</a>."
 api_docs: https://www.scala-lang.org/api/2.13.16/
 resources: [
-  ["-main-unixsys", "scala-2.13.16.tgz", "https://downloads.lightbend.com/scala/2.13.16/scala-2.13.16.tgz", "Mac OS X, Unix, Cygwin", "21.57M"],
-  ["-main-windows", "scala-2.13.16.msi", "https://downloads.lightbend.com/scala/2.13.16/scala-2.13.16.msi", "Windows (msi installer)", "130.50M"],
-  ["-non-main-sys", "scala-2.13.16.zip", "https://downloads.lightbend.com/scala/2.13.16/scala-2.13.16.zip", "Windows", "21.61M"],
-  ["-non-main-sys", "scala-2.13.16.deb", "https://downloads.lightbend.com/scala/2.13.16/scala-2.13.16.deb", "Debian", "654.54M"],
-  ["-non-main-sys", "scala-2.13.16.rpm", "https://downloads.lightbend.com/scala/2.13.16/scala-2.13.16.rpm", "RPM package", "130.74M"],
-  ["-non-main-sys", "scala-docs-2.13.16.txz", "https://downloads.lightbend.com/scala/2.13.16/scala-docs-2.13.16.txz", "API docs", "56.33M"],
-  ["-non-main-sys", "scala-docs-2.13.16.zip", "https://downloads.lightbend.com/scala/2.13.16/scala-docs-2.13.16.zip", "API docs", "112.33M"],
+  ["-main-unixsys", "scala-2.13.16.tgz", "https://github.com/scala/scala/releases/download/v2.13.16/scala-2.13.16.tgz", "Mac OS X, Unix, Cygwin", "21.57M"],
+  ["-main-windows", "scala-2.13.16.msi", "https://github.com/scala/scala/releases/download/v2.13.16/scala-2.13.16.msi", "Windows (msi installer)", "130.50M"],
+  ["-non-main-sys", "scala-2.13.16.zip", "https://github.com/scala/scala/releases/download/v2.13.16/scala-2.13.16.zip", "Windows", "21.61M"],
+  ["-non-main-sys", "scala-2.13.16.deb", "https://github.com/scala/scala/releases/download/v2.13.16/scala-2.13.16.deb", "Debian", "654.54M"],
+  ["-non-main-sys", "scala-2.13.16.rpm", "https://github.com/scala/scala/releases/download/v2.13.16/scala-2.13.16.rpm", "RPM package", "130.74M"],
+  ["-non-main-sys", "scala-docs-2.13.16.txz", "https://github.com/scala/scala/releases/download/v2.13.16/scala-docs-2.13.16.txz", "API docs", "56.33M"],
+  ["-non-main-sys", "scala-docs-2.13.16.zip", "https://github.com/scala/scala/releases/download/v2.13.16/scala-docs-2.13.16.zip", "API docs", "112.33M"],
   ["-non-main-sys", "scala-sources-2.13.16.tar.gz", "https://github.com/scala/scala/archive/v2.13.16.tar.gz", "Sources", "7.6M"]
 ]
 ---


### PR DESCRIPTION
I copied the files with this script https://gist.github.com/lrytz/502c8e99b699e0e0e017c5975573d542

I re-downloaded all files from both the old and new place and made sure they are identical.