### PR TITLE
Update index.md (removed a link)

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -283,7 +283,6 @@ Staying current:
 - [Scala.js](https://www.scala-js.org) compiles Scala code to JavaScript
 - [Scala Native](https://www.scala-native.org) compiles Scala code to LLVM for
   native execution
-- [Scala on Android](https://scala-android.org) community site
 
 The [Scala Discord](https://discord.com/invite/scala) has #scala-js, #scala-native, and #scala-android channels.
 


### PR DESCRIPTION
Removed the reference to scala-android.org because that site seems to have been hacked (just look at the Indonesian spam inserted on https://www.scala-android.org/dependencies).

Also, there is a huge difference between how the site looks today and how it looked in the past (see https://web.archive.org/web/20160706125519/http://scala-android.org/).