### PR TITLE
add some text to Ambassadors page

### DIFF
--- a/ambassadors/index.html
+++ b/ambassadors/index.html
@@ -29,6 +29,21 @@ includeTOC: false
   </div>
   <div>
     <p>Scala Ambassadors are independent community members who are known and have been recognized for their contributions to the community. They are active and welcoming individuals, happy to help newcomers, organize events, teach, speak at conferences, create content, and otherwise contribute to the Scala community.</p>
+    <p>Ambassadors promote a positive image of Scala, improve communication among everyone working with Scala, and aid and support each other's efforts.
+    <p>Ambassadors are encouraged to:
+      <ul>
+        <li>Be present whenever possible at their local community events.
+        <li>Start new community events if they aren't already happening.
+        <li>Be visible to other community members as Ambassadors.
+        <li>Be perceived by the other community members as go-to people to find high quality answers to Scala-related questions
+        <li>Relay community feedback to [the Scala organization](https://scala-lang.org/community/#whos-behind-scala)
+      </ul>
+    <p>The Center selects Ambassadors who have:
+      <ul>
+        <li>Strong knowledge of Scala and its community
+        <li>A positive track record of activity in the community - conferences, meetups, forums, chat rooms, open source projects, and so on.
+        <li>No track record of unprofessional behavior
+      </ul>
     <h3 style="text-align: center;">What does it mean for me?</h3>
     <p>Scala Ambassadors are here to help you. They are happy to answer your questions, help you get started with Scala, or point you in the right direction. You can ask an Ambassador, for example, about:
         <ul style="list-style-type: disc; padding: 10px;">


### PR DESCRIPTION
the new text is adapted from the old Ambassadors repo readme and/or the [blog post](https://www.scala-lang.org/blog/2024/03/28/ambassadors-initiative.html) announcing the Ambassadors program

references scalacenter/ambassadors#8
