### PR TITLE
Update website links

### DIFF
--- a/_scala_carousel_items/1-collections-ops.md
+++ b/_scala_carousel_items/1-collections-ops.md
@@ -1,6 +1,6 @@
 ---
 optionId: collections-ops
-scastieLink: 'https://scastie.scala-lang.org/S0bkCiXkQiuOMXnlhWn46g'
+scastieLink: 'https://scastie.scala-lang.org/LYDsuRiKQsK94eXMY5K9qw'
 codeTitle: 'Functional programming with immutable collections'
 description: "High-level operations avoid the need for complex and error-prone loops."
 ---

--- a/_scala_carousel_items/2-json-codec.md
+++ b/_scala_carousel_items/2-json-codec.md
@@ -1,6 +1,6 @@
 ---
 optionId: json-codec
-scastieLink: 'https://scastie.scala-lang.org/jzYU3JWJTZW6731MigOqlA'
+scastieLink: 'https://scastie.scala-lang.org/N0MyoiMXRdWJkLKgDJ1C5w'
 codeTitle: "Encode and decode custom data types to JSON"
 description: "The pluggable derivation system gives custom types new capabilities."
 ---

--- a/_scala_carousel_items/3-js-dom.md
+++ b/_scala_carousel_items/3-js-dom.md
@@ -1,6 +1,6 @@
 ---
 optionId: js-dom-api
-scastieLink: 'https://scastie.scala-lang.org/CQ70LFpbRJuWEDfGxbuYeQ'
+scastieLink: 'https://scastie.scala-lang.org/8i8u5uafRsuqDIsMuTsarQ'
 codeTitle: 'Target the Web with Scala.js on the frontend'
 description: "Share code full-stack, interact with the DOM or use any JS library."
 ---

--- a/_scala_carousel_items/4-data-definitions.md
+++ b/_scala_carousel_items/4-data-definitions.md
@@ -1,6 +1,6 @@
 ---
 optionId: data-definitions
-scastieLink: 'https://scastie.scala-lang.org/VcczUlAVT8mHTl7tpGmiJg'
+scastieLink: 'https://scastie.scala-lang.org/MrwGospTSOioMavfkjWl7Q'
 codeTitle: 'Define data types and pattern match on them with ease'
 description: "Model domains precisely, and make choices based on the shape of data."
 ---


### PR DESCRIPTION
Fixes https://github.com/scala/scala-lang/issues/1854

This will be changed later on to links to scalacenter organisation that will not require updating the website, rather you will be able to just update the snippet on the scastie website itself and it will update here.