### PR TITLE
Update author affiliation in sbt2 blog post

### DIFF
--- a/blog/_posts/2026-06-29-sbt2.md
+++ b/blog/_posts/2026-06-29-sbt2.md
@@ -1,7 +1,7 @@
 ---
 layout: blog-detail
 post-type: blog
-by: Anatolii Kmetiuk, Eugene Yokota, Rikito Taniguchi (VirtusLab)
+by: Anatolii Kmetiuk (Scala Center), Eugene Yokota, Rikito Taniguchi (VirtusLab)
 title: "sbt 2 is now available!"
 ---
 


### PR DESCRIPTION
This adds "(Scala Center)" next to Toli similar to https://github.com/scala/scala-lang/blob/main/blog/_posts/2026-03-31-sbt-security-advisory.md so it doesn't look like all authors are from VirtusLab.