### PR TITLE
blog post: Advent of Code 2025 recap

### DIFF
--- a/blog/_posts/2026-01-12-advent-of-code-recap.md
+++ b/blog/_posts/2026-01-12-advent-of-code-recap.md
@@ -1,0 +1,40 @@
+---
+layout: blog-detail
+post-type: blog
+by: Jamie Thompson and Seth Tisue, Scala Center
+title: Recap of Advent of Code 2025
+description: How the Scala community participated in the recent 2025 Advent of Code challenge
+---
+
+**[Advent of Code](https://adventofcode.com/)**, started by [Eric Wastl](http://was.tl/), is an annual event providing daily programming puzzles between December 1st and December 12th.
+
+Let's see how the Scala community participated in Advent of Code 2025. We were pleased by the strong engagement on both the [Scala Discord][discord] and on [our solutions website][sc-advent-of-code].
+
+## Why we do this
+
+At the [Scala Center](https://scala.epfl.ch), we love writing code in Scala, and we hope you do too. One of our core priorities is to _communicate excitement about Scala_, which motivates us to participate in the Advent of Code and share experiences solving problems with Scala with the wider programming community.
+
+Another key priority is to improve the _onboarding experience for newcomers_. Part of that experience comes from the first impressions someone has reading Scala code. We hope that through hosting articles on [our solutions website][sc-advent-of-code], newcomers can see that programming in Scala is an elegant way to solve problems.
+
+## Engagement from the community
+
+### Discord channel
+
+This year, there was lively conversation (with spoilers duly grayed out, of course!) in the `#advent-of-code` channel on the [Scala Discord server][discord]. Thank you to everyone who shared their code and/or helped each other come up with the best solutions. We especially thank those who offered friendly help to Scala newcomers.
+
+### Community solutions
+
+106 solutions were submitted to [the website][sc-advent-of-code] this year, including some from first-time contributors.
+
+We give a special shout-out again this year to [Paweł Cembaluk](https://github.com/AvaPL), who was the only participant to submit a solution for all 12 days.
+
+### Explainer articles
+
+As usual, we reached out to the community to help write the daily articles that show well-coded, well-explained solutions. The community organized a posting schedule which led to a full set of 12 complete articles. Thank you to all the authors who contributed. Each article has the author's name at the top. The articles are on [our solutions website][sc-advent-of-code].
+
+## Summary
+
+If you read this far, thank you again everyone for contributing to Scala and participating in Advent of Code, we hope you all had fun -- and learned some things, too. See you in December 2026!
+
+[sc-advent-of-code]: https://scalacenter.github.io/scala-advent-of-code/2025/
+[discord]: https://discord.com/invite/scala


### PR DESCRIPTION
for publication on Thursday, February 12 (unless we end up needing to change it not to coincide with some other blog post)