### PR TITLE
Mark 3.3.8 as LTS release

### DIFF
--- a/_downloads/2026-06-07-3.3.8.md
+++ b/_downloads/2026-06-07-3.3.8.md
@@ -1,5 +1,5 @@
 ---
-title: Scala 3.3.8
+title: Scala 3.3.8 LTS
 start: 10 June 2026
 layout: downloadpage
 release_version: 3.3.8

--- a/_posts/2026-06-10-release-notes-3.3.8.md
+++ b/_posts/2026-06-10-release-notes-3.3.8.md
@@ -1,7 +1,7 @@
 ---
 category: release
 permalink: /news/3.3.8/
-title: "Scala 3.3.8 is now available!"
+title: "Scala 3.3.8 LTS is now available!"
 by: Tomasz Godzik, VirtusLab
 ---
 


### PR DESCRIPTION
Previous update missed LTS suffix resulting in this misleading list:
```
Scala 3.4.0
Scala 3.3.8
Scala 3.3.7 LTS
Scala 3.3.6 LTS
Scala 3.3.5 LTS
Scala 3.3.4 LTS
Scala 3.3.3 LTS
Scala 3.3.1 LTS
Scala 3.3.0 LTS
```