### PR TITLE
Add GFM input support for kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,8 @@ scalaversion: "2.13.18"
 url: https://www.scala-lang.org
 baseurl: ""
 markdown: kramdown
+kramdown:
+  input: GFM
 highlighter:
 
 exclude:


### PR DESCRIPTION
Fixes : #526 

**Description:**

- This PR enables GitHub Flavored Markdown (GFM) support by updating the _config.yml configuration

- I compared the local build with the production site, and most pages rendered the same with no noticeable differences.